### PR TITLE
fix(codegen): a failed BEFORE/AFTER command must say what it said

### DIFF
--- a/.changeset/rsu-codegen-command-failure-detail.md
+++ b/.changeset/rsu-codegen-command-failure-detail.md
@@ -1,0 +1,26 @@
+---
+'@memberjunction/codegen-lib': patch
+'@memberjunction/schema-engine': patch
+'@memberjunction/server': patch
+---
+
+Report WHY an in-process CodeGen run failed instead of only that it did
+
+A CodeGen run's success is decided entirely by its BEFORE/AFTER command failures
+(`executeCodeGenPipeline` returns `commandFailures.length === 0`), and until now the text
+explaining those failures was destroyed twice on the way out:
+
+- `runCommand` rejected a non-zero exit with `Process exited with code N` and dropped the
+  command's own stdout/stderr, so `recordCommandFailures` had nothing but the exit code to
+  record. A build that failed because a source tree was missing and one that failed on a real
+  compile error produced the same string.
+- `RunInProcess` returns a bare boolean, so even the recorded failures never reached the
+  in-process caller — and that caller (RuntimeSchemaManager, running inside a live server) has
+  no console for a human to read the pipeline output from. Its RunCodeGen step could only throw
+  `In-process CodeGen failed`.
+
+Now the rejection carries a bounded tail of the command's output (40 lines / 4000 chars),
+`RunCodeGenBase` exposes `CommandFailures` and logs them on an in-process failure, and RSU's
+`RSUError('CODEGEN', …)` names the command and its message. `IRSUCodeGenRunner.LastRunFailures`
+is optional, so a runner that cannot report detail degrades to the previous message rather than
+claiming a cause it does not have.

--- a/packages/CodeGenLib/src/Misc/runCommand.ts
+++ b/packages/CodeGenLib/src/Misc/runCommand.ts
@@ -11,6 +11,27 @@ export type CommandExecutionResult = {
   elapsedTime: number;
 }
 
+/** Cap on how much of a failed command's output travels with the rejection. */
+const FAILED_COMMAND_TAIL_LINES = 40;
+const FAILED_COMMAND_TAIL_CHARS = 4000;
+
+/**
+ * Render the tail of a failed command's combined stdout/stderr for inclusion in an Error
+ * message. Bounded on both lines and characters, because a failing build can emit megabytes
+ * and this text ends up in logs and API error payloads.
+ */
+function formatCommandTail(output: string): string {
+  const trimmed = (output ?? '').trim();
+  if (!trimmed) {
+    return '';
+  }
+  let tail = trimmed.split('\n').slice(-FAILED_COMMAND_TAIL_LINES).join('\n');
+  if (tail.length > FAILED_COMMAND_TAIL_CHARS) {
+    tail = '...' + tail.slice(-FAILED_COMMAND_TAIL_CHARS);
+  }
+  return `\n${tail}`;
+}
+
 /**
  * Base class that handles the process of running commands which can be done executed from any other area of the system, typically done by the main runMemberJunctionCodeGen process
  */
@@ -101,7 +122,13 @@ export class RunCommandsBase {
                       elapsedTime: elapsedTime
                     });
           } else {
-            reject(new Error(`Process exited with code ${code}`));
+            // Carry the command's own output into the rejection. Without it the only record of
+            // the failure is the exit code, and callers that report command failures (see
+            // RunCommandsBase.runCommands -> RunCodeGenBase.recordCommandFailures) had nothing
+            // to report but "Process exited with code 1" — so a build that fails on a host is
+            // indistinguishable from one that fails on a compile error, and the actual
+            // npm/tsc/webpack message is lost at the moment it is produced.
+            reject(new Error(`Process exited with code ${code}${formatCommandTail(output)}`));
           }
         });
       });

--- a/packages/CodeGenLib/src/__tests__/runCommand.test.ts
+++ b/packages/CodeGenLib/src/__tests__/runCommand.test.ts
@@ -121,3 +121,56 @@ describe('RunCommandsBase', () => {
         });
     });
 });
+
+// The reason this block exists: a failing BEFORE/AFTER command used to reject with nothing but
+// its exit code, so `npm run build` failing on a deploy host and failing on a compile error were
+// the same string. CodeGen decides a whole run's success from these failures, and the in-process
+// (RSU) caller has no console of its own — so if the text is not on the Error, it is gone.
+describe('a failed command carries its own output', () => {
+    const runner = new RunCommandsBase();
+
+    it('puts the command output on the rejection, not just the exit code', async () => {
+        await expect(
+            runner.runCommand({
+                command: 'sh',
+                args: ['-c', "'echo TS2304-cannot-find-name 1>&2; exit 3'"],
+                workingDirectory: '/tmp',
+                when: 'after',
+                timeout: 20000,
+            })
+        ).rejects.toThrow(/Process exited with code 3[\s\S]*TS2304-cannot-find-name/);
+    });
+
+    it('hands that text to runCommands as the failed result, index-aligned', async () => {
+        const results = await runner.runCommands([
+            { command: 'sh', args: ['-c', "'echo first-ok'"], workingDirectory: '/tmp', when: 'after', timeout: 20000 },
+            { command: 'sh', args: ['-c', "'echo TS18003-no-inputs 1>&2; exit 2'"], workingDirectory: '/tmp', when: 'after', timeout: 20000 },
+        ]);
+
+        expect(results).toHaveLength(2);
+        expect(results[0].success).toBe(true);
+        expect(results[1].success).toBe(false);
+        // recordCommandFailures reads `error || output` — this is the string an operator sees.
+        expect(results[1].error).toContain('TS18003-no-inputs');
+    });
+
+    it('bounds the output it carries — a failing build can emit megabytes', async () => {
+        const script = "'i=1; while [ $i -le 200 ]; do echo line$i; i=$((i+1)); done; exit 1'";
+        let message = '';
+        try {
+            await runner.runCommand({
+                command: 'sh',
+                args: ['-c', script],
+                workingDirectory: '/tmp',
+                when: 'after',
+                timeout: 20000,
+            });
+        } catch (e) {
+            message = e instanceof Error ? e.message : String(e);
+        }
+
+        expect(message).toContain('line200');   // the tail is what diagnoses a failure
+        expect(message).not.toContain('line159'); // ...and only the tail
+        expect(message.split('\n').length).toBeLessThanOrEqual(42);
+    });
+});

--- a/packages/CodeGenLib/src/runCodeGen.ts
+++ b/packages/CodeGenLib/src/runCodeGen.ts
@@ -56,6 +56,16 @@ export class RunCodeGenBase {
    */
   protected commandFailures: Array<{ context: string; message: string }> = [];
 
+  /**
+   * The BEFORE/AFTER command failures from the most recent run, for callers that get a bare
+   * boolean back from {@link RunInProcess}. `executeCodeGenPipeline` decides the run's success
+   * from exactly this list, so a caller that has only the boolean knows a command failed and
+   * cannot say WHICH — the in-process (RSU) path had no way to report the real npm/tsc message.
+   */
+  public get CommandFailures(): ReadonlyArray<{ context: string; message: string }> {
+    return this.commandFailures;
+  }
+
   /** Record any failed entries from a BEFORE/AFTER command batch, paired by index. */
   protected recordCommandFailures(phase: string, cmds: CommandInfo[], results: CommandExecutionResult[]): void {
     results.forEach((r, i) => {
@@ -110,7 +120,16 @@ export class RunCodeGenBase {
       // are seen as PK-less → entities are skipped ("No primary key found") → 0 rows sync until an MJAPI
       // restart. In-process path only; the CLI Run() keeps load-once. Deterministic — no mtime/TOCTOU.
       ManageMetadataBase.invalidateSoftPKFKConfigCache();
-      return await this.executeCodeGenPipeline(dataSource, skipDatabaseGeneration, skipFileGeneration);
+      const success = await this.executeCodeGenPipeline(dataSource, skipDatabaseGeneration, skipFileGeneration);
+      if (!success && this.commandFailures.length > 0) {
+        // The boolean return cannot carry this, and the in-process host (RSU) is the one caller
+        // that has no console to read the pipeline's own output from. Log it here so the reason
+        // a run failed is in the host log even when the caller only checks the boolean.
+        for (const f of this.commandFailures) {
+          logError(`In-process CodeGen ${f.context} failed: ${f.message}`);
+        }
+      }
+      return success;
     } catch (e) {
       logError('In-process CodeGen failed: ' + e);
       return false;

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -426,6 +426,9 @@ export const serve = async (resolverPaths: Array<string>, app: Application = cre
           const rsuWorkDir = process.env.RSU_WORK_DIR || process.cwd();
           RuntimeSchemaManager.Instance.SetCodeGenRunner({
             RunInProcess: (skipDB) => runObject.RunInProcess(codegenDataSource, skipDB, rsuWorkDir),
+            // Without this, a failed BEFORE/AFTER command reaches RSU as a bare `false` and the
+            // real npm/tsc output never leaves CodeGenLib.
+            LastRunFailures: () => runObject.CommandFailures,
           });
           startupLog.LogIf('verbose', 'RSU in-process CodeGen runner initialized (PostgreSQL).');
 
@@ -570,6 +573,9 @@ export const serve = async (resolverPaths: Array<string>, app: Application = cre
           const rsuWorkDir = process.env.RSU_WORK_DIR || process.cwd();
           RuntimeSchemaManager.Instance.SetCodeGenRunner({
             RunInProcess: (skipDB) => runObject.RunInProcess(codegenDataSource, skipDB, rsuWorkDir),
+            // Without this, a failed BEFORE/AFTER command reaches RSU as a bare `false` and the
+            // real npm/tsc output never leaves CodeGenLib.
+            LastRunFailures: () => runObject.CommandFailures,
           });
           startupLog.LogIf('verbose', 'RSU in-process CodeGen runner initialized.');
 

--- a/packages/SchemaEngine/src/RuntimeSchemaManager.ts
+++ b/packages/SchemaEngine/src/RuntimeSchemaManager.ts
@@ -374,6 +374,13 @@ export interface RSUStatus {
 export interface IRSUCodeGenRunner {
   /** Run CodeGen in-process. Returns true on success. */
   RunInProcess(skipDatabaseGeneration?: boolean): Promise<boolean>;
+  /**
+   * Optional detail for the most recent run's BEFORE/AFTER command failures. CodeGen decides a
+   * run's success from that list, so without this the boolean above is the entire diagnosis: a
+   * failed `npm run build` and a failed migration are the same false, and RSU could only report
+   * "In-process CodeGen failed" while the actual compiler message was discarded.
+   */
+  LastRunFailures?(): ReadonlyArray<{ context?: string; message: string }>;
 }
 
 // ─── Schema Protection ───────────────────────────────────────────────
@@ -1596,13 +1603,27 @@ export class RuntimeSchemaManager extends BaseSingleton<RuntimeSchemaManager> {
    *
    * Override via RSU_CODEGEN_COMMAND env var for custom setups.
    */
+  /**
+   * The reason the last in-process CodeGen run failed, when the injected runner can report one.
+   * Returns '' when it cannot, so the message degrades to the bare legacy text rather than
+   * claiming a cause it does not have.
+   */
+  private codeGenFailureDetail(): string {
+    const failures = this._codeGenRunner?.LastRunFailures?.() ?? [];
+    if (failures.length === 0) {
+      return '';
+    }
+    const detail = failures.map((f) => (f.context ? `${f.context}: ${f.message}` : f.message)).join(' | ');
+    return ` — ${detail}`;
+  }
+
   private async runCodeGen(): Promise<boolean> {
     // Prefer in-process CodeGen runner if injected (no child process, no filesystem deps)
     if (this._codeGenRunner) {
       this.rsuLog('Running CodeGen in-process');
       const success = await this._codeGenRunner.RunInProcess(false);
       if (!success) {
-        throw new RSUError('CODEGEN', 'In-process CodeGen failed');
+        throw new RSUError('CODEGEN', `In-process CodeGen failed${this.codeGenFailureDetail()}`);
       }
       return true;
     }

--- a/packages/SchemaEngine/src/RuntimeSchemaManager.ts
+++ b/packages/SchemaEngine/src/RuntimeSchemaManager.ts
@@ -1592,18 +1592,6 @@ export class RuntimeSchemaManager extends BaseSingleton<RuntimeSchemaManager> {
   }
 
   /**
-   * Run CodeGen programmatically.
-   *
-   * Writes a temporary .mjs script that imports CodeGenLib directly (bypassing
-   * the oclif-based `mj` CLI which has heavy dependencies). The script:
-   *   1. Loads dotenv/config for DB env vars
-   *   2. Bootstraps class registrations via server-bootstrap-lite
-   *   3. Initializes config from mj.config.cjs
-   *   4. Runs full CodeGen pipeline (metadata + SQL + TypeScript generation)
-   *
-   * Override via RSU_CODEGEN_COMMAND env var for custom setups.
-   */
-  /**
    * The reason the last in-process CodeGen run failed, when the injected runner can report one.
    * Returns '' when it cannot, so the message degrades to the bare legacy text rather than
    * claiming a cause it does not have.
@@ -1617,6 +1605,18 @@ export class RuntimeSchemaManager extends BaseSingleton<RuntimeSchemaManager> {
     return ` — ${detail}`;
   }
 
+  /**
+   * Run CodeGen programmatically.
+   *
+   * Writes a temporary .mjs script that imports CodeGenLib directly (bypassing
+   * the oclif-based `mj` CLI which has heavy dependencies). The script:
+   *   1. Loads dotenv/config for DB env vars
+   *   2. Bootstraps class registrations via server-bootstrap-lite
+   *   3. Initializes config from mj.config.cjs
+   *   4. Runs full CodeGen pipeline (metadata + SQL + TypeScript generation)
+   *
+   * Override via RSU_CODEGEN_COMMAND env var for custom setups.
+   */
   private async runCodeGen(): Promise<boolean> {
     // Prefer in-process CodeGen runner if injected (no child process, no filesystem deps)
     if (this._codeGenRunner) {

--- a/packages/SchemaEngine/src/__tests__/RuntimeSchemaManager.test.ts
+++ b/packages/SchemaEngine/src/__tests__/RuntimeSchemaManager.test.ts
@@ -478,3 +478,48 @@ describe('RuntimeSchemaManager', () => {
         });
     });
 });
+
+// ─── CodeGen failure detail ──────────────────────────────────────────
+//
+// RSU's RunCodeGen step used to throw RSUError('CODEGEN', 'In-process CodeGen failed') and
+// nothing else, because the injected runner returns a bare boolean. CodeGen decides a run's
+// success from its BEFORE/AFTER command failures, so that boolean was hiding the one thing an
+// operator needs — WHICH command failed and what it said. Applies on a host where the AFTER
+// build could not run reported only a failed step, and the tables were created while the
+// entity maps never were.
+describe('RunCodeGen failure detail', () => {
+    const runCodeGen = (rsm: RuntimeSchemaManager) =>
+        (rsm as unknown as { runCodeGen: () => Promise<boolean> }).runCodeGen();
+
+    afterEach(() => {
+        // The manager is a singleton — leave no stub runner behind for the rest of the suite.
+        (RuntimeSchemaManager.Instance as unknown as { _codeGenRunner: unknown })._codeGenRunner = null;
+    });
+
+    it('carries the runner-reported command failure into the RSUError', async () => {
+        const rsm = RuntimeSchemaManager.Instance;
+        rsm.SetCodeGenRunner({
+            RunInProcess: async () => false,
+            LastRunFailures: () => [
+                { context: 'AFTER command', message: '`npm run build` failed: error TS18003: No inputs were found' },
+            ],
+        });
+
+        await expect(runCodeGen(rsm)).rejects.toThrow(/TS18003: No inputs were found/);
+    });
+
+    it('names the step even when the runner reports no detail', async () => {
+        const rsm = RuntimeSchemaManager.Instance;
+        rsm.SetCodeGenRunner({ RunInProcess: async () => false });
+
+        // Degrades to the legacy message rather than claiming a cause it does not have.
+        await expect(runCodeGen(rsm)).rejects.toThrow('In-process CodeGen failed');
+    });
+
+    it('does not throw when the run succeeds', async () => {
+        const rsm = RuntimeSchemaManager.Instance;
+        rsm.SetCodeGenRunner({ RunInProcess: async () => true, LastRunFailures: () => [] });
+
+        await expect(runCodeGen(rsm)).resolves.toBe(true);
+    });
+});


### PR DESCRIPTION
## The problem

A CodeGen run's success is decided entirely by its BEFORE/AFTER command failures —
`executeCodeGenPipeline` ends with `return this.commandFailures.length === 0`. The text that
explains those failures was destroyed twice on the way out:

1. **`runCommand` dropped the command's own output.** On a non-zero exit it rejected with
   `new Error('Process exited with code N')` while the accumulated stdout/stderr sat in a local
   that went out of scope. `recordCommandFailures` reads `r.error || r.output`, so all it could
   ever record was the exit code. A `npm run build` that failed because its source tree was
   absent and one that failed on a genuine type error produced the same string.

2. **`RunInProcess` returns a bare boolean**, so even the recorded `commandFailures` never
   reached the in-process caller. `RunWithResult` (the CLI path) does surface them as
   `errors[]` — the in-process path had no equivalent, and that caller is
   `RuntimeSchemaManager`, running inside a live server with no console for a human to read the
   pipeline's output from. Its RunCodeGen step could only ever throw
   `RSUError('CODEGEN', 'In-process CodeGen failed')`.

The combination is a blind spot with real consequences: a runtime schema update whose AFTER
command cannot succeed on the host reports a failed CodeGen step and aborts — after the tables
have been created but before the entity maps are — and nothing anywhere records which command
failed or what it said.

## The change

- `runCommand` appends a **bounded** tail of the command's combined output to the rejection —
  40 lines / 4000 characters, because a failing build can emit megabytes and this text ends up
  in logs and error payloads.
- `RunCodeGenBase` exposes `CommandFailures`, and `RunInProcess` logs each failure via
  `logError` when a run fails — so the reason is in the host log even for a caller that only
  checks the boolean.
- `IRSUCodeGenRunner` gains an **optional** `LastRunFailures()`. `RuntimeSchemaManager` appends
  what it reports to the `RSUError` message; a runner that cannot report detail degrades to the
  previous message rather than claiming a cause it does not have.
- `MJServer` wires `LastRunFailures` for both the SQL Server and PostgreSQL RSU setups.

No behavior changes: the same runs succeed and fail as before, they just say why.

## Tests

- `packages/CodeGenLib/src/__tests__/runCommand.test.ts` — a real failing shell command must put
  its stderr on the rejection alongside the exit code; `runCommands` must hand that same text
  back as the failed result's `error`, index-aligned with the command that produced it; and a
  200-line failure must be truncated to its tail.
- `packages/SchemaEngine/src/__tests__/RuntimeSchemaManager.test.ts` — the RSUError carries a
  runner-reported failure, degrades to the legacy message when the runner reports none, and
  still does not throw on success.
