### PR TITLE
fix: reconcile main's pnpm-lock.yaml with the v6.1.0-edge.2 manifests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,46 +183,46 @@ importers:
   packages/AI/A2AServer:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/api-keys':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../APIKeys/Engine
       '@memberjunction/config':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Config
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/encryption':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Encryption
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJServer
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ServerBootstrapLite
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       cosmiconfig:
         specifier: ^9.0.0
@@ -259,55 +259,55 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.11)
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Agents
       '@memberjunction/ai-anthropic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Providers/Anthropic
       '@memberjunction/ai-betty-bot':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Providers/BettyBot
       '@memberjunction/ai-cerebras':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Providers/Cerebras
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-groq':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Providers/Groq
       '@memberjunction/ai-mistral':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Providers/Mistral
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Providers/OpenAI
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Prompts
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntitiesServer
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@oclif/core':
         specifier: ^3.27.0
@@ -368,25 +368,25 @@ importers:
   packages/AI/AgentHarness:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/engine
     devDependencies:
       '@types/node':
@@ -405,28 +405,28 @@ importers:
   packages/AI/AgentManager/actions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Base
       '@memberjunction/ai-agent-manager':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -442,28 +442,28 @@ importers:
   packages/AI/AgentManager/core:
     dependencies:
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../BaseAIEngine
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Templates/engine
     devDependencies:
       '@types/node':
@@ -479,55 +479,55 @@ importers:
   packages/AI/Agents:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Prompts
       '@memberjunction/ai-reranker':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Reranker
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Vectors/Dupe
       '@memberjunction/ai-vector-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Vectors/Sync
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/context-crush':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ContextCrush
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/search-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SearchEngine
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJStorage
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/engine
       dotenv:
         specifier: ^17.2.4
@@ -576,13 +576,13 @@ importers:
   packages/AI/AgentsClient:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
       rxjs:
         specifier: ^7.8.1
@@ -598,22 +598,22 @@ importers:
   packages/AI/BaseAIEngine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/base-types
       dotenv:
         specifier: ^17.2.4
@@ -638,25 +638,25 @@ importers:
   packages/AI/Clustering:
     dependencies:
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Prompts
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       umap-js:
         specifier: ^1.4.0
@@ -675,13 +675,13 @@ importers:
   packages/AI/ComputerUse:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       playwright:
         specifier: '>=1.40.0'
@@ -715,7 +715,7 @@ importers:
   packages/AI/Core:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -740,22 +740,22 @@ importers:
   packages/AI/CorePlus:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/base-types
       date-fns:
         specifier: ^4.1.0
@@ -786,25 +786,25 @@ importers:
   packages/AI/DatabaseDesigner/actions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/database-designer-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/schema-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../SchemaEngine
     devDependencies:
       '@types/node':
@@ -826,25 +826,25 @@ importers:
   packages/AI/DatabaseDesigner/core:
     dependencies:
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/schema-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../SchemaEngine
     devDependencies:
       '@types/node':
@@ -866,31 +866,31 @@ importers:
   packages/AI/Engine:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../BaseAIEngine
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJStorage
       dotenv:
         specifier: ^17.2.4
@@ -915,34 +915,34 @@ importers:
   packages/AI/FormBuilder/core:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Engine
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Prompts
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../InteractiveComponents
     devDependencies:
       '@types/node':
@@ -964,28 +964,28 @@ importers:
   packages/AI/Knowledge/Pipeline:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-vector-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Vectors/Sync
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Vectors/Database
       '@memberjunction/ai-vectors':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Vectors/Core
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -998,37 +998,37 @@ importers:
   packages/AI/Knowledge/TagEngine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Prompts
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/clustering-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Clustering
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/tag-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TagEngineBase
     devDependencies:
       '@types/node':
@@ -1044,13 +1044,13 @@ importers:
   packages/AI/Knowledge/TagEngineBase:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -1066,16 +1066,16 @@ importers:
   packages/AI/MCPClient:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
@@ -1097,67 +1097,67 @@ importers:
   packages/AI/MCPServer:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-agent-manager':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AgentManager/core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/api-keys':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../APIKeys/Engine
       '@memberjunction/auth-providers':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AuthProviders
       '@memberjunction/config':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Config
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Credentials/Engine
       '@memberjunction/encryption':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Encryption
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJServer
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ServerBootstrapLite
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
@@ -1212,37 +1212,37 @@ importers:
   packages/AI/MJComputerUse:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Prompts
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/computer-use':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ComputerUse
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/testing-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../TestingFramework/Engine
       playwright:
         specifier: '>=1.40.0'
@@ -1286,40 +1286,40 @@ importers:
   packages/AI/PredictiveStudio/Engine:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/predictive-studio-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/predictive-studio-sidecar':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Sidecar
       '@memberjunction/record-set-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../RecordSetProcessor/engine
       '@memberjunction/record-set-processor-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../RecordSetProcessor/base
       rxjs:
         specifier: ^7.8.2
@@ -1344,7 +1344,7 @@ importers:
   packages/AI/PredictiveStudio/Sidecar:
     dependencies:
       '@memberjunction/predictive-studio-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
     devDependencies:
       tsc-alias:
@@ -1360,34 +1360,34 @@ importers:
   packages/AI/Prompts:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../BaseAIEngine
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/engine
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/base-types
       date-fns:
         specifier: ^2.30.0
@@ -1427,10 +1427,10 @@ importers:
         specifier: 0.73.0
         version: 0.73.0(zod@4.3.6)
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1443,10 +1443,10 @@ importers:
   packages/AI/Providers/AssemblyAI:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       typescript:
@@ -1465,10 +1465,10 @@ importers:
         specifier: ^4.13.0
         version: 4.13.1
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       rimraf:
@@ -1484,10 +1484,10 @@ importers:
         specifier: ^3.984.0
         version: 3.984.0
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1500,10 +1500,10 @@ importers:
   packages/AI/Providers/BettyBot:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -1525,10 +1525,10 @@ importers:
   packages/AI/Providers/BlackForestLabs:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1541,88 +1541,88 @@ importers:
   packages/AI/Providers/Bundle:
     dependencies:
       '@memberjunction/ai-anthropic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Anthropic
       '@memberjunction/ai-assemblyai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AssemblyAI
       '@memberjunction/ai-azure':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Azure
       '@memberjunction/ai-bedrock':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Bedrock
       '@memberjunction/ai-betty-bot':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../BettyBot
       '@memberjunction/ai-blackforestlabs':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../BlackForestLabs
       '@memberjunction/ai-cerebras':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Cerebras
       '@memberjunction/ai-cohere':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Cohere
       '@memberjunction/ai-elevenlabs':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ElevenLabs
       '@memberjunction/ai-fireworks':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Fireworks
       '@memberjunction/ai-gemini':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Gemini
       '@memberjunction/ai-groq':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Groq
       '@memberjunction/ai-heygen':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../HeyGen
       '@memberjunction/ai-inception':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Inception
       '@memberjunction/ai-inworld':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Inworld
       '@memberjunction/ai-llamacpp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../LlamaCpp
       '@memberjunction/ai-lmstudio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../LMStudio
       '@memberjunction/ai-local-embeddings':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../LocalEmbeddings
       '@memberjunction/ai-minimax':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MiniMax
       '@memberjunction/ai-mistral':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Mistral
       '@memberjunction/ai-ollama':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Ollama
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenAI
       '@memberjunction/ai-openrouter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenRouter
       '@memberjunction/ai-recommendations-rex':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Recommendations-Rex
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Vectors/Providers/Pinecone
       '@memberjunction/ai-vertex':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Vertex
       '@memberjunction/ai-xai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../xAI
       '@memberjunction/ai-zhipu':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Zhipu
     devDependencies:
       typescript:
@@ -1635,10 +1635,10 @@ importers:
         specifier: ^1.64.1
         version: 1.64.1(encoding@0.1.13)
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1651,10 +1651,10 @@ importers:
   packages/AI/Providers/Cohere:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       cohere-ai:
         specifier: ^7.20.0
@@ -1676,10 +1676,10 @@ importers:
         specifier: ^2.34.0
         version: 2.34.0(encoding@0.1.13)
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1692,10 +1692,10 @@ importers:
   packages/AI/Providers/Fireworks:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -1717,10 +1717,10 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1733,10 +1733,10 @@ importers:
   packages/AI/Providers/Groq:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       groq-sdk:
         specifier: ^0.37.0
@@ -1755,10 +1755,10 @@ importers:
         specifier: ^2.34.0
         version: 2.34.0(encoding@0.1.13)
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -1774,13 +1774,13 @@ importers:
   packages/AI/Providers/HuggingFace:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -1793,13 +1793,13 @@ importers:
   packages/AI/Providers/Inception:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -1815,10 +1815,10 @@ importers:
   packages/AI/Providers/Inworld:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       typescript:
@@ -1831,10 +1831,10 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1847,13 +1847,13 @@ importers:
   packages/AI/Providers/LlamaCpp:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1866,10 +1866,10 @@ importers:
   packages/AI/Providers/LocalEmbeddings:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@xenova/transformers':
         specifier: ^2.17.2
@@ -1885,13 +1885,13 @@ importers:
   packages/AI/Providers/MiniMax:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1904,10 +1904,10 @@ importers:
   packages/AI/Providers/Mistral:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@mistralai/mistralai':
         specifier: ^1.14.0
@@ -1929,10 +1929,10 @@ importers:
   packages/AI/Providers/Ollama:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       ollama:
         specifier: ^0.6.3
@@ -1948,10 +1948,10 @@ importers:
   packages/AI/Providers/OpenAI:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -1967,13 +1967,13 @@ importers:
   packages/AI/Providers/OpenRouter:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -1986,19 +1986,19 @@ importers:
   packages/AI/Providers/Recommendations-Rex:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-recommendations':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Recommendations/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -2026,13 +2026,13 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-gemini':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Gemini
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -2048,13 +2048,13 @@ importers:
   packages/AI/Providers/Zhipu:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -2067,13 +2067,13 @@ importers:
   packages/AI/Providers/xAI:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenAI
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       openai:
         specifier: 6.18.0
@@ -2089,13 +2089,13 @@ importers:
   packages/AI/RealtimeBridge/Base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -2117,16 +2117,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Discord:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2145,16 +2145,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/GoogleMeet:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2173,16 +2173,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/LiveKit:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2201,10 +2201,10 @@ importers:
   packages/AI/RealtimeBridge/Providers/LiveKitNative:
     dependencies:
       '@memberjunction/ai-bridge-livekit':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../LiveKit
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
     devDependencies:
       '@types/node':
@@ -2227,16 +2227,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/RingCentral:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2265,16 +2265,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Slack:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2293,16 +2293,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Teams:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2328,16 +2328,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Twilio:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2360,16 +2360,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Vonage:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2392,16 +2392,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Webex:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2420,16 +2420,16 @@ importers:
   packages/AI/RealtimeBridge/Providers/Zoom:
     dependencies:
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2452,19 +2452,19 @@ importers:
   packages/AI/RealtimeBridge/Server:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -2488,7 +2488,7 @@ importers:
         version: 3.0.7(@azure/identity@4.13.1)
       googleapis:
         specifier: ^144.0.0
-        version: 144.0.0(encoding@0.1.13)
+        version: 144.0.0
 
   packages/AI/RealtimeClient:
     dependencies:
@@ -2496,10 +2496,10 @@ importers:
         specifier: ^1.40.0
         version: 1.52.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2512,16 +2512,16 @@ importers:
   packages/AI/Recommendations/Engine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -2534,13 +2534,13 @@ importers:
   packages/AI/RemoteBrowser/Base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -2562,16 +2562,16 @@ importers:
   packages/AI/RemoteBrowser/Cdp:
     dependencies:
       '@memberjunction/computer-use':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ComputerUse
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
     devDependencies:
       '@types/node':
@@ -2590,16 +2590,16 @@ importers:
   packages/AI/RemoteBrowser/Providers/Browserbase:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2618,16 +2618,16 @@ importers:
   packages/AI/RemoteBrowser/Providers/Browserless:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2649,16 +2649,16 @@ importers:
         specifier: '*'
         version: 0.91.8(encoding@0.1.13)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2677,19 +2677,19 @@ importers:
   packages/AI/RemoteBrowser/Providers/SelfHost:
     dependencies:
       '@memberjunction/computer-use':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../ComputerUse
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2711,16 +2711,16 @@ importers:
   packages/AI/RemoteBrowser/Providers/Steel:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Cdp
     devDependencies:
       '@types/node':
@@ -2739,19 +2739,19 @@ importers:
   packages/AI/RemoteBrowser/Server:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/remote-browser-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
     devDependencies:
       '@types/node':
@@ -2770,25 +2770,25 @@ importers:
   packages/AI/Reranker:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Prompts
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2807,25 +2807,25 @@ importers:
   packages/AI/Segmentation:
     dependencies:
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Prompts
       '@memberjunction/ai-vectors':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Vectors/Core
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       cheerio:
         specifier: ^1.2.0
@@ -2841,25 +2841,25 @@ importers:
   packages/AI/Vectors/Core:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Database
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -2881,13 +2881,13 @@ importers:
   packages/AI/Vectors/Database:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../SQLDialect
       dotenv:
         specifier: ^17.2.4
@@ -2906,40 +2906,40 @@ importers:
   packages/AI/Vectors/Dupe:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Prompts
       '@memberjunction/ai-vector-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Sync
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Database
       '@memberjunction/ai-vectors':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/record-comparison':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../RecordComparison
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Templates/engine
       dotenv:
         specifier: ^17.2.4
@@ -2961,13 +2961,13 @@ importers:
   packages/AI/Vectors/Memory:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Database
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -2983,19 +2983,19 @@ importers:
   packages/AI/Vectors/Providers/Pinecone:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Database
       '@memberjunction/ai-vectors':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       '@pinecone-database/pinecone':
         specifier: 2.2.2
@@ -3023,13 +3023,13 @@ importers:
   packages/AI/Vectors/Providers/Qdrant:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Database
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       '@qdrant/js-client-rest':
         specifier: ^1.13.0
@@ -3051,13 +3051,13 @@ importers:
   packages/AI/Vectors/Providers/SQLServer:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Database
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -3076,13 +3076,13 @@ importers:
   packages/AI/Vectors/Providers/pgvector:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Database
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -3107,43 +3107,43 @@ importers:
   packages/AI/Vectors/Sync:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Prompts
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Database
       '@memberjunction/ai-vectors':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Core
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Providers/Pinecone
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Templates/engine
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Templates/base-types
       dotenv:
         specifier: ^17.2.4
@@ -3168,13 +3168,13 @@ importers:
   packages/APIKeys/Base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -3190,16 +3190,16 @@ importers:
   packages/APIKeys/Engine:
     dependencies:
       '@memberjunction/api-keys-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       cosmiconfig:
         specifier: 9.0.0
@@ -3221,19 +3221,19 @@ importers:
   packages/Actions/ApolloEnrichment:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -3249,16 +3249,16 @@ importers:
   packages/Actions/Base:
     dependencies:
       '@memberjunction/code-execution':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeExecution
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       zod:
         specifier: ^3.25.0
@@ -3274,19 +3274,19 @@ importers:
   packages/Actions/BizApps/Accounting:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -3302,19 +3302,19 @@ importers:
   packages/Actions/BizApps/CRM:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -3330,19 +3330,19 @@ importers:
   packages/Actions/BizApps/FormBuilders:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -3370,19 +3370,19 @@ importers:
   packages/Actions/BizApps/LMS:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       '@types/node':
@@ -3401,19 +3401,19 @@ importers:
   packages/Actions/BizApps/Social:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -3435,10 +3435,10 @@ importers:
   packages/Actions/CodeExecution:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       date-fns:
         specifier: ^3.0.0
@@ -3487,28 +3487,28 @@ importers:
   packages/Actions/ContentAutotag:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
       '@memberjunction/ai-vector-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Vectors/Sync
       '@memberjunction/content-autotagging':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ContentAutotagging
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -3533,115 +3533,115 @@ importers:
         specifier: ^1.1.8
         version: 1.1.8
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Core
       '@memberjunction/ai-agent-manager':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/AgentManager/core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Agents
       '@memberjunction/ai-betty-bot':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Providers/BettyBot
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/BaseAIEngine
       '@memberjunction/ai-mcp-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/MCPClient
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Prompts
       '@memberjunction/ai-vector-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Vectors/Sync
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Engine
       '@memberjunction/clustering-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Clustering
       '@memberjunction/code-execution':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeExecution
       '@memberjunction/communication-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/engine
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/base-types
       '@memberjunction/content-autotagging':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ContentAutotagging
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntitiesServer
       '@memberjunction/esignature':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../eSignature/Base
       '@memberjunction/export-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJExportEngine
       '@memberjunction/external-change-detection':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ExternalChangeDetection
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/geo-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../geo/geo-core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Integration/engine
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../InteractiveComponents
       '@memberjunction/lists':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Lists/server
       '@memberjunction/lists-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Lists/base
       '@memberjunction/react-linter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../React/linter
       '@memberjunction/record-set-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../RecordSetProcessor/engine
       '@memberjunction/record-set-processor-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../RecordSetProcessor/base
       '@memberjunction/search-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SearchEngine
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLDialect
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJStorage
       '@types/d3-cloud':
         specifier: ^1.2.9
@@ -3834,28 +3834,28 @@ importers:
   packages/Actions/Engine:
     dependencies:
       '@memberjunction/action-runtime':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Runtime
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Core
       '@memberjunction/code-execution':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeExecution
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/doc-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../DocUtils
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -3871,19 +3871,19 @@ importers:
   packages/Actions/Runtime:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
       '@memberjunction/code-execution':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeExecution
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -3896,37 +3896,37 @@ importers:
   packages/Actions/RuntimeHost:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Engine
       '@memberjunction/code-execution':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeExecution
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -3939,76 +3939,76 @@ importers:
   packages/Angular/Bootstrap:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/BaseAIEngine
       '@memberjunction/ai-realtime-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/RealtimeClient
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Vectors/Memory
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/entity-comm-base
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
       '@memberjunction/ng-artifacts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/artifacts
       '@memberjunction/ng-auth-services':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/auth-services
       '@memberjunction/ng-clustering':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/clustering
       '@memberjunction/ng-conversations':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/conversations
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/core-entity-forms
       '@memberjunction/ng-dashboard-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/dashboard-viewer
       '@memberjunction/ng-dashboards':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/dashboards
       '@memberjunction/ng-entity-action-ux':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/entity-action-ux
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/entity-viewer
       '@memberjunction/ng-explorer-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/explorer-core
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/explorer-settings
       '@memberjunction/ng-file-storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/file-storage
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/shared
       '@memberjunction/tag-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Knowledge/TagEngineBase
       rxjs:
         specifier: ^7.8.2
@@ -4030,7 +4030,7 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/test-utils
       ng-packagr:
         specifier: ^21.1.0
@@ -4046,64 +4046,64 @@ importers:
   packages/Angular/BootstrapLite:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/BaseAIEngine
       '@memberjunction/ai-realtime-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/RealtimeClient
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Vectors/Memory
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/entity-comm-base
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
       '@memberjunction/ng-artifacts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/artifacts
       '@memberjunction/ng-auth-services':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/auth-services
       '@memberjunction/ng-conversations':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/conversations
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/core-entity-forms
       '@memberjunction/ng-dashboard-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/dashboard-viewer
       '@memberjunction/ng-entity-action-ux':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/entity-action-ux
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/entity-viewer
       '@memberjunction/ng-explorer-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/explorer-core
       '@memberjunction/ng-file-storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Generic/file-storage
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Explorer/shared
       rxjs:
         specifier: ^7.8.2
@@ -4143,10 +4143,10 @@ importers:
         specifier: ^16.0.3
         version: 16.11.1
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@okta/okta-auth-js':
         specifier: ^7.14.1
@@ -4180,13 +4180,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       golden-layout:
         specifier: ^2.6.0
@@ -4229,118 +4229,118 @@ importers:
         specifier: ^6.5.2
         version: 6.5.2
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-action-gallery':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/action-gallery
       '@memberjunction/ng-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/actions
       '@memberjunction/ng-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/agents
       '@memberjunction/ng-ai-test-harness':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ai-test-harness
       '@memberjunction/ng-base-application':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/code-editor
       '@memberjunction/ng-deep-diff':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/deep-diff
       '@memberjunction/ng-entity-relationship-diagram':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/entity-relationship-diagram
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/entity-viewer
       '@memberjunction/ng-flow-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/flow-editor
       '@memberjunction/ng-join-grid':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/join-grid
       '@memberjunction/ng-link-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../link-directives
       '@memberjunction/ng-list-management':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/list-management
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/markdown
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/notifications
       '@memberjunction/ng-record-process-studio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/record-process-studio
       '@memberjunction/ng-resource-permissions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/resource-permissions
       '@memberjunction/ng-search':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/search
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       '@memberjunction/ng-tabstrip':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/tab-strip
       '@memberjunction/ng-task-graph-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/task-graph-editor
       '@memberjunction/ng-testing':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/Testing
       '@memberjunction/ng-timeline':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/timeline
       '@memberjunction/ng-trees':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ui-components
       '@memberjunction/ng-versions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/versions
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Templates/base-types
       '@types/d3':
         specifier: ^7.4.3
@@ -4383,7 +4383,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/dashboards:
@@ -4425,187 +4425,187 @@ importers:
         specifier: 6.43.8
         version: 6.43.8
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Base
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/api-keys-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../APIKeys/Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Credentials/Engine
       '@memberjunction/export-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJExportEngine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/integration-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Integration/engine-base
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../InteractiveComponents
       '@memberjunction/lists-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Lists/base
       '@memberjunction/ng-action-gallery':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/action-gallery
       '@memberjunction/ng-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/actions
       '@memberjunction/ng-agent-requests':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/agent-requests
       '@memberjunction/ng-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/agents
       '@memberjunction/ng-ai-test-harness':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ai-test-harness
       '@memberjunction/ng-archive-manager':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/archive-manager
       '@memberjunction/ng-base-application':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-clustering':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/clustering
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/code-editor
       '@memberjunction/ng-composer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/composer
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/container-directives
       '@memberjunction/ng-conversations':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/conversations
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../core-entity-forms
       '@memberjunction/ng-credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/credentials
       '@memberjunction/ng-dashboard-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/dashboard-viewer
       '@memberjunction/ng-entity-relationship-diagram':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/entity-relationship-diagram
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/entity-viewer
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../explorer-settings
       '@memberjunction/ng-export-service':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/export-service
       '@memberjunction/ng-filter-builder':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/filter-builder
       '@memberjunction/ng-list-management':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/list-management
       '@memberjunction/ng-map-view':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ng-map-view
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/markdown
       '@memberjunction/ng-media-player':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/media-player
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/notifications
       '@memberjunction/ng-query-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/query-viewer
       '@memberjunction/ng-react':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/react
       '@memberjunction/ng-record-process-studio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/record-process-studio
       '@memberjunction/ng-resource-permissions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/resource-permissions
       '@memberjunction/ng-scheduling':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/scheduling
       '@memberjunction/ng-search':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/search
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       '@memberjunction/ng-tabstrip':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/tab-strip
       '@memberjunction/ng-task-graph-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/task-graph-editor
       '@memberjunction/ng-testing':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/Testing
       '@memberjunction/ng-trees':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ui-components
       '@memberjunction/ng-user-routines':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/user-routines
       '@memberjunction/ng-versions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/versions
       '@memberjunction/ng-word-cloud':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/word-cloud
       '@memberjunction/predictive-studio-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/PredictiveStudio/Core
       '@memberjunction/tag-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Knowledge/TagEngineBase
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Templates/base-types
       '@memberjunction/testing-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../TestingFramework/EngineBase
       '@memberjunction/theme-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../ThemeEngine
       ag-grid-angular:
         specifier: ^35.0.1
@@ -4636,7 +4636,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/test-utils
       '@types/d3':
         specifier: ^7.4.0
@@ -4657,25 +4657,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-forms
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/container-directives
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ui-components
       tslib:
         specifier: ^2.8.1
@@ -4688,7 +4688,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/entity-permissions:
@@ -4703,25 +4703,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ui-components
       tslib:
         specifier: ^2.8.1
@@ -4734,7 +4734,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/explorer-app:
@@ -4743,52 +4743,52 @@ importers:
         specifier: ^21.0.0
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-agent-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/AgentsClient
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/ng-agent-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/agent-client
       '@memberjunction/ng-auth-services':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../auth-services
       '@memberjunction/ng-base-application':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-application
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-bootstrap':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Bootstrap/dist
       '@memberjunction/ng-conversations':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/conversations
       '@memberjunction/ng-explorer-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../explorer-core
       '@memberjunction/ng-explorer-service-worker':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../service-worker
       '@memberjunction/ng-feedback':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/feedback
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/notifications
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-workspace-initializer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../workspace-initializer
       rxjs:
         specifier: ^7.8.2
@@ -4837,154 +4837,154 @@ importers:
         specifier: ^2.6.0
         version: 2.6.0(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/router@21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2))
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Communication/base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/entity-communications-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Communication/entity-comm-client
       '@memberjunction/export-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJExportEngine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../InteractiveComponents
       '@memberjunction/lists-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Lists/base
       '@memberjunction/ng-ai-test-harness':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ai-test-harness
       '@memberjunction/ng-artifacts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/artifacts
       '@memberjunction/ng-auth-services':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../auth-services
       '@memberjunction/ng-base-application':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-composer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/composer
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/container-directives
       '@memberjunction/ng-conversations':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/conversations
       '@memberjunction/ng-dashboard-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/dashboard-viewer
       '@memberjunction/ng-dashboards':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../dashboards
       '@memberjunction/ng-entity-form-dialog':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-form-dialog
       '@memberjunction/ng-entity-permissions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-permissions
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/entity-viewer
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../explorer-settings
       '@memberjunction/ng-export-service':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/export-service
       '@memberjunction/ng-feedback':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/feedback
       '@memberjunction/ng-file-storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/file-storage
       '@memberjunction/ng-generic-dialog':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/generic-dialog
       '@memberjunction/ng-list-detail-grid':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../list-detail-grid
       '@memberjunction/ng-list-management':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/list-management
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/markdown
       '@memberjunction/ng-mj-livekit-room':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/mj-livekit-room
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/notifications
       '@memberjunction/ng-pagination':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/pagination
       '@memberjunction/ng-query-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/query-viewer
       '@memberjunction/ng-react':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/react
       '@memberjunction/ng-record-changes':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/record-changes
       '@memberjunction/ng-record-selector':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/record-selector
       '@memberjunction/ng-record-tags':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/record-tags
       '@memberjunction/ng-resource-permissions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/resource-permissions
       '@memberjunction/ng-search':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/search
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ui-components
       '@memberjunction/ng-user-avatar':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/user-avatar
       '@memberjunction/ng-word-cloud':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/word-cloud
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Templates/base-types
       '@memberjunction/theme-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../ThemeEngine
       golden-layout:
         specifier: ^2.6.0
@@ -5003,7 +5003,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/test-utils
       sass:
         specifier: ^1.97.3
@@ -5021,25 +5021,25 @@ importers:
         specifier: ^21.0.0
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/container-directives
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../core-entity-forms
       '@memberjunction/ng-explorer-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../explorer-core
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../explorer-settings
       '@memberjunction/ng-link-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../link-directives
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-workspace-initializer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../workspace-initializer
       tslib:
         specifier: ^2.8.1
@@ -5067,58 +5067,58 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-application':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/code-editor
       '@memberjunction/ng-entity-form-dialog':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-form-dialog
       '@memberjunction/ng-entity-permissions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-permissions
       '@memberjunction/ng-join-grid':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/join-grid
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/notifications
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       '@memberjunction/ng-simple-record-list':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../simple-record-list
       '@memberjunction/ng-tabstrip':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/tab-strip
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ui-components
       '@memberjunction/ng-user-avatar':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/user-avatar
       rxjs:
         specifier: ~7.8.2
@@ -5134,7 +5134,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/link-directives:
@@ -5146,13 +5146,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       tslib:
         specifier: ^2.8.1
@@ -5180,28 +5180,28 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/entity-viewer
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ui-components
       rxjs:
         specifier: ~7.8.2
@@ -5217,7 +5217,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/service-worker:
@@ -5263,37 +5263,37 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Communication/entity-comm-base
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-application':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-application
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       html-to-image:
         specifier: ^1.11.11
@@ -5324,31 +5324,31 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/container-directives
       '@memberjunction/ng-entity-form-dialog':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-form-dialog
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/ui-components
       tslib:
         specifier: ^2.8.1
@@ -5361,7 +5361,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/test-utils
 
   packages/Angular/Explorer/workspace-initializer:
@@ -5376,31 +5376,31 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-auth-services':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../auth-services
       '@memberjunction/ng-explorer-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../explorer-core
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Generic/shared
       '@memberjunction/theme-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../ThemeEngine
       rxjs:
         specifier: ^7.8.2
@@ -5431,34 +5431,34 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       '@memberjunction/testing-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../TestingFramework/EngineBase
       rxjs:
         specifier: ^7.8.2
@@ -5474,7 +5474,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5495,28 +5495,28 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-ai-test-harness':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ai-test-harness
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -5532,7 +5532,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -5556,22 +5556,22 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -5587,10 +5587,10 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Base
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5605,10 +5605,10 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/ai-agent-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/AgentsClient
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -5639,28 +5639,28 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../forms
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       rxjs:
         specifier: ^7.8.2
@@ -5676,7 +5676,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5703,28 +5703,28 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -5740,7 +5740,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -5767,46 +5767,46 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-task-graph-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../task-graph-editor
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       angular-split:
         specifier: ^20.0.0
@@ -5825,7 +5825,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5843,22 +5843,22 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -5874,7 +5874,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -5901,58 +5901,58 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../InteractiveComponents
       '@memberjunction/ng-base-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-forms
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-export-service':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../export-service
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../markdown
       '@memberjunction/ng-media-player':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../media-player
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-pagination':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../pagination
       '@memberjunction/ng-query-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../query-viewer
       '@memberjunction/ng-react':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../react
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-trees':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -5983,7 +5983,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -6007,49 +6007,49 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../InteractiveComponents
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-viewer
       '@memberjunction/ng-list-management':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../list-management
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../markdown
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-react':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../react
       '@memberjunction/ng-record-changes':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../record-changes
       '@memberjunction/ng-record-tags':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../record-tags
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       primeng:
         specifier: 21.1.1
@@ -6068,7 +6068,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6083,13 +6083,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       tslib:
         specifier: ^2.8.1
@@ -6117,19 +6117,19 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../markdown
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -6142,7 +6142,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6160,34 +6160,34 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-entity-card':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-card
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-viewer
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -6206,7 +6206,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6257,19 +6257,19 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       codemirror:
         specifier: ^6.0.2
@@ -6285,7 +6285,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -6306,13 +6306,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -6325,7 +6325,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6340,10 +6340,10 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       rxjs:
         specifier: ~7.8.2
@@ -6383,91 +6383,91 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Core
       '@memberjunction/ai-agent-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/AgentsClient
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/ai-realtime-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/RealtimeClient
       '@memberjunction/conversations-runtime':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../ConversationsRuntime
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../InteractiveComponents
       '@memberjunction/ng-agent-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../agent-client
       '@memberjunction/ng-artifacts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../artifacts
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-composer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../composer
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../forms
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../markdown
       '@memberjunction/ng-media-player':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../media-player
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-resource-permissions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../resource-permissions
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-task-graph-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../task-graph-editor
       '@memberjunction/ng-tasks':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../tasks
       '@memberjunction/ng-testing':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Testing
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       '@memberjunction/ng-user-routines':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../user-routines
       '@memberjunction/ng-whiteboard':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../whiteboard
       angular-split:
         specifier: ^20.0.0
@@ -6486,7 +6486,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -6507,25 +6507,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -6541,7 +6541,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6565,37 +6565,37 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-artifacts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../artifacts
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-viewer
       '@memberjunction/ng-map-view':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ng-map-view
       '@memberjunction/ng-query-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../query-viewer
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-trees':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       golden-layout:
         specifier: ^2.6.0
@@ -6614,7 +6614,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6632,25 +6632,25 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -6663,7 +6663,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6681,13 +6681,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -6700,7 +6700,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6718,25 +6718,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       '@memberjunction/record-set-processor-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../RecordSetProcessor/base
       rxjs:
         specifier: ^7.8.2
@@ -6752,7 +6752,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       rimraf:
         specifier: ^5.0.10
@@ -6770,13 +6770,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       tslib:
         specifier: ^2.8.1
@@ -6789,7 +6789,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6807,37 +6807,37 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Communication/base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Communication/entity-comm-base
       '@memberjunction/entity-communications-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Communication/entity-comm-client
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Templates/base-types
       tslib:
         specifier: ^2.8.1
@@ -6850,7 +6850,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -6874,16 +6874,16 @@ importers:
         specifier: ^1.1.8
         version: 1.1.8
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       '@types/d3':
         specifier: ^7.4.3
@@ -6908,7 +6908,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -6932,55 +6932,55 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/export-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJExportEngine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-entity-action-ux':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-action-ux
       '@memberjunction/ng-export-service':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../export-service
       '@memberjunction/ng-filter-builder':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../filter-builder
       '@memberjunction/ng-list-management':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../list-management
       '@memberjunction/ng-map-view':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ng-map-view
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-pagination':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../pagination
       '@memberjunction/ng-record-changes':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../record-changes
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-timeline':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../timeline
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -7002,7 +7002,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7023,7 +7023,7 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/export-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJExportEngine
       tslib:
         specifier: ^2.8.1
@@ -7036,7 +7036,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7054,19 +7054,19 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ~7.8.2
@@ -7082,7 +7082,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7103,34 +7103,34 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Explorer/shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -7152,7 +7152,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7173,10 +7173,10 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -7207,25 +7207,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -7247,7 +7247,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7286,25 +7286,25 @@ importers:
         specifier: 1.1.1
         version: 1.1.1
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -7320,7 +7320,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -7341,13 +7341,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../markdown
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -7360,7 +7360,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7375,7 +7375,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       dhtmlx-gantt:
         specifier: ^9.1.1
@@ -7391,7 +7391,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7406,7 +7406,7 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -7419,7 +7419,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7437,28 +7437,28 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -7471,7 +7471,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7486,7 +7486,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       tslib:
         specifier: ^2.8.1
@@ -7499,7 +7499,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7517,31 +7517,31 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/lists-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Lists/base
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -7557,7 +7557,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7575,13 +7575,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/livekit-room-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../LiveKitRoomCore
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       '@memberjunction/ng-whiteboard':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../whiteboard
       livekit-client:
         specifier: ^2.7.4
@@ -7600,7 +7600,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7618,7 +7618,7 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/markdown-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MarkdownCore
       mermaid:
         specifier: ^11.12.2
@@ -7637,7 +7637,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       jsdom:
         specifier: 26.1.0
@@ -7655,13 +7655,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       tslib:
         specifier: ^2.8.1
@@ -7674,7 +7674,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7689,25 +7689,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/livekit-room-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../LiveKitRoomCore
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-livekit-room':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../livekit-room
       '@memberjunction/ng-media-player':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../media-player
       rxjs:
         specifier: ^7.8.2
@@ -7735,19 +7735,19 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/geo-maps':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../geo/geo-maps
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@types/leaflet':
         specifier: ^1.9.17
@@ -7769,7 +7769,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7784,19 +7784,19 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       rxjs:
         specifier: ^7.8.2
@@ -7852,40 +7852,40 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/export-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJExportEngine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-export-service':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../export-service
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../markdown
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-pagination':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../pagination
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -7907,7 +7907,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -7928,31 +7928,31 @@ importers:
         specifier: ^7.29.1
         version: 7.29.1
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../InteractiveComponents
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/react-runtime':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../React/runtime
       '@types/react':
         specifier: ^19.2.13
@@ -7998,28 +7998,28 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       '@memberjunction/ng-versions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../versions
       diff:
         specifier: 8.0.3
@@ -8038,7 +8038,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       '@types/diff':
         specifier: ^5.2.3
@@ -8056,19 +8056,19 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8084,7 +8084,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8102,25 +8102,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-entity-action-ux':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-action-ux
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8136,7 +8136,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       rimraf:
         specifier: ^5.0.10
@@ -8157,19 +8157,19 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -8182,7 +8182,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8197,28 +8197,28 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       '@memberjunction/ng-word-cloud':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../word-cloud
       tslib:
         specifier: ^2.8.1
@@ -8231,7 +8231,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8249,31 +8249,31 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-generic-dialog':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../generic-dialog
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       ag-grid-angular:
         specifier: ^35.0.1
@@ -8292,7 +8292,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8310,25 +8310,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8344,7 +8344,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8362,25 +8362,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8396,7 +8396,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8414,19 +8414,19 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/theme-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../ThemeEngine
       dompurify:
         specifier: ^3.3.0
@@ -8445,7 +8445,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8460,10 +8460,10 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       tslib:
         specifier: ^2.8.1
@@ -8476,7 +8476,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8497,25 +8497,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-flow-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../flow-editor
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8531,7 +8531,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       sass:
         specifier: ^1.97.3
@@ -8555,22 +8555,22 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       dhtmlx-gantt:
         specifier: ^9.1.1
@@ -8583,7 +8583,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8592,7 +8592,7 @@ importers:
   packages/Angular/Generic/test-utils:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       tslib:
         specifier: ^2.8.1
@@ -8620,13 +8620,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ~7.8.2
@@ -8642,7 +8642,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8660,19 +8660,19 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8688,7 +8688,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8725,7 +8725,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8740,13 +8740,13 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       rxjs:
         specifier: ^7.8.2
@@ -8783,43 +8783,43 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../Actions/Base
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-composer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../composer
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../container-directives
       '@memberjunction/ng-notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../notifications
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-trees':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../trees
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8835,7 +8835,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8853,25 +8853,25 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../GraphQLDataProvider
       '@memberjunction/ng-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../shared
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8887,7 +8887,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8905,16 +8905,16 @@ importers:
         specifier: ^21.1.3
         version: 21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/ng-code-editor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../code-editor
       '@memberjunction/ng-markdown':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../markdown
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ui-components
       rxjs:
         specifier: ^7.8.2
@@ -8930,7 +8930,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8955,7 +8955,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/ng-test-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../test-utils
       vitest:
         specifier: ^4.0.18
@@ -8991,13 +8991,13 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.1.3(@angular/animations@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(@angular/common@21.1.3(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.1.3(@angular/compiler@21.1.3)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
       rxjs:
         specifier: ^7.8.2
@@ -9025,34 +9025,34 @@ importers:
   packages/Archiving/Action:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/archiving-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
 
   packages/Archiving/Engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJStorage
     devDependencies:
       typescript:
@@ -9065,10 +9065,10 @@ importers:
   packages/AuthProviders:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       graphql:
         specifier: ^16.12.0
@@ -9099,7 +9099,7 @@ importers:
   packages/CLICore:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@oclif/core':
         specifier: ^3.27.0
@@ -9130,88 +9130,88 @@ importers:
   packages/CodeGenLib:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/cli-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CLICore
       '@memberjunction/config':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Config
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntitiesServer
       '@memberjunction/external-data-source-databricks':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/Databricks
       '@memberjunction/external-data-source-mongodb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/MongoDB
       '@memberjunction/external-data-source-mysql':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/MySQL
       '@memberjunction/external-data-source-oracle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/Oracle
       '@memberjunction/external-data-source-postgres':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/Postgres
       '@memberjunction/external-data-source-snowflake':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/Snowflake
       '@memberjunction/external-data-source-sqlserver':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/SQLServer
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Engine
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/postgresql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../PostgreSQLDataProvider
       '@memberjunction/query-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../QueryProcessor
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerBootstrapLite
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLParser
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@oclif/core':
         specifier: ^3.27.0
@@ -9266,16 +9266,16 @@ importers:
   packages/Communication/base-types:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/base-types
       rxjs:
         specifier: ^7.8.2
@@ -9291,25 +9291,25 @@ importers:
   packages/Communication/engine:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/lists':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Lists/server
       '@memberjunction/lists-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Lists/base
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/engine
       rxjs:
         specifier: ^7.8.2
@@ -9325,16 +9325,16 @@ importers:
   packages/Communication/entity-comm-base:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -9347,22 +9347,22 @@ importers:
   packages/Communication/entity-comm-client:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-comm-base
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
     devDependencies:
       ts-node-dev:
@@ -9375,22 +9375,22 @@ importers:
   packages/Communication/entity-comm-server:
     dependencies:
       '@memberjunction/communication-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../engine
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/entity-communications-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../entity-comm-base
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -9403,28 +9403,28 @@ importers:
   packages/Communication/notifications:
     dependencies:
       '@memberjunction/communication-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../engine
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/engine
     devDependencies:
       ts-node-dev:
@@ -9443,28 +9443,28 @@ importers:
         specifier: ^5.0.3
         version: 5.4.0
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Core
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../AI/Engine
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../SQLServerDataProvider
       '@microsoft/microsoft-graph-client':
         specifier: ^3.0.7
@@ -9501,13 +9501,13 @@ importers:
   packages/Communication/providers/expo-push:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -9526,13 +9526,13 @@ importers:
   packages/Communication/providers/gmail:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -9554,16 +9554,16 @@ importers:
   packages/Communication/providers/sendgrid:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       '@sendgrid/mail':
         specifier: ^8.1.6
@@ -9582,13 +9582,13 @@ importers:
   packages/Communication/providers/twilio:
     dependencies:
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../base-types
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       dotenv:
         specifier: ^17.2.4
@@ -9610,19 +9610,19 @@ importers:
   packages/ComponentRegistry:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../InteractiveComponents
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@types/express':
         specifier: ^5.0.6
@@ -9659,13 +9659,13 @@ importers:
   packages/ComponentRegistryClientSDK:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../InteractiveComponents
     devDependencies:
       ts-node-dev:
@@ -9706,52 +9706,52 @@ importers:
         specifier: ^12.30.0
         version: 12.30.0
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-segmentation':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Segmentation
       '@memberjunction/ai-vector-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Sync
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Database
       '@memberjunction/ai-vectors':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Core
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJStorage
       '@memberjunction/tag-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Knowledge/TagEngine
       '@memberjunction/tag-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Knowledge/TagEngineBase
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Templates/engine
       axios:
         specifier: ^1.13.4
@@ -9815,25 +9815,25 @@ importers:
   packages/ConversationsRuntime:
     dependencies:
       '@memberjunction/ai-agent-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/AgentsClient
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/BaseAIEngine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GraphQLDataProvider
       rxjs:
         specifier: ^7.8.2
@@ -9849,13 +9849,13 @@ importers:
   packages/Credentials/Engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       ajv:
         specifier: ^8.17.1
@@ -9889,16 +9889,16 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.11)
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerBootstrapLite
       '@oclif/core':
         specifier: ^3.27.0
@@ -9971,13 +9971,13 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       axios:
         specifier: ^1.13.4
@@ -10062,19 +10062,19 @@ importers:
   packages/Encryption:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       cosmiconfig:
         specifier: ^9.0.0
@@ -10103,22 +10103,22 @@ importers:
   packages/ExternalChangeDetection:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/encryption':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Encryption
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
     devDependencies:
       ts-node-dev:
@@ -10131,22 +10131,22 @@ importers:
   packages/ExternalDataSources/Engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLParser
     devDependencies:
       '@types/node':
@@ -10168,16 +10168,16 @@ importers:
   packages/ExternalDataSources/Providers/Databricks:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
     devDependencies:
       '@databricks/sql':
@@ -10202,16 +10202,16 @@ importers:
   packages/ExternalDataSources/Providers/MongoDB:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       mongodb:
         specifier: ^6.10.0
@@ -10236,16 +10236,16 @@ importers:
   packages/ExternalDataSources/Providers/MySQL:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       mysql2:
         specifier: ^3.16.3
@@ -10270,16 +10270,16 @@ importers:
   packages/ExternalDataSources/Providers/Oracle:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       oracledb:
         specifier: ^6.8.0
@@ -10304,16 +10304,16 @@ importers:
   packages/ExternalDataSources/Providers/Postgres:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       pg:
         specifier: ^8.13.3
@@ -10341,16 +10341,16 @@ importers:
   packages/ExternalDataSources/Providers/SQLServer:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       mssql:
         specifier: ^12.7.0
@@ -10378,16 +10378,16 @@ importers:
   packages/ExternalDataSources/Providers/Snowflake:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       snowflake-sdk:
         specifier: ^2.4.0
@@ -10415,7 +10415,7 @@ importers:
   packages/FieldRulesTransforms:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@xmldom/xmldom':
         specifier: ^0.8.11
@@ -10440,28 +10440,28 @@ importers:
   packages/GeneratedActions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntitiesServer
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       zod:
         specifier: ^3.25.0
@@ -10477,10 +10477,10 @@ importers:
   packages/GeneratedEntities:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       zod:
         specifier: ^3.25.0
@@ -10496,43 +10496,43 @@ importers:
   packages/GenericDatabaseProvider:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/encryption':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Encryption
       '@memberjunction/geo-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../geo/geo-core
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/query-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../QueryProcessor
       '@memberjunction/queue':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJQueue
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLParser
       sql-formatter:
         specifier: ^15.7.0
@@ -10554,25 +10554,25 @@ importers:
   packages/GraphQLDataProvider:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../InteractiveComponents
       '@memberjunction/lists-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Lists/base
       '@tempfix/idb':
         specifier: ^8.0.3
@@ -10616,22 +10616,22 @@ importers:
   packages/Integration/actions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../engine
     devDependencies:
       tsc-alias:
@@ -10647,19 +10647,19 @@ importers:
   packages/Integration/connectors:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ExternalDataSources/Engine
       '@memberjunction/integration-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../engine
       '@memberjunction/integration-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../engine-base
     devDependencies:
       tsc-alias:
@@ -10675,22 +10675,22 @@ importers:
   packages/Integration/engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/integration-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../engine-base
       '@memberjunction/integration-pk-classifier':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../pk-classifier
       '@memberjunction/integration-progress-artifacts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../progress-artifacts
     devDependencies:
       tsc-alias:
@@ -10706,13 +10706,13 @@ importers:
   packages/Integration/engine-base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       tsc-alias:
@@ -10728,13 +10728,13 @@ importers:
   packages/Integration/pk-classifier:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       tsc-alias:
@@ -10750,7 +10750,7 @@ importers:
   packages/Integration/progress-artifacts:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       tsc-alias:
@@ -10766,19 +10766,19 @@ importers:
   packages/Integration/schema-builder:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../engine
       '@memberjunction/schema-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SchemaEngine
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLDialect
     devDependencies:
       tsc-alias:
@@ -10800,10 +10800,10 @@ importers:
   packages/InteractiveComponents:
     dependencies:
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Memory
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
     devDependencies:
       ts-node-dev:
@@ -10825,16 +10825,16 @@ importers:
   packages/Lists/server:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/lists-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base
     devDependencies:
       ts-node-dev:
@@ -10856,7 +10856,7 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2(@types/dom-mediacapture-transform@0.1.11)(livekit-client@2.19.2(@types/dom-mediacapture-record@1.0.22))
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       livekit-client:
         specifier: ^2.7.4
@@ -10875,25 +10875,25 @@ importers:
   packages/LiveKitRoomServer:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Base
       '@memberjunction/ai-bridge-livekit':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/LiveKit
       '@memberjunction/ai-bridge-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Server
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       livekit-server-sdk:
         specifier: ^2.9.7
@@ -10912,31 +10912,31 @@ importers:
   packages/MJAPI:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/communication-sendgrid':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/providers/sendgrid
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/messaging-adapters':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MessagingAdapters
       '@memberjunction/server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJServer
       '@memberjunction/server-bootstrap':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerBootstrap
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Templates/engine
       axios:
         specifier: ^1.13.4
@@ -10952,7 +10952,7 @@ importers:
         version: link:../GeneratedEntities
     devDependencies:
       '@memberjunction/cli':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCLI
       dotenv:
         specifier: 17.2.4
@@ -10976,49 +10976,49 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.11)
       '@memberjunction/ai-cli':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/AICLI
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/cli-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CLICore
       '@memberjunction/codegen-lib':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeGenLib
       '@memberjunction/config':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Config
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/db-auto-doc':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../DBAutoDoc
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/installer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJInstaller
       '@memberjunction/metadata-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MetadataSync
       '@memberjunction/open-app-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../OpenApp/Engine
       '@memberjunction/query-gen':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../QueryGen
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerBootstrapLite
       '@memberjunction/skyway-core':
         specifier: ^0.6.2
@@ -11030,19 +11030,19 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2
       '@memberjunction/sql-converter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLConverter
       '@memberjunction/sqlglot-ts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLGlotTS
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@memberjunction/standards':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Standards
       '@memberjunction/testing-cli':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TestingFramework/CLI
       '@oclif/core':
         specifier: ^3.27.0
@@ -11130,22 +11130,22 @@ importers:
   packages/MJCodeGenAPI:
     dependencies:
       '@memberjunction/codegen-lib':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeGenLib
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerBootstrapLite
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@types/axios':
         specifier: ^0.14.4
@@ -11200,10 +11200,10 @@ importers:
   packages/MJCore:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       debug:
         specifier: ^4.4.3
@@ -11231,16 +11231,16 @@ importers:
   packages/MJCoreEntities:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../InteractiveComponents
       rxjs:
         specifier: ^7.8.2
@@ -11259,76 +11259,76 @@ importers:
   packages/MJCoreEntitiesServer:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Dupe
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Database
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/doc-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../DocUtils
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Integration/engine
       '@memberjunction/integration-pk-classifier':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Integration/pk-classifier
       '@memberjunction/predictive-studio-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/PredictiveStudio/Core
       '@memberjunction/scheduling-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/engine
       '@memberjunction/sql-converter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLConverter
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLParser
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@memberjunction/tag-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Knowledge/TagEngine
       nunjucks:
         specifier: 3.2.4
@@ -11350,13 +11350,13 @@ importers:
   packages/MJDataContext:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -11369,13 +11369,13 @@ importers:
   packages/MJDataContextServer:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/data-context':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJDataContext
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       mssql:
         specifier: ^12.2.0
@@ -11502,82 +11502,82 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2(@types/dom-mediacapture-transform@0.1.11)(livekit-client@2.19.2(@types/dom-mediacapture-record@1.0.22))
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GraphQLDataProvider
       '@memberjunction/ng-auth-services':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/auth-services
       '@memberjunction/ng-base-application':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/base-application
       '@memberjunction/ng-base-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Generic/base-forms
       '@memberjunction/ng-bootstrap':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Bootstrap/dist
       '@memberjunction/ng-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/BootstrapLite
       '@memberjunction/ng-container-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Generic/container-directives
       '@memberjunction/ng-core-entity-forms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/core-entity-forms
       '@memberjunction/ng-dashboards':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/dashboards
       '@memberjunction/ng-entity-viewer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Generic/entity-viewer
       '@memberjunction/ng-explorer-app':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/explorer-app
       '@memberjunction/ng-explorer-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/explorer-core
       '@memberjunction/ng-explorer-modules':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/explorer-modules
       '@memberjunction/ng-explorer-service-worker':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/service-worker
       '@memberjunction/ng-explorer-settings':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/explorer-settings
       '@memberjunction/ng-join-grid':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Generic/join-grid
       '@memberjunction/ng-link-directives':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/link-directives
       '@memberjunction/ng-record-changes':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Generic/record-changes
       '@memberjunction/ng-shared':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/shared
       '@memberjunction/ng-shared-generic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Generic/shared
       '@memberjunction/ng-timeline':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Generic/timeline
       '@memberjunction/ng-ui-components':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Generic/ui-components
       '@memberjunction/ng-workspace-initializer':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Angular/Explorer/workspace-initializer
       '@okta/okta-auth-js':
         specifier: ^7.14.1
@@ -11770,7 +11770,7 @@ importers:
         specifier: 21.1.3
         version: 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
       '@memberjunction/cli':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCLI
       '@types/body-parser':
         specifier: ^1.19.6
@@ -11861,22 +11861,22 @@ importers:
   packages/MJQueue:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@types/uuid':
         specifier: ^11.0.0
@@ -11907,271 +11907,271 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0(graphql@16.12.0)
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Engine
       '@memberjunction/actions-apollo':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/ApolloEnrichment
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/actions-bizapps-accounting':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/Accounting
       '@memberjunction/actions-bizapps-crm':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/CRM
       '@memberjunction/actions-bizapps-formbuilders':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/FormBuilders
       '@memberjunction/actions-bizapps-lms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/LMS
       '@memberjunction/actions-bizapps-social':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/Social
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-agent-manager':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/AgentManager/core
       '@memberjunction/ai-agent-manager-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/AgentManager/actions
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Agents
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Base
       '@memberjunction/ai-bridge-ringcentral':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/RingCentral
       '@memberjunction/ai-bridge-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Server
       '@memberjunction/ai-bridge-teams':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/Teams
       '@memberjunction/ai-bridge-twilio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/Twilio
       '@memberjunction/ai-bridge-vonage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/Vonage
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/BaseAIEngine
       '@memberjunction/ai-mcp-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/MCPClient
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-vector-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Sync
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Database
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/Pinecone
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/api-keys':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../APIKeys/Engine
       '@memberjunction/auth-providers':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AuthProviders
       '@memberjunction/clustering-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Clustering
       '@memberjunction/codegen-lib':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeGenLib
       '@memberjunction/communication-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/engine
       '@memberjunction/communication-ms-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/providers/MSGraph
       '@memberjunction/communication-sendgrid':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/providers/sendgrid
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/base-types
       '@memberjunction/component-registry-client-sdk':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ComponentRegistryClientSDK
       '@memberjunction/computer-use':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/ComputerUse
       '@memberjunction/computer-use-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/MJComputerUse
       '@memberjunction/config':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Config
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntitiesServer
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Credentials/Engine
       '@memberjunction/data-context':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJDataContext
       '@memberjunction/data-context-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJDataContextServer
       '@memberjunction/doc-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../DocUtils
       '@memberjunction/encryption':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Encryption
       '@memberjunction/entity-communications-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/entity-comm-base
       '@memberjunction/entity-communications-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/entity-comm-server
       '@memberjunction/esignature':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../eSignature/Base
       '@memberjunction/external-change-detection':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalChangeDetection
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GraphQLDataProvider
       '@memberjunction/integration-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Integration/engine
       '@memberjunction/integration-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Integration/engine-base
       '@memberjunction/integration-progress-artifacts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Integration/progress-artifacts
       '@memberjunction/integration-schema-builder':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Integration/schema-builder
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../InteractiveComponents
       '@memberjunction/lists':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Lists/server
       '@memberjunction/lists-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Lists/base
       '@memberjunction/livekit-room-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../LiveKitRoomServer
       '@memberjunction/notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/notifications
       '@memberjunction/postgresql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../PostgreSQLDataProvider
       '@memberjunction/queue':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJQueue
       '@memberjunction/record-comparison':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../RecordComparison
       '@memberjunction/redis-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../RedisProvider
       '@memberjunction/remote-browser-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RemoteBrowser/Base
       '@memberjunction/remote-browser-cdp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RemoteBrowser/Cdp
       '@memberjunction/remote-browser-selfhost':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RemoteBrowser/Providers/SelfHost
       '@memberjunction/remote-browser-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RemoteBrowser/Server
       '@memberjunction/scheduling-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/actions
       '@memberjunction/scheduling-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/base-types
       '@memberjunction/scheduling-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/engine
       '@memberjunction/scheduling-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/base-engine
       '@memberjunction/schema-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SchemaEngine
       '@memberjunction/search-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SearchEngine
       '@memberjunction/server-extensions-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerExtensionsCore
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJStorage
       '@memberjunction/tag-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Knowledge/TagEngine
       '@memberjunction/tag-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Knowledge/TagEngineBase
       '@memberjunction/task-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TaskGraph
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Templates/engine
       '@memberjunction/testing-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TestingFramework/Engine
       '@memberjunction/testing-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TestingFramework/EngineBase
       '@memberjunction/version-history':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../VersionHistory
       '@octokit/auth-app':
         specifier: ^7.1.5
@@ -12319,16 +12319,16 @@ importers:
         specifier: ^7.19.0
         version: 7.19.0(encoding@0.1.13)
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@microsoft/mgt-element':
         specifier: ^4.6.0
@@ -12408,34 +12408,34 @@ importers:
   packages/MessagingAdapters:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/server-extensions-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerExtensionsCore
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@memberjunction/task-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TaskGraph
       '@slack/socket-mode':
         specifier: ^2.0.3
@@ -12472,40 +12472,40 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.10.11)
       '@memberjunction/cli-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CLICore
       '@memberjunction/config':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Config
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntitiesServer
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GraphQLDataProvider
       '@memberjunction/postgresql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../PostgreSQLDataProvider
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerBootstrapLite
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       '@oclif/core':
         specifier: ^3.27.0
@@ -12572,28 +12572,28 @@ importers:
         specifier: ^57.0.7
         version: 57.0.7(expo@54.0.35)(typescript@5.9.3)
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-realtime-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeClient
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GraphQLDataProvider
       '@memberjunction/markdown-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MarkdownCore
       '@memberjunction/react-runtime':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../React/runtime
       expo:
         specifier: ~54.0.0
@@ -12702,16 +12702,16 @@ importers:
   packages/OpenApp/Engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLDialect
       '@octokit/rest':
         specifier: ^21.1.1
@@ -12758,22 +12758,22 @@ importers:
   packages/PostgreSQLDataProvider:
     dependencies:
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Database
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/query-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../QueryProcessor
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       pg:
         specifier: ^8.13.3
@@ -12795,34 +12795,34 @@ importers:
   packages/QueryGen:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Prompts
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLServerDataProvider
       chalk:
         specifier: ^5.6.2
@@ -12856,13 +12856,13 @@ importers:
   packages/QueryProcessor:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       nunjucks:
         specifier: ^3.2.4
@@ -12890,25 +12890,25 @@ importers:
         specifier: ^7.29.0
         version: 7.29.7
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../InteractiveComponents
       '@memberjunction/react-runtime':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../runtime
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLParser
       typescript:
         specifier: ^5.9.3
@@ -12927,19 +12927,19 @@ importers:
         specifier: ^7.29.1
         version: 7.29.1
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../InteractiveComponents
       rxjs:
         specifier: ^7.8.2
@@ -12988,40 +12988,40 @@ importers:
         specifier: ^7.29.0
         version: 7.29.7
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Vectors/Memory
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntitiesServer
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/interactive-component-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../InteractiveComponents
       '@memberjunction/react-linter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../linter
       '@memberjunction/react-runtime':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../runtime
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLDialect
       '@memberjunction/sql-parser':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLParser
       '@playwright/test':
         specifier: ^1.58.1
@@ -13046,10 +13046,10 @@ importers:
         version: 5.9.3
     devDependencies:
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@types/mssql':
         specifier: ^9.1.9
@@ -13070,13 +13070,13 @@ importers:
   packages/RecordComparison:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
     devDependencies:
       '@types/node':
@@ -13089,10 +13089,10 @@ importers:
   packages/RecordSetProcessor/base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -13108,40 +13108,40 @@ importers:
   packages/RecordSetProcessor/engine:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/field-rules-transforms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../FieldRulesTransforms
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/record-set-processor-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/engine
     devDependencies:
       '@types/node':
@@ -13157,10 +13157,10 @@ importers:
   packages/RedisProvider:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       ioredis:
         specifier: ^5.6.1
@@ -13179,10 +13179,10 @@ importers:
   packages/SQLConverter:
     dependencies:
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       '@memberjunction/sqlglot-ts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLGlotTS
     devDependencies:
       '@types/pg':
@@ -13222,7 +13222,7 @@ importers:
   packages/SQLParser:
     dependencies:
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       node-sql-parser:
         specifier: ^5.4.0
@@ -13238,49 +13238,49 @@ importers:
   packages/SQLServerDataProvider:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Dupe
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Database
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/encryption':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Encryption
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/query-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../QueryProcessor
       '@memberjunction/queue':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJQueue
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       mssql:
         specifier: ^12.2.0
@@ -13311,25 +13311,25 @@ importers:
   packages/Scheduling/actions:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/scheduling-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/scheduling-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../engine
       cron-parser:
         specifier: ^4.9.0
@@ -13348,16 +13348,16 @@ importers:
   packages/Scheduling/base-engine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/scheduling-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       rxjs:
         specifier: ^7.8.2
@@ -13373,7 +13373,7 @@ importers:
   packages/Scheduling/base-types:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -13386,52 +13386,52 @@ importers:
   packages/Scheduling/engine:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Prompts
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/integration-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Integration/engine
       '@memberjunction/notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/notifications
       '@memberjunction/record-set-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../RecordSetProcessor/engine
       '@memberjunction/scheduling-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       '@memberjunction/scheduling-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-engine
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@memberjunction/task-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../TaskGraph
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/engine
       cron-parser:
         specifier: ^4.9.0
@@ -13456,16 +13456,16 @@ importers:
   packages/SchemaEngine:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/queue':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJQueue
       '@memberjunction/sql-dialect':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SQLDialect
       '@octokit/rest':
         specifier: ^21.1.1
@@ -13484,25 +13484,25 @@ importers:
   packages/SearchEngine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Core
       '@memberjunction/ai-vectordb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Database
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJStorage
       nunjucks:
         specifier: ^3.2.4
@@ -13525,346 +13525,346 @@ importers:
   packages/ServerBootstrap:
     dependencies:
       '@memberjunction/action-runtime-host':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/RuntimeHost
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Engine
       '@memberjunction/actions-apollo':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/ApolloEnrichment
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/actions-bizapps-accounting':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/Accounting
       '@memberjunction/actions-bizapps-crm':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/CRM
       '@memberjunction/actions-bizapps-formbuilders':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/FormBuilders
       '@memberjunction/actions-bizapps-lms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/LMS
       '@memberjunction/actions-bizapps-social':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/Social
       '@memberjunction/actions-content-autotag':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/ContentAutotag
       '@memberjunction/ai-agent-harness':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/AgentHarness
       '@memberjunction/ai-agent-manager':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/AgentManager/core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Agents
       '@memberjunction/ai-anthropic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Anthropic
       '@memberjunction/ai-assemblyai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/AssemblyAI
       '@memberjunction/ai-azure':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Azure
       '@memberjunction/ai-bedrock':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bedrock
       '@memberjunction/ai-betty-bot':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/BettyBot
       '@memberjunction/ai-blackforestlabs':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/BlackForestLabs
       '@memberjunction/ai-bridge-livekit':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/LiveKit
       '@memberjunction/ai-bridge-ringcentral':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/RingCentral
       '@memberjunction/ai-bridge-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Server
       '@memberjunction/ai-bridge-teams':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/Teams
       '@memberjunction/ai-bridge-twilio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/Twilio
       '@memberjunction/ai-bridge-vonage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RealtimeBridge/Providers/Vonage
       '@memberjunction/ai-cerebras':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Cerebras
       '@memberjunction/ai-cohere':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Cohere
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-elevenlabs':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/ElevenLabs
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/BaseAIEngine
       '@memberjunction/ai-fireworks':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Fireworks
       '@memberjunction/ai-form-builder':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/FormBuilder/core
       '@memberjunction/ai-gemini':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Gemini
       '@memberjunction/ai-groq':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Groq
       '@memberjunction/ai-heygen':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/HeyGen
       '@memberjunction/ai-huggingface':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/HuggingFace
       '@memberjunction/ai-inception':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Inception
       '@memberjunction/ai-inworld':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Inworld
       '@memberjunction/ai-llamacpp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/LlamaCpp
       '@memberjunction/ai-lmstudio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/LMStudio
       '@memberjunction/ai-local-embeddings':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/LocalEmbeddings
       '@memberjunction/ai-minimax':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/MiniMax
       '@memberjunction/ai-mistral':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Mistral
       '@memberjunction/ai-ollama':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Ollama
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/OpenAI
       '@memberjunction/ai-openrouter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/OpenRouter
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-recommendations-rex':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Recommendations-Rex
       '@memberjunction/ai-reranker':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Reranker
       '@memberjunction/ai-segmentation':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Segmentation
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Dupe
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Memory
       '@memberjunction/ai-vectors-pgvector':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/pgvector
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/Pinecone
       '@memberjunction/ai-vectors-qdrant':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/Qdrant
       '@memberjunction/ai-vectors-sqlserver':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/SQLServer
       '@memberjunction/ai-vertex':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Vertex
       '@memberjunction/ai-xai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/xAI
       '@memberjunction/ai-zhipu':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Zhipu
       '@memberjunction/archiving-action':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Archiving/Action
       '@memberjunction/archiving-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Archiving/Engine
       '@memberjunction/auth-providers':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AuthProviders
       '@memberjunction/codegen-lib':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../CodeGenLib
       '@memberjunction/communication-ms-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/providers/MSGraph
       '@memberjunction/communication-sendgrid':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/providers/sendgrid
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/base-types
       '@memberjunction/computer-use-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/MJComputerUse
       '@memberjunction/content-autotagging':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ContentAutotagging
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntitiesServer
       '@memberjunction/data-context-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJDataContextServer
       '@memberjunction/database-designer-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/DatabaseDesigner/actions
       '@memberjunction/database-designer-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/DatabaseDesigner/core
       '@memberjunction/doc-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../DocUtils
       '@memberjunction/encryption':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Encryption
       '@memberjunction/entity-communications-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/entity-comm-base
       '@memberjunction/esignature':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../eSignature/Base
       '@memberjunction/esignature-docusign':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../eSignature/Providers/DocuSign
       '@memberjunction/esignature-dropboxsign':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../eSignature/Providers/DropboxSign
       '@memberjunction/esignature-pandadoc':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../eSignature/Providers/PandaDoc
       '@memberjunction/external-data-source-databricks':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/Databricks
       '@memberjunction/external-data-source-mongodb':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/MongoDB
       '@memberjunction/external-data-source-mysql':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/MySQL
       '@memberjunction/external-data-source-oracle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/Oracle
       '@memberjunction/external-data-source-postgres':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/Postgres
       '@memberjunction/external-data-source-snowflake':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/Snowflake
       '@memberjunction/external-data-source-sqlserver':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Providers/SQLServer
       '@memberjunction/external-data-sources':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ExternalDataSources/Engine
       '@memberjunction/geo-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../geo/geo-core
       '@memberjunction/integration-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Integration/actions
       '@memberjunction/integration-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Integration/engine
       '@memberjunction/messaging-adapters':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MessagingAdapters
       '@memberjunction/predictive-studio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/PredictiveStudio/Engine
       '@memberjunction/queue':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJQueue
       '@memberjunction/react-linter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../React/linter
       '@memberjunction/record-comparison':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../RecordComparison
       '@memberjunction/record-set-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../RecordSetProcessor/engine
       '@memberjunction/remote-browser-selfhost':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RemoteBrowser/Providers/SelfHost
       '@memberjunction/remote-browser-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/RemoteBrowser/Server
       '@memberjunction/scheduling-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/actions
       '@memberjunction/scheduling-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/engine
       '@memberjunction/scheduling-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/base-engine
       '@memberjunction/search-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SearchEngine
       '@memberjunction/server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJServer
       '@memberjunction/server-extensions-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ServerExtensionsCore
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJStorage
       '@memberjunction/tag-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Knowledge/TagEngineBase
       '@memberjunction/task-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TaskGraph
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Templates/engine
       '@memberjunction/testing-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TestingFramework/Engine
       '@memberjunction/testing-integration':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TestingFramework/testing-integration
       cosmiconfig:
         specifier: ^9.0.0
@@ -13880,226 +13880,226 @@ importers:
   packages/ServerBootstrapLite:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Engine
       '@memberjunction/actions-apollo':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/ApolloEnrichment
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/actions-bizapps-accounting':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/Accounting
       '@memberjunction/actions-bizapps-crm':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/CRM
       '@memberjunction/actions-bizapps-formbuilders':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/FormBuilders
       '@memberjunction/actions-bizapps-lms':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/LMS
       '@memberjunction/actions-bizapps-social':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/BizApps/Social
       '@memberjunction/ai-agent-harness':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/AgentHarness
       '@memberjunction/ai-agent-manager':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/AgentManager/core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Agents
       '@memberjunction/ai-anthropic':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Anthropic
       '@memberjunction/ai-assemblyai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/AssemblyAI
       '@memberjunction/ai-azure':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Azure
       '@memberjunction/ai-bedrock':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bedrock
       '@memberjunction/ai-betty-bot':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/BettyBot
       '@memberjunction/ai-blackforestlabs':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/BlackForestLabs
       '@memberjunction/ai-cerebras':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Cerebras
       '@memberjunction/ai-cohere':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Cohere
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-elevenlabs':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/ElevenLabs
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/BaseAIEngine
       '@memberjunction/ai-fireworks':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Fireworks
       '@memberjunction/ai-form-builder':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/FormBuilder/core
       '@memberjunction/ai-gemini':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Gemini
       '@memberjunction/ai-groq':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Groq
       '@memberjunction/ai-heygen':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/HeyGen
       '@memberjunction/ai-inception':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Inception
       '@memberjunction/ai-inworld':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Inworld
       '@memberjunction/ai-llamacpp':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/LlamaCpp
       '@memberjunction/ai-lmstudio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/LMStudio
       '@memberjunction/ai-local-embeddings':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/LocalEmbeddings
       '@memberjunction/ai-minimax':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/MiniMax
       '@memberjunction/ai-mistral':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Mistral
       '@memberjunction/ai-ollama':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Ollama
       '@memberjunction/ai-openai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/OpenAI
       '@memberjunction/ai-openrouter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/OpenRouter
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Prompts
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Bundle
       '@memberjunction/ai-recommendations-rex':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Recommendations-Rex
       '@memberjunction/ai-reranker':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Reranker
       '@memberjunction/ai-vector-dupe':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Dupe
       '@memberjunction/ai-vectors-memory':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Memory
       '@memberjunction/ai-vectors-pgvector':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/pgvector
       '@memberjunction/ai-vectors-pinecone':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/Pinecone
       '@memberjunction/ai-vectors-qdrant':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/Qdrant
       '@memberjunction/ai-vectors-sqlserver':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Vectors/Providers/SQLServer
       '@memberjunction/ai-vertex':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Vertex
       '@memberjunction/ai-xai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/xAI
       '@memberjunction/ai-zhipu':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Providers/Zhipu
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/base-types
       '@memberjunction/content-autotagging':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../ContentAutotagging
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/CoreActions
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/core-entities-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntitiesServer
       '@memberjunction/data-context-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJDataContextServer
       '@memberjunction/doc-utils':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../DocUtils
       '@memberjunction/encryption':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Encryption
       '@memberjunction/geo-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../geo/geo-core
       '@memberjunction/predictive-studio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/PredictiveStudio/Engine
       '@memberjunction/queue':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJQueue
       '@memberjunction/react-linter':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../React/linter
       '@memberjunction/record-comparison':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../RecordComparison
       '@memberjunction/record-set-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../RecordSetProcessor/engine
       '@memberjunction/scheduling-actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/actions
       '@memberjunction/scheduling-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/engine
       '@memberjunction/scheduling-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Scheduling/base-engine
       '@memberjunction/search-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../SearchEngine
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJStorage
       '@memberjunction/tag-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Knowledge/TagEngineBase
       '@memberjunction/task-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TaskGraph
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Templates/engine
       '@memberjunction/testing-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../TestingFramework/Engine
     devDependencies:
       '@types/node':
@@ -14112,10 +14112,10 @@ importers:
   packages/ServerExtensionsCore:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       express:
         specifier: ^5.2.1
@@ -14149,31 +14149,31 @@ importers:
   packages/TaskGraph:
     dependencies:
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Actions/Base
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
       '@memberjunction/notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Communication/notifications
     devDependencies:
       '@types/node':
@@ -14189,13 +14189,13 @@ importers:
   packages/Templates/base-types:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       typescript:
@@ -14205,28 +14205,28 @@ importers:
   packages/Templates/engine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Core
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-provider-bundle':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Providers/Bundle
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../base-types
       nunjucks:
         specifier: 3.2.4
@@ -14239,28 +14239,28 @@ importers:
   packages/TestingFramework/CLI:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@memberjunction/testing-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/testing-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../EngineBase
       '@memberjunction/testing-integration':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../testing-integration
       '@oclif/core':
         specifier: ^3.27.0
@@ -14303,31 +14303,31 @@ importers:
   packages/TestingFramework/Engine:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Core
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Agents
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Engine
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/testing-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../EngineBase
       debug:
         specifier: ^4.4.3
@@ -14355,13 +14355,13 @@ importers:
   packages/TestingFramework/EngineBase:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       debug:
         specifier: ^4.4.3
@@ -14383,130 +14383,130 @@ importers:
   packages/TestingFramework/integration-test-suite:
     dependencies:
       '@memberjunction/actions':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Engine
       '@memberjunction/actions-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Actions/Base
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Core
       '@memberjunction/ai-agent-harness':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/AgentHarness
       '@memberjunction/ai-agents':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Agents
       '@memberjunction/ai-bridge-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/RealtimeBridge/Base
       '@memberjunction/ai-bridge-server':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/RealtimeBridge/Server
       '@memberjunction/ai-core-plus':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/CorePlus
       '@memberjunction/ai-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/BaseAIEngine
       '@memberjunction/ai-prompts':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Prompts
       '@memberjunction/aiengine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Engine
       '@memberjunction/api-keys':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../APIKeys/Engine
       '@memberjunction/codegen-lib':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../CodeGenLib
       '@memberjunction/communication-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/engine
       '@memberjunction/communication-expo-push':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/providers/expo-push
       '@memberjunction/communication-gmail':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/providers/gmail
       '@memberjunction/communication-ms-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/providers/MSGraph
       '@memberjunction/communication-sendgrid':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/providers/sendgrid
       '@memberjunction/communication-twilio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/providers/twilio
       '@memberjunction/communication-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/base-types
       '@memberjunction/content-autotagging':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ContentAutotagging
       '@memberjunction/conversations-runtime':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ConversationsRuntime
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
       '@memberjunction/metadata-sync':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MetadataSync
       '@memberjunction/notifications':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Communication/notifications
       '@memberjunction/open-app-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../OpenApp/Engine
       '@memberjunction/predictive-studio':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/PredictiveStudio/Engine
       '@memberjunction/predictive-studio-core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/PredictiveStudio/Core
       '@memberjunction/query-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../QueryProcessor
       '@memberjunction/record-set-processor':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../RecordSetProcessor/engine
       '@memberjunction/record-set-processor-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../RecordSetProcessor/base
       '@memberjunction/scheduling-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Scheduling/engine
       '@memberjunction/search-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SearchEngine
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@memberjunction/task-graph':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../TaskGraph
       '@memberjunction/templates':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/engine
       '@memberjunction/templates-base-types':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Templates/base-types
       '@memberjunction/testing-integration':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../testing-integration
       dotenv:
         specifier: 17.2.4
@@ -14528,31 +14528,31 @@ importers:
   packages/TestingFramework/testing-integration:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/generic-database-provider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GenericDatabaseProvider
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
       '@memberjunction/server-bootstrap-lite':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ServerBootstrapLite
       '@memberjunction/sqlserver-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../SQLServerDataProvider
       '@memberjunction/testing-engine':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../Engine
       '@memberjunction/testing-engine-base':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../EngineBase
       cosmiconfig:
         specifier: 9.0.0
@@ -14575,7 +14575,7 @@ importers:
         version: 4.0.18(@types/node@24.10.11)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.2)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@memberjunction/postgresql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../PostgreSQLDataProvider
 
   packages/ThemeEngine:
@@ -14587,7 +14587,7 @@ importers:
   packages/UnitTesting:
     dependencies:
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
     devDependencies:
       ts-node-dev:
@@ -14603,13 +14603,13 @@ importers:
   packages/VersionHistory:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../MJGlobal
     devDependencies:
       typescript:
@@ -14619,25 +14619,25 @@ importers:
   packages/Web/RealtimeWidget:
     dependencies:
       '@memberjunction/ai':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/Core
       '@memberjunction/ai-realtime-client':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../AI/RealtimeClient
       '@memberjunction/conversations-runtime':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../ConversationsRuntime
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/graphql-dataprovider':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../GraphQLDataProvider
     devDependencies:
       '@types/node':
@@ -14656,28 +14656,28 @@ importers:
   packages/eSignature/Base:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/credentials':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Credentials/Engine
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
       '@memberjunction/storage':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJStorage
 
   packages/eSignature/Providers/DocuSign:
     dependencies:
       '@memberjunction/esignature':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
       jsonwebtoken:
         specifier: ^9.0.0
@@ -14690,31 +14690,31 @@ importers:
   packages/eSignature/Providers/DropboxSign:
     dependencies:
       '@memberjunction/esignature':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
 
   packages/eSignature/Providers/PandaDoc:
     dependencies:
       '@memberjunction/esignature':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../Base
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../../MJGlobal
 
   packages/geo/geo-core:
     dependencies:
       '@memberjunction/core':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCore
       '@memberjunction/core-entities':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJCoreEntities
       '@memberjunction/global':
-        specifier: 6.1.0-edge.1
+        specifier: 6.1.0-edge.2
         version: link:../../MJGlobal
     devDependencies:
       '@types/node':
@@ -29530,7 +29530,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
+      '@angular-devkit/build-webpack': 0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))
       '@angular-devkit/core': 21.1.3(chokidar@5.0.0)
       '@angular/build': 21.1.3(a1c152c28654637a273e49d67cbd7227)
       '@angular/compiler-cli': 21.1.3(@angular/compiler@21.1.3)(typescript@5.9.3)
@@ -29581,7 +29581,7 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
+      webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(webpack@5.105.0(esbuild@0.27.2))
     optionalDependencies:
@@ -29620,15 +29620,6 @@ snapshots:
       rxjs: 7.8.2
       webpack: 5.105.0(esbuild@0.27.2)
       webpack-dev-server: 5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-    transitivePeerDependencies:
-      - chokidar
-
-  '@angular-devkit/build-webpack@0.2101.3(chokidar@5.0.0)(webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)))(webpack@5.105.0(esbuild@0.27.2))':
-    dependencies:
-      '@angular-devkit/architect': 0.2101.3(chokidar@5.0.0)
-      rxjs: 7.8.2
-      webpack: 5.105.0(esbuild@0.27.2)
-      webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
     transitivePeerDependencies:
       - chokidar
 
@@ -42637,7 +42628,7 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0(encoding@0.1.13):
+  googleapis-common@7.2.0:
     dependencies:
       extend: 3.0.2
       gaxios: 6.7.1(encoding@0.1.13)
@@ -42660,10 +42651,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@144.0.0(encoding@0.1.13):
+  googleapis@144.0.0:
     dependencies:
       google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis-common: 7.2.0(encoding@0.1.13)
+      googleapis-common: 7.2.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -48628,45 +48619,6 @@ snapshots:
       - tslib
 
   webpack-dev-server@5.2.2(debug@4.4.3)(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.25
-      '@types/express-serve-static-core': 4.19.8
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.10
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.3.0
-      chokidar: 3.6.0
-      colorette: 2.0.20
-      compression: 1.8.1
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.1
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
-      ipaddr.js: 2.3.0
-      launch-editor: 2.12.0
-      open: 10.2.0
-      p-retry: 6.2.1
-      schema-utils: 4.3.3
-      selfsigned: 2.4.1
-      serve-index: 1.9.2
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2))
-      ws: 8.19.0
-    optionalDependencies:
-      webpack: 5.105.0(esbuild@0.27.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - tslib
-      - utf-8-validate
-
-  webpack-dev-server@5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.27.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4


### PR DESCRIPTION
**One sentence:** `main`'s committed `pnpm-lock.yaml` still pins 2287 `@memberjunction/*` workspace specifiers at `6.1.0-edge.1` while every manifest says `6.1.0-edge.2`, so no `pnpm install --frozen-lockfile` can succeed on `main` — this regenerates the lockfile with a real install, changing nothing about which packages resolve.

## Evidence

The versioned docs deploy's **Build v6 (main)** job failed on `pnpm install --frozen-lockfile` ([run 32270678576](https://github.com/MemberJunction/MJ/actions/runs/32270678576), 2026-08-19):

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/AI/Core/package.json
  specifiers in the lockfile don't match specifiers in package.json:
* 1 dependencies are mismatched:
  - @memberjunction/global (lockfile: 6.1.0-edge.1, manifest: 6.1.0-edge.2)
```

Reproduced locally on a clean `origin/main` worktree, identical error.

## What actually drifted

**pnpm's error is not an inventory** — the frozen check aborts on the first mismatched importer it reaches (`packages/AI/Core`, alphabetically early) and reports one specifier. The real scope, from a full sweep of all 307 lockfile importers against their manifests:

| | count |
|---|---|
| `@memberjunction/*` specifiers at `6.1.0-edge.1` vs manifest `6.1.0-edge.2` | **2287** |
| importers affected | **291** of 307 |
| distinct drifted (lockfile → manifest) specifier pairs | **1** — `6.1.0-edge.1` → `6.1.0-edge.2` |
| third-party dependency drift | **0** |

The drift is a single homogeneous class. Three things that *look* like additional drift on a naive comparison are not, and are worth recording so the next person doesn't chase them:

- **`rimraf`, `@types/node`, `jsdom`, `browserslist` …** — the lockfile records `^5.0.10` / `24.10.11` / `26.1.0` against manifests asking for something else. These are pinned in root `pnpm.overrides`; pnpm records the *effective* (overridden) specifier. Correct as-is (69 rows).
- **`@angular/*`, `rxjs` in ~200 rows** — declared as `peerDependencies`, hoisted into the importer's `dependencies` block by `autoInstallPeers: true`. Specifiers match exactly.
- **`packages/geo/geo-maps` has no importer entry at all** — it is the only workspace package with zero dependencies of any kind, and pnpm omits dependency-less projects from `importers`. Not a defect. (This is why pnpm reports 308 workspace projects against 307 importers.)

## Why it happened

`publish.yml`'s main-branch path never refreshes the lockfile after the version bump:

1. `pnpm install --frozen-lockfile` runs **before** `changeset version` — by definition it cannot write the lockfile.
2. `pnpm run version` (`changeset version`) rewrites the version and every internal dependency range across ~300 manifests.
3. `ci/commit_push.mjs` does `git add ./*` and pushes to `main`. It would have committed a refreshed lockfile — but nothing in the job ever regenerated one, so it commits bumped manifests beside a stale lockfile.
4. The only lockfile refresh in the whole workflow is the final back-merge step, `ci/merge_main_and_update_lock.mjs` → `refreshLockfile()`, which runs **after `git checkout next`** and therefore lands on `next`.

Net effect: `next` gets a reconciled lockfile, `main` never does. That matches the observed state — this only surfaced now because the docs deploy recently began building `/v6` from `main`.

## The fix and its proof

Regenerated with a real `pnpm install` (**not** `--lockfile-only`, per the repo's pnpm doctrine).

Diff stat — one file, and the scope is provably narrow:

```
 pnpm-lock.yaml | 4634 ++++++++++++++++++--------------------
 1 file changed, 2293 insertions(+), 2341 deletions(-)
```

Section-by-section against `HEAD`:

| lockfile section | identical? |
|---|---|
| `packages` (resolved versions + integrity hashes) | **YES — byte-identical** |
| `overrides` / `patchedDependencies` / `settings` | YES |
| `importers` | no — the 2287 specifiers |
| `snapshots` | no — 48 lines net removed |

**`packages:` being byte-identical is the load-bearing check:** not one dependency was added, removed, upgraded or re-resolved, and no integrity hash moved. Every changed line is accounted for — 2287 importer specifiers, plus pruning of orphaned peer-context snapshot keys (`googleapis@144.0.0(encoding@0.1.13)` → `googleapis@144.0.0`, `webpack-dev-server@5.2.2(…)` gaining a `debug@4.4.3` context). Those keep the same resolved versions; only the peer-context suffix changes.

**Frozen-install proof**, run in a *second, separate* worktree checked out clean at `origin/main` with only this lockfile applied and **no `node_modules`**:

```
$ CI=1 pnpm install --frozen-lockfile
Scope: all 308 workspace projects
Lockfile is up to date, resolution step is skipped
Packages: +3224
Done in 23.8s using pnpm v10.33.0
EXIT=0
```

The run left the lockfile byte-identical, so the result is idempotent rather than quietly re-reconciled.

## For the reviewer

- **Only `pnpm-lock.yaml` is committed.** Nothing else was modified or staged.
- A pre-existing `WARN Failed to create bin … mj-querygen` appears in the install output. It is unrelated to this change (it shows up equally before and after, in any unbuilt checkout — the bin target lives in a `dist/` that has not been built yet) and it is a warning, not a failure.
- The 2287-line diff is large but mechanical. The section table above is the fast way to review it; spot-checking a handful of `specifier:` lines plus trusting `packages:`-identical covers the substance.

## Systemic follow-up (flagging only, not implemented here)

This will recur on the next edge release. `publish-lts.yml` already has the guard — a *"Version (normal mode) and refresh lockfile"* step that refreshes and commits the lockfile alongside the bump (#3559). `publish.yml`'s edge/main path has no equivalent and should get one.

One caveat if that work is picked up: **do not copy the LTS step verbatim.** It refreshes with `pnpm install --lockfile-only`, which this repo has already been burned by (a `--lockfile-only` refresh once drifted 827 packages, hence the standing rule to reconcile with a real `pnpm install`). The edge path wants the *shape* of the LTS guard with a real install, and the LTS path arguably wants correcting to match.

Worth confirming separately whether `main` was already unbuildable-from-clean at `v6.1.0-edge.1`, or whether the `.0` → `.1` release happened to leave it consistent — that determines whether this is the first occurrence or the first one anybody noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnZaUxhuvSKe26rqvWuD6e
