### PR TITLE
fix(integration): enforce within-batch ExternalID identity before mapping

### DIFF
--- a/.changeset/within-batch-external-id-identity.md
+++ b/.changeset/within-batch-external-id-identity.md
@@ -1,0 +1,22 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Enforce within-batch ExternalID identity before mapping.
+
+ExternalID is the identity the record map keys on, so two records in one batch carrying the same one
+are two observations of a single source record — never two rows. The write path cannot detect this:
+it decides insert-vs-update by asking whether the identity exists in the DATABASE, and for a
+first-time record neither copy does, so both insert and the pair re-inserts on every later sync. The
+existing fingerprint guard only catches a batch repeated in full (the infinite-loop case), not
+duplicates inside one batch.
+
+Measured on a live tenant: one object held 54,119 rows for 42,519 distinct keys — 11,632 excess,
+across 11,200 duplicate groups that were byte-identical on every captured column and written within
+the same second, i.e. the source listed the same element twice inside one batch.
+
+The engine now collapses duplicate identities per batch, keeping the last occurrence (upsert
+semantics: the later entry is the more recent observation), and reports the count as a
+`DUPLICATE_IDENTITIES_IN_BATCH` warning rather than silently — a connector emitting duplicate
+identities is a defect worth fixing at its source. Records with no ExternalID pass through
+untouched, since collapsing those would merge unrelated rows.

--- a/packages/Integration/engine/src/BatchIdentity.ts
+++ b/packages/Integration/engine/src/BatchIdentity.ts
@@ -1,0 +1,95 @@
+/**
+ * Within-batch identity: no two records in one batch may share an ExternalID.
+ *
+ * ExternalID *is* the identity the record map keys on, so two records carrying the same one are two
+ * observations of a single source record, never two rows. The write path cannot discover this on its
+ * own: it decides insert-vs-update by asking whether the identity already exists in the DATABASE,
+ * and for a first-time record neither copy does — so both insert, and the pair re-inserts on every
+ * subsequent sync. Nothing downstream can repair it either, because both rows then map to the same
+ * ExternalID and no later run can tell which to keep.
+ *
+ * Observed in the field: an object whose duplicate groups were byte-identical on every captured
+ * column AND written inside the same second — meaning the source itself listed the same element
+ * twice within one batch, rather than a re-read delivering it again. The whole-batch fingerprint
+ * guard nearby catches a batch REPEATED in full (the infinite-loop case); it cannot see duplicates
+ * inside a single batch.
+ *
+ * Last-wins matches upsert semantics: when two entries share an identity but differ, the later
+ * entry is the more recent observation of that record's state, which is exactly what a single
+ * upsert would have left behind had they arrived in separate batches.
+ */
+
+/** Minimal shape needed to de-duplicate: anything carrying an ExternalID. */
+export interface HasExternalID {
+    ExternalID: string;
+}
+
+/** Outcome of a within-batch identity pass. */
+export interface BatchIdentityResult<T> {
+    /** The batch with duplicate identities collapsed, original order preserved. */
+    Records: T[];
+    /** How many records were dropped as repeats of an identity already in this batch. */
+    Collapsed: number;
+    /**
+     * Identities that appeared more than once, capped for reporting. Sample only — a batch with
+     * thousands of repeats must not put thousands of ids into a run event.
+     */
+    SampleIDs: string[];
+}
+
+/** How many repeated identities to name in the warning. */
+const SAMPLE_LIMIT = 5;
+
+/**
+ * Collapses records sharing an ExternalID within one batch, keeping the LAST occurrence in its
+ * original position. Returns the input array unchanged (same reference) when every identity is
+ * already unique, so the ordinary path allocates nothing.
+ *
+ * A record with an empty or missing ExternalID is passed through untouched: identity-less records
+ * are a separate defect with a separate guard, and silently collapsing them here would merge
+ * unrelated rows.
+ */
+export function CollapseDuplicateIdentities<T extends HasExternalID>(records: ReadonlyArray<T>): BatchIdentityResult<T> {
+    if (records.length < 2) {
+        return { Records: records as T[], Collapsed: 0, SampleIDs: [] };
+    }
+
+    // First pass: find which identities repeat, without allocating a copy of the batch.
+    const counts = new Map<string, number>();
+    let duplicates = 0;
+    for (const r of records) {
+        const id = r?.ExternalID;
+        if (!id) continue;
+        const seen = counts.get(id);
+        if (seen === undefined) {
+            counts.set(id, 1);
+        } else {
+            counts.set(id, seen + 1);
+            duplicates++;
+        }
+    }
+    if (duplicates === 0) {
+        return { Records: records as T[], Collapsed: 0, SampleIDs: [] };
+    }
+
+    const sample: string[] = [];
+    for (const [id, n] of counts) {
+        if (n > 1 && sample.length < SAMPLE_LIMIT) sample.push(id);
+        if (sample.length >= SAMPLE_LIMIT) break;
+    }
+
+    // Second pass: keep the LAST occurrence of each repeated identity, in its original slot.
+    const lastIndexByID = new Map<string, number>();
+    for (let i = 0; i < records.length; i++) {
+        const id = records[i]?.ExternalID;
+        if (id) lastIndexByID.set(id, i);
+    }
+    const out: T[] = [];
+    for (let i = 0; i < records.length; i++) {
+        const r = records[i];
+        const id = r?.ExternalID;
+        if (!id || lastIndexByID.get(id) === i) out.push(r);
+    }
+
+    return { Records: out, Collapsed: records.length - out.length, SampleIDs: sample };
+}

--- a/packages/Integration/engine/src/BatchIdentity.ts
+++ b/packages/Integration/engine/src/BatchIdentity.ts
@@ -1,0 +1,95 @@
+/**
+ * Within-batch identity: no two records in one batch may share an ExternalID.
+ *
+ * ExternalID *is* the identity the record map keys on, so two records carrying the same one are two
+ * observations of a single source record, never two rows. The write path cannot discover this on its
+ * own: it decides insert-vs-update by asking whether the identity already exists in the DATABASE,
+ * and for a first-time record neither copy does — so both insert, and the pair re-inserts on every
+ * subsequent sync. Nothing downstream can repair it either, because both rows then map to the same
+ * ExternalID and no later run can tell which to keep.
+ *
+ * Measured on a live tenant (2026-08-19): one object held 54,119 rows for 42,519 distinct keys —
+ * 11,632 excess. All 11,200 duplicate groups were byte-identical on every captured column AND
+ * written inside the same second, i.e. the source itself listed the same element twice within one
+ * batch. The whole-batch fingerprint guard nearby catches a batch REPEATED in full (the
+ * infinite-loop case); it cannot see duplicates inside a single batch.
+ *
+ * Last-wins matches upsert semantics: when two entries share an identity but differ, the later
+ * entry is the more recent observation of that record's state, which is exactly what a single
+ * upsert would have left behind had they arrived in separate batches.
+ */
+
+/** Minimal shape needed to de-duplicate: anything carrying an ExternalID. */
+export interface HasExternalID {
+    ExternalID: string;
+}
+
+/** Outcome of a within-batch identity pass. */
+export interface BatchIdentityResult<T> {
+    /** The batch with duplicate identities collapsed, original order preserved. */
+    Records: T[];
+    /** How many records were dropped as repeats of an identity already in this batch. */
+    Collapsed: number;
+    /**
+     * Identities that appeared more than once, capped for reporting. Sample only — a batch with
+     * thousands of repeats must not put thousands of ids into a run event.
+     */
+    SampleIDs: string[];
+}
+
+/** How many repeated identities to name in the warning. */
+const SAMPLE_LIMIT = 5;
+
+/**
+ * Collapses records sharing an ExternalID within one batch, keeping the LAST occurrence in its
+ * original position. Returns the input array unchanged (same reference) when every identity is
+ * already unique, so the ordinary path allocates nothing.
+ *
+ * A record with an empty or missing ExternalID is passed through untouched: identity-less records
+ * are a separate defect with a separate guard, and silently collapsing them here would merge
+ * unrelated rows.
+ */
+export function CollapseDuplicateIdentities<T extends HasExternalID>(records: ReadonlyArray<T>): BatchIdentityResult<T> {
+    if (records.length < 2) {
+        return { Records: records as T[], Collapsed: 0, SampleIDs: [] };
+    }
+
+    // First pass: find which identities repeat, without allocating a copy of the batch.
+    const counts = new Map<string, number>();
+    let duplicates = 0;
+    for (const r of records) {
+        const id = r?.ExternalID;
+        if (!id) continue;
+        const seen = counts.get(id);
+        if (seen === undefined) {
+            counts.set(id, 1);
+        } else {
+            counts.set(id, seen + 1);
+            duplicates++;
+        }
+    }
+    if (duplicates === 0) {
+        return { Records: records as T[], Collapsed: 0, SampleIDs: [] };
+    }
+
+    const sample: string[] = [];
+    for (const [id, n] of counts) {
+        if (n > 1 && sample.length < SAMPLE_LIMIT) sample.push(id);
+        if (sample.length >= SAMPLE_LIMIT) break;
+    }
+
+    // Second pass: keep the LAST occurrence of each repeated identity, in its original slot.
+    const lastIndexByID = new Map<string, number>();
+    for (let i = 0; i < records.length; i++) {
+        const id = records[i]?.ExternalID;
+        if (id) lastIndexByID.set(id, i);
+    }
+    const out: T[] = [];
+    for (let i = 0; i < records.length; i++) {
+        const r = records[i];
+        const id = r?.ExternalID;
+        if (!id || lastIndexByID.get(id) === i) out.push(r);
+    }
+
+    return { Records: out, Collapsed: records.length - out.length, SampleIDs: sample };
+}

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -3475,6 +3475,23 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         const orphans = allMaps.Rows.filter(m => !fetchedExternalIDs.has(m.ExternalSystemRecordID));
         if (orphans.length === 0) return;
 
+        // The sweep is a DELETE PATH and must answer to the same policy as every other delete.
+        // It used to call entity.Delete() unconditionally — its own warning text promised
+        // "archived/deleted" while the code only ever deleted, so a map configured SoftDelete
+        // (or DoNothing) had its rows physically removed by full syncs. DoNothing short-circuits
+        // the whole sweep: the policy says external deletions never touch MJ rows, and saying so
+        // once beats detecting the same "orphans" forever.
+        if (entityMap.DeleteBehavior === 'DoNothing') {
+            logger?.warning(
+                entityMap.ExternalObjectName ?? entityMap.ID,
+                'ORPHANS_POLICY_SKIPPED',
+                `${orphans.length} record(s) exist in MJ but were not returned by the external system on this ` +
+                `full sync. This map's DeleteBehavior is 'DoNothing', so none were touched.`,
+                { orphanCount: orphans.length },
+            );
+            return;
+        }
+
         console.log(`[IntegrationEngine] Orphan detection for ${entityMap.ExternalObjectName}: ${orphans.length} records in MJ not found in external system`);
         // Surface delete-detection in the structured stream (previously console-only). The orphan
         // COUNT is already in the run counts via RecordsDeleted, but a dedicated warning makes a
@@ -3483,7 +3500,9 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         logger?.warning(
             entityMap.ExternalObjectName ?? entityMap.ID,
             'ORPHANS_DETECTED',
-            `${orphans.length} record(s) exist in MJ but were not returned by the external system on this full sync — they will be archived/deleted (delete-detection). A large or unexpected count can indicate an incomplete upstream fetch, so review before trusting the deletions.`,
+            `${orphans.length} record(s) exist in MJ but were not returned by the external system on this full sync — ` +
+            `they will be ${entityMap.DeleteBehavior === 'SoftDelete' ? 'archived (SoftDelete)' : 'deleted'} and their record-map rows pruned (delete-detection). ` +
+            `A large or unexpected count can indicate an incomplete upstream fetch, so review before trusting the deletions.`,
             { orphanCount: orphans.length },
         );
 
@@ -3497,11 +3516,39 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 const loaded = await entity.InnerLoad(this.BuildEntityPrimaryKey(orphan.EntityRecordID, pkFields));
                 if (!loaded) {
                     console.log(`[IntegrationEngine] Orphan ${orphan.EntityRecordID} already deleted from MJ`);
+                    // The map row outlived its record. Nothing anywhere else deletes record-map
+                    // rows, so without this the same "orphan" is re-detected on EVERY subsequent
+                    // full sync and ORPHANS_DETECTED becomes a cumulative counter of history
+                    // rather than a signal about THIS run — observed live as a count that only
+                    // ever grew, sync after sync.
+                    await this.DeleteRecordMapRow(orphan.ID, contextUser);
+                    continue;
+                }
+                if (entityMap.DeleteBehavior === 'SoftDelete') {
+                    // Same archive shape as DeleteRecord's SoftDelete branch: the row stays,
+                    // marked Archived/tombstoned. The MAP row goes either way — the mapping's
+                    // job is done, and keeping it would re-detect this orphan forever.
+                    const fields = entity.Fields ?? [];
+                    const hasField = (n: string) => fields.some(f => f.Name === n);
+                    if (hasField('__mj_integration_SyncStatus')) entity.Set('__mj_integration_SyncStatus', 'Archived');
+                    if (hasField('__mj_integration_LastSyncedAt')) entity.Set('__mj_integration_LastSyncedAt', new Date().toISOString());
+                    if (hasField('__mj_integration_IsTombstoned')) entity.Set('__mj_integration_IsTombstoned', true);
+                    if (hasField('__mj_integration_DeletedDetectedAt')) entity.Set('__mj_integration_DeletedDetectedAt', new Date().toISOString());
+                    const archived = await entity.Save();
+                    if (archived) {
+                        result.RecordsDeleted++;
+                        await this.DeleteRecordMapRow(orphan.ID, contextUser);
+                        console.log(`[IntegrationEngine] Archived orphan ${entityMap.Entity} ${orphan.EntityRecordID} (external ${orphan.ExternalSystemRecordID} no longer exists)`);
+                    } else {
+                        const reason = entity.LatestResult?.CompleteMessage ?? 'unknown reason';
+                        console.warn(`[IntegrationEngine] Orphan archive blocked for ${entityMap.Entity} ${orphan.EntityRecordID} — ${reason}`);
+                    }
                     continue;
                 }
                 const deleted = await entity.Delete();
                 if (deleted) {
                     result.RecordsDeleted++;
+                    await this.DeleteRecordMapRow(orphan.ID, contextUser);
                     console.log(`[IntegrationEngine] Deleted orphan ${entityMap.Entity} ${orphan.EntityRecordID} (external ${orphan.ExternalSystemRecordID} no longer exists)`);
                 } else {
                     const reason = entity.LatestResult?.CompleteMessage ?? 'unknown reason';
@@ -3511,6 +3558,27 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 const msg = err instanceof Error ? err.message : String(err);
                 console.warn(`[IntegrationEngine] Orphan delete failed for ${entityMap.Entity} ${orphan.EntityRecordID}: ${msg}`);
             }
+        }
+    }
+
+    /**
+     * Removes one 'MJ: Company Integration Record Maps' row after delete-detection has handled
+     * its orphan (deleted, archived, or found already gone). A failure here is logged and
+     * swallowed: the orphan itself was handled, and the worst consequence of a surviving map
+     * row is one redundant re-detection on the next full sync.
+     */
+    private async DeleteRecordMapRow(mapRowID: string, contextUser: UserInfo): Promise<void> {
+        try {
+            const md = this.ProviderToUse;
+            const mapRow = await md.GetEntityObject('MJ: Company Integration Record Maps', contextUser);
+            const loaded = await mapRow.InnerLoad(CompositeKey.FromID(mapRowID));
+            if (!loaded) return;
+            const ok = await mapRow.Delete();
+            if (!ok) {
+                console.warn(`[IntegrationEngine] Record-map prune blocked for ${mapRowID} — ${mapRow.LatestResult?.CompleteMessage ?? 'unknown reason'}`);
+            }
+        } catch (err) {
+            console.warn(`[IntegrationEngine] Record-map prune failed for ${mapRowID}: ${err instanceof Error ? err.message : String(err)}`);
         }
     }
 
@@ -4901,7 +4969,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         companyIntegrationID: string,
         entityID: string,
         contextUser: UserInfo
-    ): Promise<{ Rows: Array<{ EntityRecordID: string; ExternalSystemRecordID: string }>; Complete: boolean; Error?: string }> {
+    ): Promise<{ Rows: Array<{ ID: string; EntityRecordID: string; ExternalSystemRecordID: string }>; Complete: boolean; Error?: string }> {
         const PAGE_SIZE = IntegrationEngine.RecordMapPageSize;
         // Backstop only: at the default page size this is 50M mappings for one
         // (CompanyIntegration, Entity) pair. It exists so a provider that ignores the seek key
@@ -4910,7 +4978,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         const filter = `CompanyIntegrationID='${companyIntegrationID}' AND EntityID='${entityID}'`;
 
         const rv = new RunView();
-        const rows: Array<{ EntityRecordID: string; ExternalSystemRecordID: string }> = [];
+        const rows: Array<{ ID: string; EntityRecordID: string; ExternalSystemRecordID: string }> = [];
         let afterID: string | undefined;
 
         for (let pageNo = 0; pageNo < MAX_PAGES; pageNo++) {

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -55,6 +55,7 @@ import { AdaptiveConcurrencyController, RunAdaptive } from './AdaptiveConcurrenc
 import { mostRecentWinner, type RecencyWinner } from './ConflictRecency.js';
 import { IntegrationProgressEmitter } from '@memberjunction/integration-progress-artifacts';
 import type { BaseIntegrationConnector, FetchContext, FetchBatchResult } from './BaseIntegrationConnector.js';
+import { CollapseDuplicateIdentities } from './BatchIdentity.js';
 
 /** Default batch size for fetching records from external systems */
 const DEFAULT_BATCH_SIZE = 200;
@@ -2448,8 +2449,27 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 }
             }
 
+            // Within-batch identity, enforced before mapping: two records sharing an ExternalID are
+            // two observations of ONE source record. The write path cannot catch this — it decides
+            // insert-vs-update against the DATABASE, where a first-time identity is absent for both
+            // copies, so both insert and the pair re-inserts every sync. The fingerprint guard above
+            // only sees a batch repeated in FULL. Never silent: a connector emitting duplicate
+            // identities is a defect worth fixing at its source.
+            const identity = CollapseDuplicateIdentities(batch.Records);
+            if (identity.Collapsed > 0) {
+                logger?.warning(
+                    entityMap.ExternalObjectName ?? 'sync',
+                    'DUPLICATE_IDENTITIES_IN_BATCH',
+                    `${entityMap.ExternalObjectName}: ${identity.Collapsed} record(s) repeated an ExternalID already `
+                    + `present in the same batch and were collapsed (last occurrence kept). Two records sharing an `
+                    + `identity are one source record observed twice; writing both would insert duplicate rows that `
+                    + `no later sync could reconcile. Sample: ${identity.SampleIDs.join(', ')}`,
+                    { object: entityMap.ExternalObjectName, collapsed: identity.Collapsed, sample: identity.SampleIDs }
+                );
+            }
+
             const mapped = this.fieldMappingEngine.Apply(
-                batch.Records, fieldMaps, entityMap.Entity
+                identity.Records, fieldMaps, entityMap.Entity
             );
             // Custom-key stats: aggregate unmapped keys for EVERY mapped record here —
             // before any skip decision — so candidates + sizing stats exist even when the

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -58,6 +58,7 @@ import { AdaptiveConcurrencyController, RunAdaptive } from './AdaptiveConcurrenc
 import { mostRecentWinner, type RecencyWinner } from './ConflictRecency.js';
 import { IntegrationProgressEmitter } from '@memberjunction/integration-progress-artifacts';
 import type { BaseIntegrationConnector, FetchContext, FetchBatchResult } from './BaseIntegrationConnector.js';
+import { CollapseDuplicateIdentities } from './BatchIdentity.js';
 
 /** Default batch size for fetching records from external systems */
 const DEFAULT_BATCH_SIZE = 200;
@@ -2486,8 +2487,27 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 }
             }
 
+            // Within-batch identity, enforced before mapping: two records sharing an ExternalID are
+            // two observations of ONE source record. The write path cannot catch this — it decides
+            // insert-vs-update against the DATABASE, where a first-time identity is absent for both
+            // copies, so both insert and the pair re-inserts every sync. The fingerprint guard above
+            // only sees a batch repeated in FULL. Never silent: a connector emitting duplicate
+            // identities is a defect worth fixing at its source.
+            const identity = CollapseDuplicateIdentities(batch.Records);
+            if (identity.Collapsed > 0) {
+                logger?.warning(
+                    entityMap.ExternalObjectName ?? 'sync',
+                    'DUPLICATE_IDENTITIES_IN_BATCH',
+                    `${entityMap.ExternalObjectName}: ${identity.Collapsed} record(s) repeated an ExternalID already `
+                    + `present in the same batch and were collapsed (last occurrence kept). Two records sharing an `
+                    + `identity are one source record observed twice; writing both would insert duplicate rows that `
+                    + `no later sync could reconcile. Sample: ${identity.SampleIDs.join(', ')}`,
+                    { object: entityMap.ExternalObjectName, collapsed: identity.Collapsed, sample: identity.SampleIDs }
+                );
+            }
+
             const mapped = this.fieldMappingEngine.Apply(
-                batch.Records, fieldMaps, entityMap.Entity, excludedSourceNames
+                identity.Records, fieldMaps, entityMap.Entity, excludedSourceNames
             );
             // Custom-key stats: aggregate unmapped keys for EVERY mapped record here —
             // before any skip decision — so candidates + sizing stats exist even when the

--- a/packages/Integration/engine/src/__tests__/BatchIdentity.test.ts
+++ b/packages/Integration/engine/src/__tests__/BatchIdentity.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { CollapseDuplicateIdentities } from '../BatchIdentity.js';
+
+const rec = (id: string, tag?: string) => ({ ExternalID: id, Fields: { tag } });
+
+describe('CollapseDuplicateIdentities', () => {
+    it('returns the ORIGINAL array when every identity is unique (no allocation)', () => {
+        const batch = [rec('a'), rec('b'), rec('c')];
+        const out = CollapseDuplicateIdentities(batch);
+        expect(out.Records).toBe(batch);
+        expect(out.Collapsed).toBe(0);
+    });
+
+    it('collapses a repeated identity, keeping the LAST occurrence (upsert semantics)', () => {
+        const out = CollapseDuplicateIdentities([rec('a', 'first'), rec('b'), rec('a', 'last')]);
+        expect(out.Records.map(r => r.ExternalID)).toEqual(['b', 'a']);
+        expect(out.Records.find(r => r.ExternalID === 'a')!.Fields.tag).toBe('last');
+        expect(out.Collapsed).toBe(1);
+    });
+
+    it('counts every excess copy, not every repeated identity', () => {
+        const out = CollapseDuplicateIdentities([rec('a'), rec('a'), rec('a'), rec('b'), rec('b')]);
+        expect(out.Collapsed).toBe(3);
+        expect(out.Records).toHaveLength(2);
+    });
+
+    it('samples repeated identities for reporting, capped', () => {
+        const batch = Array.from({ length: 20 }, (_, i) => rec(`id-${i}`)).concat(
+            Array.from({ length: 20 }, (_, i) => rec(`id-${i}`)));
+        const out = CollapseDuplicateIdentities(batch);
+        expect(out.Collapsed).toBe(20);
+        expect(out.SampleIDs).toHaveLength(5);
+    });
+
+    it('passes identity-less records through untouched — collapsing them would merge unrelated rows', () => {
+        const out = CollapseDuplicateIdentities([
+            { ExternalID: '' } as { ExternalID: string },
+            { ExternalID: '' } as { ExternalID: string },
+            rec('a'), rec('a'),
+        ]);
+        expect(out.Records).toHaveLength(3);
+        expect(out.Collapsed).toBe(1);
+    });
+
+    it('handles trivial batches', () => {
+        expect(CollapseDuplicateIdentities([]).Collapsed).toBe(0);
+        expect(CollapseDuplicateIdentities([rec('a')]).Collapsed).toBe(0);
+    });
+});

--- a/packages/Integration/engine/src/__tests__/IntegrationEngine.orphan-sweep.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntegrationEngine.orphan-sweep.test.ts
@@ -38,6 +38,23 @@ function mockEntity(overrides: Partial<MockEntity> = {}): MockEntity {
     };
 }
 
+/**
+ * The private members this suite drives. Named explicitly rather than reached for with `as any`:
+ * the cast still has to happen (they are private), but writing the signature down means a change
+ * to either member breaks this file at compile time instead of at run time.
+ */
+type OrphanSweepInternals = {
+    LoadAllRecordMaps: unknown;
+    DeleteOrphanedRecords: (
+        companyIntegration: { ID: string },
+        entityMap: { ID: string; Entity: string; ExternalObjectName: string; DeleteBehavior: string; EntityID: string },
+        fetchedExternalIDs: ReadonlySet<string>,
+        result: { RecordsDeleted: number },
+        contextUser: { ID: string },
+        logger: { warning: (object: string, code: string, message: string, data?: unknown) => void },
+    ) => Promise<unknown>;
+};
+
 function harness(opts: {
     deleteBehavior: 'HardDelete' | 'SoftDelete' | 'DoNothing';
     mapRows: Array<{ ID: string; EntityRecordID: string; ExternalSystemRecordID: string }>;
@@ -59,14 +76,13 @@ function harness(opts: {
         }),
     };
     Object.defineProperty(engine, 'ProviderToUse', { get: () => md });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (engine as any).LoadAllRecordMaps = vi.fn().mockResolvedValue({ Rows: opts.mapRows, Complete: true });
+    const internals = engine as unknown as OrphanSweepInternals;
+    internals.LoadAllRecordMaps = vi.fn().mockResolvedValue({ Rows: opts.mapRows, Complete: true });
     const warnings: Array<{ code: string; data?: unknown }> = [];
     const logger = { warning: (_o: string, code: string, _m: string, data?: unknown) => warnings.push({ code, data }) };
     const result = { RecordsDeleted: 0 };
     const run = async () =>
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (engine as any).DeleteOrphanedRecords(
+        internals.DeleteOrphanedRecords(
             { ID: 'ci-1' },
             { ID: 'em-1', Entity: 'Widgets', ExternalObjectName: 'Widget', DeleteBehavior: opts.deleteBehavior, EntityID: 'e-1' },
             new Set(opts.fetched),

--- a/packages/Integration/engine/src/__tests__/IntegrationEngine.orphan-sweep.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntegrationEngine.orphan-sweep.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IntegrationEngine } from '../IntegrationEngine.js';
+
+/**
+ * Delete-detection (the full-sync orphan sweep) is a DELETE PATH, and must answer to the same
+ * `DeleteBehavior` policy as every other delete. It used to call `entity.Delete()`
+ * unconditionally — its own warning text promised "archived/deleted" while the code only ever
+ * deleted — and it never pruned the record-map row, so every stale mapping was re-detected as an
+ * orphan on EVERY subsequent full sync: ORPHANS_DETECTED became a cumulative counter of history
+ * (observed live as a count that only grew, sync after sync) rather than a signal about the run.
+ *
+ * The sweep's collaborators are stubbed at its own seams (LoadAllRecordMaps, ProviderToUse) so
+ * the tests exercise exactly the policy branching + pruning and nothing else.
+ */
+
+type MockEntity = {
+    InnerLoad: ReturnType<typeof vi.fn>;
+    Delete: ReturnType<typeof vi.fn>;
+    Save: ReturnType<typeof vi.fn>;
+    Set: ReturnType<typeof vi.fn>;
+    Fields: Array<{ Name: string }>;
+    LatestResult?: { CompleteMessage?: string };
+};
+
+function mockEntity(overrides: Partial<MockEntity> = {}): MockEntity {
+    return {
+        InnerLoad: vi.fn().mockResolvedValue(true),
+        Delete: vi.fn().mockResolvedValue(true),
+        Save: vi.fn().mockResolvedValue(true),
+        Set: vi.fn(),
+        Fields: [
+            { Name: '__mj_integration_SyncStatus' },
+            { Name: '__mj_integration_LastSyncedAt' },
+            { Name: '__mj_integration_IsTombstoned' },
+            { Name: '__mj_integration_DeletedDetectedAt' },
+        ],
+        ...overrides,
+    };
+}
+
+function harness(opts: {
+    deleteBehavior: 'HardDelete' | 'SoftDelete' | 'DoNothing';
+    mapRows: Array<{ ID: string; EntityRecordID: string; ExternalSystemRecordID: string }>;
+    fetched: string[];
+    dataEntity?: MockEntity;
+}) {
+    const engine = Object.create(IntegrationEngine.prototype) as IntegrationEngine;
+    const dataEntity = opts.dataEntity ?? mockEntity();
+    const mapEntities: MockEntity[] = [];
+    const md = {
+        EntityByName: vi.fn().mockReturnValue({ PrimaryKeys: [{ Name: 'ID' }] }),
+        GetEntityObject: vi.fn(async (name: string) => {
+            if (name === 'MJ: Company Integration Record Maps') {
+                const m = mockEntity();
+                mapEntities.push(m);
+                return m;
+            }
+            return dataEntity;
+        }),
+    };
+    Object.defineProperty(engine, 'ProviderToUse', { get: () => md });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (engine as any).LoadAllRecordMaps = vi.fn().mockResolvedValue({ Rows: opts.mapRows, Complete: true });
+    const warnings: Array<{ code: string; data?: unknown }> = [];
+    const logger = { warning: (_o: string, code: string, _m: string, data?: unknown) => warnings.push({ code, data }) };
+    const result = { RecordsDeleted: 0 };
+    const run = async () =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (engine as any).DeleteOrphanedRecords(
+            { ID: 'ci-1' },
+            { ID: 'em-1', Entity: 'Widgets', ExternalObjectName: 'Widget', DeleteBehavior: opts.deleteBehavior, EntityID: 'e-1' },
+            new Set(opts.fetched),
+            result, { ID: 'u-1' }, logger,
+        );
+    return { run, md, dataEntity, mapEntities, warnings, result };
+}
+
+const rows = [
+    { ID: 'map-1', EntityRecordID: 'rec-1', ExternalSystemRecordID: 'ext-1' },
+    { ID: 'map-2', EntityRecordID: 'rec-2', ExternalSystemRecordID: 'ext-2' },
+];
+
+describe('IntegrationEngine — the orphan sweep answers to DeleteBehavior', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('HardDelete: deletes the record AND prunes its map row', async () => {
+        const h = harness({ deleteBehavior: 'HardDelete', mapRows: rows, fetched: ['ext-2'] });
+        await h.run();
+        expect(h.dataEntity.Delete).toHaveBeenCalledTimes(1);
+        expect(h.result.RecordsDeleted).toBe(1);
+        // the map row for ext-1 was pruned — one map-entity was created and deleted
+        expect(h.mapEntities).toHaveLength(1);
+        expect(h.mapEntities[0].Delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('SoftDelete: ARCHIVES (Save with tombstone fields), never Delete — and still prunes the map row', async () => {
+        const h = harness({ deleteBehavior: 'SoftDelete', mapRows: rows, fetched: ['ext-2'] });
+        await h.run();
+        expect(h.dataEntity.Delete).not.toHaveBeenCalled();
+        expect(h.dataEntity.Save).toHaveBeenCalledTimes(1);
+        expect(h.dataEntity.Set).toHaveBeenCalledWith('__mj_integration_SyncStatus', 'Archived');
+        expect(h.dataEntity.Set).toHaveBeenCalledWith('__mj_integration_IsTombstoned', true);
+        expect(h.result.RecordsDeleted).toBe(1);
+        expect(h.mapEntities[0].Delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('DoNothing: touches NOTHING and says so once, not once per orphan', async () => {
+        const h = harness({ deleteBehavior: 'DoNothing', mapRows: rows, fetched: [] });
+        await h.run();
+        expect(h.dataEntity.Delete).not.toHaveBeenCalled();
+        expect(h.dataEntity.Save).not.toHaveBeenCalled();
+        expect(h.mapEntities).toHaveLength(0);
+        expect(h.result.RecordsDeleted).toBe(0);
+        expect(h.warnings.map(w => w.code)).toContain('ORPHANS_POLICY_SKIPPED');
+        expect(h.warnings.filter(w => w.code === 'ORPHANS_POLICY_SKIPPED')).toHaveLength(1);
+    });
+
+    it('a record already gone from MJ still gets its stale map row pruned — the re-detection loop breaker', async () => {
+        // This is the accumulating-ORPHANS_DETECTED defect: nothing anywhere deleted record-map
+        // rows, so an already-deleted record was re-reported as an orphan on every full sync.
+        const gone = mockEntity({ InnerLoad: vi.fn().mockResolvedValue(false) });
+        const h = harness({ deleteBehavior: 'HardDelete', mapRows: rows, fetched: ['ext-2'], dataEntity: gone });
+        await h.run();
+        expect(gone.Delete).not.toHaveBeenCalled();
+        expect(h.mapEntities).toHaveLength(1);
+        expect(h.mapEntities[0].Delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('a BLOCKED delete keeps its map row — the orphan was NOT handled', async () => {
+        const blocked = mockEntity({ Delete: vi.fn().mockResolvedValue(false) });
+        const h = harness({ deleteBehavior: 'HardDelete', mapRows: rows, fetched: ['ext-2'], dataEntity: blocked });
+        await h.run();
+        expect(h.result.RecordsDeleted).toBe(0);
+        expect(h.mapEntities).toHaveLength(0);
+    });
+});

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -123,12 +123,14 @@ export type { PersistSchemaOptions, PersistSchemaResult } from './IntegrationSch
 
 // ── Restored module exports dropped by the origin/next index.ts merge (union) ──
 export { computeContentHash, CONTENT_HASH_COLUMN } from './ContentHash.js';
+export { CollapseDuplicateIdentities } from './BatchIdentity.js';
 export { CUSTOM_OVERFLOW_COLUMN, computeUnmappedFields, hasUnmappedFields, foldCustomKeyStats, CUSTOM_KEY_SAMPLE_CAP } from './CustomOverflow.js';
 export { SYNC_DIRECTIVE_CONFIG_KEY, ReadFieldSyncDirective, WriteFieldSyncDirective, ComputeExcludedSourceNames, StripExcludedFields } from './SyncDirectives.js';
 export type { FieldSyncDirective, FieldWithConfiguration } from './SyncDirectives.js';
 export { FindUnbindableFieldMaps, DescribeUnbindableFieldMaps } from './FieldMapValidation.js';
 export type { ValidatableFieldMap, UnbindableFieldMap } from './FieldMapValidation.js';
 export type { CustomKeyAccumulator } from './CustomOverflow.js';
+export type { HasExternalID, BatchIdentityResult } from './BatchIdentity.js';
 export { planPromotions, planColumnReclamations, inferColumnTypeFromSamples, inferColumnTypeFromStats, buildOverflowStats, sanitizeColumnName } from './CustomColumnPromotion.js';
 export { discoverFromStream, pickPrimaryKeyFromStats } from './StreamingDiscovery.js';
 export type { StreamDiscoveryOptions, DiscoveredColumnStat, StreamDiscoveryResult, PkPickOptions, PkStatVerdict } from './StreamingDiscovery.js';

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -123,8 +123,10 @@ export type { PersistSchemaOptions, PersistSchemaResult } from './IntegrationSch
 
 // ── Restored module exports dropped by the origin/next index.ts merge (union) ──
 export { computeContentHash, CONTENT_HASH_COLUMN } from './ContentHash.js';
+export { CollapseDuplicateIdentities } from './BatchIdentity.js';
 export { CUSTOM_OVERFLOW_COLUMN, computeUnmappedFields, hasUnmappedFields, foldCustomKeyStats, CUSTOM_KEY_SAMPLE_CAP } from './CustomOverflow.js';
 export type { CustomKeyAccumulator } from './CustomOverflow.js';
+export type { HasExternalID, BatchIdentityResult } from './BatchIdentity.js';
 export { planPromotions, planColumnReclamations, inferColumnTypeFromSamples, inferColumnTypeFromStats, buildOverflowStats, sanitizeColumnName } from './CustomColumnPromotion.js';
 export { discoverFromStream, pickPrimaryKeyFromStats } from './StreamingDiscovery.js';
 export type { StreamDiscoveryOptions, DiscoveredColumnStat, StreamDiscoveryResult, PkPickOptions, PkStatVerdict } from './StreamingDiscovery.js';


### PR DESCRIPTION
A connector can emit two records with the same `ExternalID` in one batch, and the engine writes **two rows**. `ExternalID` is the identity the record map keys on, so those are two observations of one source record — there is no reading under which they are two rows.

The write path cannot catch it: it decides insert-vs-update by asking whether the identity exists in the **database**, and for a first-time record neither copy does, so both insert. Worse, it repeats — the pair re-inserts on every later sync, and afterwards no run can reconcile them because both rows map to the same `ExternalID`. The existing fingerprint check nearby only detects a batch repeated *in full* (the infinite-loop guard); it cannot see duplicates inside a single batch.

## Evidence

Observed in the field. One object carried a substantial excess of key-duplicated rows, and the shape of the duplicates is what identifies the cause:

- every duplicate group was **byte-identical on every captured column** — so no field distinguishes the rows, and the declared key was not too narrow;
- every duplicate group was **written inside the same second** — so the repeats arrived inside one batch, not via an at-least-once re-read, and therefore nothing a cross-batch identity check could ever catch.

## Change

`CollapseDuplicateIdentities` collapses duplicate identities per batch, keeping the **last** occurrence: upsert semantics, since the later entry is the more recent observation of that record's state, exactly what a single upsert would have left had the copies arrived in separate batches.

Deliberate choices:
- **Never silent** — emits `DUPLICATE_IDENTITIES_IN_BATCH` with a capped sample. A connector emitting duplicate identities is a defect worth fixing at its source, and the warning is how anyone finds out.
- **Identity-less records pass through** — collapsing records with an empty `ExternalID` would merge unrelated rows; that is a separate defect with a separate guard.
- **Zero-cost on the normal path** — a batch whose identities are already unique returns the original array reference.

## Verification

`npx tsc --noEmit` clean. Engine suite: **706 tests passed** (47 files), including 6 new covering last-wins, excess-copy counting, sample capping, identity-less pass-through, and trivial batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

