### PR TITLE
fix(hierarchy-tree): derive default OrderBy from resolved name field

### DIFF
--- a/packages/Angular/Generic/hierarchy-tree/src/lib/components/hierarchy-tree.component.ts
+++ b/packages/Angular/Generic/hierarchy-tree/src/lib/components/hierarchy-tree.component.ts
@@ -360,10 +360,11 @@ export class HierarchyTreeComponent extends BaseAngularComponent implements OnIn
             }
 
             const rv = RunView.FromMetadataProvider(this.ProviderToUse);
+            const defaultOrderBy = `${this.resolveNameFieldName()} ASC`;
             const rvParams = {
                 EntityName: targetEntityName,
                 ExtraFilter: this.Config.ExtraFilter || '',
-                OrderBy: this.Config.OrderBy || 'Name ASC',
+                OrderBy: this.Config.OrderBy || defaultOrderBy,
                 ResultType: 'simple' as const,
                 MaxRows: this.Config.MaxRows ?? 0
             };


### PR DESCRIPTION
## Summary
- In `HierarchyTreeComponent`, derive the default `OrderBy` from `${this.resolveNameFieldName()} ASC` rather than hardcoding `'Name ASC'`.
- Prevents query execution failures on entities whose primary label is not named `Name` (such as `Title` on Activities).