### PR TITLE
release-lines: record line 5.51's candidate step on main

### DIFF
--- a/release-lines.json
+++ b/release-lines.json
@@ -14,5 +14,12 @@
       }
     }
   },
-  "lines": {}
+  "lines": {
+    "5.51": {
+      "status": "candidate",
+      "candidateDate": "2026-07-31",
+      "supportEnds": "2027-02-14",
+      "upgradeImpact": "none"
+    }
+  }
 }


### PR DESCRIPTION
**1 of 2.** Brings line 5.51's record to `main`, which still reads `"lines": {}` from 2026-07-28.

## Why this is needed

Line 5.51 was cut as a candidate on **2026-07-31** and certified on **2026-08-14**, but neither step was ever recorded in `release-lines.json` on `main`. The manifest went straight from no lines to `certified` in a single commit on `next` (`2f82c81693`), and that commit has never reached `main`.

**The certification itself completed and is live — nothing is wrong with it:**

| | |
|---|---|
| npm `latest` | **5.51.1** across all packages |
| git tag | `v5.51.0` exists |
| scorecard | `certifications/5.51.0.md`, signed — *"release created, comms sent, signed"* |

Only the record is missing.

## Why two PRs

`ci/validate-release-lines.mjs` requires a line to appear as `candidate` before it can be `certified` ([line 251](ci/validate-release-lines.mjs#L251)), and holds `certifiedBuild` / `candidateDate` / `certifiedDate` immutable once set. So the honest fix is to record the two steps in order rather than back-date a single entry.

That rule is doing its job here: operation 2's manifest write was skipped and only operation 4 wrote.

It surfaced now rather than sooner because **v6.1.0-edge.2 merged on 2026-08-12** — two days before the certify commit — so the v6.1.0-edge.3 release PR (#3989) is the first into `main` to carry it. Without this, every future release PR fails `validate-pr` identically.

## This PR

```json
"5.51": {
  "status": "candidate",
  "candidateDate": "2026-07-31",
  "supportEnds": "2027-02-14",
  "upgradeImpact": "none"
}
```

Every value is the real one, taken from the certified entry on `next`. `certifiedBuild` and `certifiedDate` are deliberately absent — the validator holds them immutable once set, so they belong to the flip in PR 2.

Verified locally: `node ci/validate-release-lines.mjs --base origin/main --mode pr` → **OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)