### PR TITLE
fix(changeset): unblock the v6.1.0-edge.3 publish — two unplannable changeset entries

### DIFF
--- a/.changeset/generic-graph-view-and-core-form-modernization.md
+++ b/.changeset/generic-graph-view-and-core-form-modernization.md
@@ -1,7 +1,6 @@
 ---
 "@memberjunction/ng-graph-view": minor
 "@memberjunction/ng-core-entity-forms": minor
-"mj_explorer": patch
 ---
 
 Add reusable generic `@memberjunction/ng-graph-view` Angular component with physics force relaxation, circular layouts, zoom/pan controls, search filtering, and cancelable Before/After event suite. Add modern hero headers and 4-card overview mini-dashboards for AIAgentCategories, Conversations, Employees, Companies, and Users in `@memberjunction/ng-core-entity-forms`.

--- a/.changeset/recursive-fks-and-hierarchy-traversal.md
+++ b/.changeset/recursive-fks-and-hierarchy-traversal.md
@@ -3,7 +3,6 @@
 "@memberjunction/core": minor
 "@memberjunction/core-entities": minor
 "@memberjunction/server": patch
-"@memberjunction/api": patch
 "@memberjunction/ng-core-entity-forms": patch
 ---
 


### PR DESCRIPTION
The **v6.1.0-edge.3 publish failed in `changeset version`**, before building or publishing anything. **Nothing reached npm** — `latest` is still `5.51.1`, `edge` is still `6.1.0-edge.2`, and no `6.1.0-edge.3` version exists on the registry.

Two changesets each name a package changesets refuses to plan. It reports only the **first**, so this looked like one problem until the second surfaced on the next attempt:

| Changeset | Entry | Error |
|---|---|---|
| `generic-graph-view-and-core-form-modernization` | `"mj_explorer": patch` | `Found mixed changeset … Found ignored packages: mj_explorer` — mixed ignored + not-ignored is not allowed |
| `recursive-fks-and-hierarchy-traversal` | `"@memberjunction/api": patch` | `Found changeset … for package @memberjunction/api which is not in the workspace` |

## Both entries were inert even when they "worked"

- `mj_explorer` matches the `mj_*` ignore pattern in `.changeset/config.json` — it was never going to be versioned or published.
- `@memberjunction/api` **does not exist**. MJAPI's package name is `mj_api`, which is *also* ignored.

So the fix is to **delete** the two lines, not correct them: naming MJAPI properly would just turn the second error into the first. Diff is exactly two deletions.

## Neither is new, and no PR check could have caught them

Both have been on `next` and rode into `main` with the release. The publish path is the only thing that runs `changeset version`, so nothing on a PR ever exercised it — **every** release would have failed here.

## Verified by running it, not by reasoning about it

```
npx changeset version   →  exit 0,  6.1.0-edge.3 across the workspace
```

That version also satisfies `publish.yml`'s grammar guard (pre mode requires an `-edge.` suffix). All **196** changesets were then swept for both failure classes — these two are the only occurrences, so this is not whack-a-mole.

## On merge

This pushes to `main`, which triggers `publish.yml` and completes the v6.1.0-edge.3 release. Watch for `latest` staying at **5.51.1** while `edge` moves to `6.1.0-edge.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)