### PR TITLE
fix(integration): REST DiscoverFields must report the declared primary key

### DIFF
--- a/.changeset/rest-discoverfields-declared-pk.md
+++ b/.changeset/rest-discoverfields-declared-pk.md
@@ -6,11 +6,12 @@ Carry the declared primary key through a REST connector's DiscoverFields
 
 `BaseRESTIntegrationConnector.FieldEntityToSchema` — the converter every declarative REST
 connector's `DiscoverFields` runs each cached field through — set
-`IsUniqueKey: f.IsUniqueKey || f.IsPrimaryKey` and never set `IsPrimaryKey`. An apply builds each
-field map with `fm.IsKeyField = field.IsPrimaryKey ?? false`, so every field map of every
-declarative REST connector was created keyless, and `object-state`-style checks reported
-"NO KEY FIELD: every row is unmatchable, so writes cannot be reconciled" for objects whose catalog
-declared the key correctly. `IsUniqueKey` is not a substitute — a primary key is one of possibly
+`IsUniqueKey: f.IsUniqueKey || f.IsPrimaryKey` and never set `IsPrimaryKey`. The initial apply
+builds each field map from `DiscoverFields` with `fm.IsKeyField = field.IsPrimaryKey ?? false`, so
+newly applied objects on such a connector got keyless field maps and reported "NO KEY FIELD: every
+row is unmatchable, so writes cannot be reconciled" even though their catalog declared the key
+correctly. The other two field-map writers read the entity rows straight off the engine cache and
+were unaffected — which is why the symptom appears only on freshly applied objects. `IsUniqueKey` is not a substitute — a primary key is one of possibly
 several unique fields, and IsKeyField was deliberately narrowed from unique to primary (PK ≠
 unique), which is what turned this omission from a lost flag into a silent no-sync.
 

--- a/.changeset/rest-discoverfields-declared-pk.md
+++ b/.changeset/rest-discoverfields-declared-pk.md
@@ -1,0 +1,18 @@
+---
+'@memberjunction/integration-engine': patch
+---
+
+Carry the declared primary key through a REST connector's DiscoverFields
+
+`BaseRESTIntegrationConnector.FieldEntityToSchema` — the converter every declarative REST
+connector's `DiscoverFields` runs each cached field through — set
+`IsUniqueKey: f.IsUniqueKey || f.IsPrimaryKey` and never set `IsPrimaryKey`. An apply builds each
+field map with `fm.IsKeyField = field.IsPrimaryKey ?? false`, so every field map of every
+declarative REST connector was created keyless, and `object-state`-style checks reported
+"NO KEY FIELD: every row is unmatchable, so writes cannot be reconciled" for objects whose catalog
+declared the key correctly. `IsUniqueKey` is not a substitute — a primary key is one of possibly
+several unique fields, and IsKeyField was deliberately narrowed from unique to primary (PK ≠
+unique), which is what turned this omission from a lost flag into a silent no-sync.
+
+`BuildSourceObjectInfo`, the sibling converter over the same entity in the same class, has always
+propagated `IsPrimaryKey`; only this one did not.

--- a/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
@@ -1425,6 +1425,16 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
 
     /**
      * Converts an IntegrationObjectFieldEntity to the ExternalFieldSchema format.
+     *
+     * `IsPrimaryKey` MUST be carried through. An apply builds each field map with
+     * `fm.IsKeyField = field.IsPrimaryKey ?? false` (IntegrationDiscoveryResolver), so dropping it
+     * here made every field map keyless for every declarative REST connector — object-state then
+     * reports "NO KEY FIELD: every row is unmatchable, so writes cannot be reconciled" even though
+     * the catalog declares the key correctly. Note that `IsUniqueKey` is NOT a substitute: a PK is
+     * one of possibly several unique fields, and IsKeyField was deliberately narrowed from unique
+     * to primary (see the U1 note on PK ≠ unique) — which is exactly what turned this omission
+     * from cosmetic into a silent no-sync. `BuildSourceObjectInfo`, the sibling converter for the
+     * same entity, has always propagated it; only this one did not.
      */
     private FieldEntityToSchema(f: MJIntegrationObjectFieldEntity): ExternalFieldSchema {
         return {
@@ -1433,6 +1443,7 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
             Description: f.Description ?? undefined,
             DataType: f.Type,
             IsRequired: f.IsRequired,
+            IsPrimaryKey: f.IsPrimaryKey,
             IsUniqueKey: f.IsUniqueKey || f.IsPrimaryKey,
             IsReadOnly: f.IsReadOnly,
             IsForeignKey: f.RelatedIntegrationObjectID != null,

--- a/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
@@ -1426,15 +1426,18 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
     /**
      * Converts an IntegrationObjectFieldEntity to the ExternalFieldSchema format.
      *
-     * `IsPrimaryKey` MUST be carried through. An apply builds each field map with
-     * `fm.IsKeyField = field.IsPrimaryKey ?? false` (IntegrationDiscoveryResolver), so dropping it
-     * here made every field map keyless for every declarative REST connector — object-state then
-     * reports "NO KEY FIELD: every row is unmatchable, so writes cannot be reconciled" even though
-     * the catalog declares the key correctly. Note that `IsUniqueKey` is NOT a substitute: a PK is
-     * one of possibly several unique fields, and IsKeyField was deliberately narrowed from unique
-     * to primary (see the U1 note on PK ≠ unique) — which is exactly what turned this omission
-     * from cosmetic into a silent no-sync. `BuildSourceObjectInfo`, the sibling converter for the
-     * same entity, has always propagated it; only this one did not.
+     * `IsPrimaryKey` MUST be carried through. The initial apply builds each field map with
+     * `fm.IsKeyField = field.IsPrimaryKey ?? false` from `DiscoverFields`
+     * (IntegrationDiscoveryResolver.createFieldMapsForEntityMap), so dropping it here created
+     * KEYLESS field maps for every declarative REST connector — object-state then reports "NO KEY
+     * FIELD: every row is unmatchable, so writes cannot be reconciled" even though the catalog
+     * declares the key correctly. The other two field-map writers read the entity rows straight
+     * off the engine cache and were always right, which is why only freshly APPLIED objects show
+     * the symptom. `IsUniqueKey` is NOT a substitute: a PK is one of possibly several unique
+     * fields, and IsKeyField was deliberately narrowed from unique to primary (see the U1 note on
+     * PK ≠ unique) — which is exactly what turned this omission from cosmetic into a silent
+     * no-sync. `BuildSourceObjectInfo`, the sibling converter over the same entity in this class,
+     * has always propagated it; only this one did not.
      */
     private FieldEntityToSchema(f: MJIntegrationObjectFieldEntity): ExternalFieldSchema {
         return {

--- a/packages/Integration/engine/src/__tests__/BaseRESTIntegrationConnector.discoverfields-pk.test.ts
+++ b/packages/Integration/engine/src/__tests__/BaseRESTIntegrationConnector.discoverfields-pk.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression pin: a declarative REST connector's DiscoverFields must report the DECLARED
+ * primary key.
+ *
+ * The bug: `FieldEntityToSchema` — the converter DiscoverFields runs every cached field through —
+ * set `IsUniqueKey: f.IsUniqueKey || f.IsPrimaryKey` and never set `IsPrimaryKey` at all. An apply
+ * builds field maps with `fm.IsKeyField = field.IsPrimaryKey ?? false`, so EVERY field map of
+ * EVERY declarative REST connector came out keyless, and object-state reported "NO KEY FIELD:
+ * every row is unmatchable, so writes cannot be reconciled" — for objects whose catalog declared
+ * the key correctly. `IsUniqueKey` is not a stand-in: IsKeyField was deliberately narrowed from
+ * unique to primary (PK ≠ unique), which is what made the omission stop syncing rather than merely
+ * lose a flag.
+ */
+import { describe, it, expect } from 'vitest';
+import type { UserInfo } from '@memberjunction/core';
+import type {
+    MJCompanyIntegrationEntity,
+    MJIntegrationObjectEntity,
+    MJIntegrationObjectFieldEntity,
+} from '@memberjunction/core-entities';
+import { BaseRESTIntegrationConnector } from '../BaseRESTIntegrationConnector';
+import type { FetchContext, FetchBatchResult, ConnectionTestResult, ExternalObjectSchema } from '../BaseIntegrationConnector';
+
+const field = (name: string, over: Partial<MJIntegrationObjectFieldEntity> = {}) =>
+    ({
+        Name: name,
+        DisplayName: name,
+        Description: null,
+        Type: 'String',
+        IsRequired: false,
+        IsReadOnly: false,
+        IsPrimaryKey: false,
+        IsUniqueKey: false,
+        RelatedIntegrationObjectID: null,
+        RelatedIntegrationObject: null,
+        Sequence: 0,
+        ...over,
+    }) as unknown as MJIntegrationObjectFieldEntity;
+
+/** A declarative REST connector whose catalog says: mediaId is the key, alias is merely unique. */
+class StubRESTConnector extends BaseRESTIntegrationConnector {
+    protected override GetCachedObject(): MJIntegrationObjectEntity {
+        return { ID: 'obj-1', Name: 'ApplicationFile' } as unknown as MJIntegrationObjectEntity;
+    }
+    protected override GetCachedFields(): MJIntegrationObjectFieldEntity[] {
+        return [
+            field('mediaId', { IsPrimaryKey: true, IsRequired: true }),
+            field('alias', { IsUniqueKey: true }),
+            field('caption'),
+        ];
+    }
+
+    // Abstract transport members — unused by DiscoverFields, which is cache-driven.
+    protected async Authenticate(): Promise<Record<string, unknown>> { return {}; }
+    protected BuildHeaders(): Record<string, string> { return {}; }
+    protected async MakeHTTPRequest(): Promise<unknown> { return {}; }
+    protected NormalizeResponse(): Record<string, unknown>[] { return []; }
+    protected ExtractPaginationInfo(): { HasMore: boolean; NextCursor?: string } { return { HasMore: false }; }
+    protected GetBaseURL(): string { return 'https://example.invalid'; }
+    public async TestConnection(): Promise<ConnectionTestResult> { return { Success: true, Message: 'ok' }; }
+    public async DiscoverObjects(): Promise<ExternalObjectSchema[]> { return []; }
+    public override async FetchChanges(_ctx: FetchContext): Promise<FetchBatchResult> { return { Records: [], HasMore: false }; }
+}
+
+const ci = { IntegrationID: 'int-1' } as unknown as MJCompanyIntegrationEntity;
+const user = {} as unknown as UserInfo;
+
+describe('BaseRESTIntegrationConnector.DiscoverFields — declared PK propagation', () => {
+    it('reports the declared primary key, which is what becomes IsKeyField on the field map', async () => {
+        const fields = await new StubRESTConnector().DiscoverFields(ci, 'ApplicationFile', user);
+        expect(fields.find(f => f.Name === 'mediaId')!.IsPrimaryKey).toBe(true);
+    });
+
+    it('does not promote a merely-unique field to primary key', async () => {
+        const fields = await new StubRESTConnector().DiscoverFields(ci, 'ApplicationFile', user);
+        const alias = fields.find(f => f.Name === 'alias')!;
+        expect(alias.IsUniqueKey).toBe(true);
+        expect(alias.IsPrimaryKey).toBe(false);
+    });
+
+    it('leaves an ordinary field neither key nor unique', async () => {
+        const fields = await new StubRESTConnector().DiscoverFields(ci, 'ApplicationFile', user);
+        const caption = fields.find(f => f.Name === 'caption')!;
+        expect(caption.IsPrimaryKey).toBe(false);
+        expect(caption.IsUniqueKey).toBe(false);
+    });
+
+    it('still treats the primary key as unique', async () => {
+        const fields = await new StubRESTConnector().DiscoverFields(ci, 'ApplicationFile', user);
+        expect(fields.find(f => f.Name === 'mediaId')!.IsUniqueKey).toBe(true);
+    });
+});


### PR DESCRIPTION
## The bug

`BaseRESTIntegrationConnector` has two converters over the same `IntegrationObjectField` entity:

| converter | used by | propagates `IsPrimaryKey`? |
| --- | --- | --- |
| `BuildSourceObjectInfo` | `IntrospectSchema` | yes |
| `FieldEntityToSchema` | **`DiscoverFields`** | **no** |

`FieldEntityToSchema` set `IsUniqueKey: f.IsUniqueKey || f.IsPrimaryKey` and never set
`IsPrimaryKey` at all.

Three code paths create field maps, and all three do the same thing with the flag:

```ts
fm.IsKeyField = field.IsPrimaryKey ?? false; // key on the record's PRIMARY key (identity)
```

Two of them (`processRSUPendingWork` in MJServer, and the re-resolve path in
`IntegrationDiscoveryResolver`) read `IntegrationEngineBase.GetIntegrationObjectFields(...)` —
the entity rows themselves, which carry `IsPrimaryKey` — so they are correct. The **initial
apply** (`createFieldMapsForEntityMap`) instead calls `connector.DiscoverFields(...)`, which for
every declarative REST connector goes through `FieldEntityToSchema`. Those field maps are
therefore created keyless no matter what the catalog declares.

`IsUniqueKey` is not a stand-in. `IsKeyField` was deliberately narrowed from unique to primary
(the "PK ≠ unique" note in that same resolver), because a primary key is one of possibly several
unique fields. That narrowing is correct — and it is what turned this omission from a lost flag
into a silent no-sync.

## How it presents

A live tenant, one REST connector, 30 objects. The 25 whose maps were created through the
engine-cache paths are keyed correctly. The 5 applied through the initial-apply path are not —
and their catalogs are unambiguous:

```
  ApplicationFile              declared=mediaId               isKeyField=<none>   <-- KEYLESS
  ApplicationRoundSubmission   declared=applicationId,roundId isKeyField=<none>   <-- KEYLESS
  ApplicationWinnerType        declared=id                    isKeyField=<none>   <-- KEYLESS
  Judge                        declared=userId                isKeyField=<none>   <-- KEYLESS
  Media                        declared=mediaId               isKeyField=<none>   <-- KEYLESS
  JudgeRecusal                 declared=applicationId,userId  isKeyField=applicationId,userId
  Application                  declared=id                    isKeyField=id
  ... 24 more, all keyed
```

`JudgeRecusal` proves a composite key maps fine through the working paths. Rows then arrive into
the keyless tables and stall, because nothing can be matched or reconciled — the failure looks
like a slow or empty sync, never like a metadata defect.

## The fix

Add `IsPrimaryKey: f.IsPrimaryKey` to `FieldEntityToSchema`, so `DiscoverFields` reports what the
catalog says — the same contract `BuildSourceObjectInfo` has always honoured. One line, and no
behaviour change for connectors that override `DiscoverFields` themselves.

Existing tenants need their already-created field maps repaired (set `IsKeyField` where the
mapped source field is a declared primary key); this fix stops new ones being created wrong.

## Tests

`packages/Integration/engine/src/__tests__/BaseRESTIntegrationConnector.discoverfields-pk.test.ts`
pins all four corners of the contract against a stub REST connector whose catalog declares
`mediaId` as the key and `alias` as merely unique: the declared PK is reported, a merely-unique
field is **not** promoted to PK, an ordinary field is neither, and the PK is still unique.

Related contract, one layer up: `BaseIntegrationConnector.pk-propagation.test.ts` (U1) pins that
`IntrospectSchema` must not coerce PK *silence* into `false`. This is the `DiscoverFields` end of
the same contract, where the flag was not coerced but simply dropped.
