### PR TITLE
fix(core-entities): stop UserInfoEngine debounced flush raising an unhandled rejection

### DIFF
--- a/.changeset/userinfoengine-debounce-unhandled-rejection.md
+++ b/.changeset/userinfoengine-debounce-unhandled-rejection.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/core-entities": patch
+---
+
+Stop `UserInfoEngine`'s debounced settings flush from raising a process-level unhandled rejection.
+
+`SetSettingDebounced` arms a 500ms timer whose callback called `FlushPendingSettings()` fire-and-forget — unawaited, with no `.catch()` — so any rejection from that flush escaped as an `unhandledRejection` rather than something a caller could handle. The rejection itself came from `SetSetting`, which read `md.CurrentUser?.ID` off `this.ProviderToUse`: the optional chain guarded `CurrentUser` but not the provider, and `ProviderToUse` resolves to `this._provider || Metadata.Provider`, which is `undefined` when no provider is configured or when one has been torn down while the timer was still armed.
+
+Two changes: `SetSetting` now guards the provider itself (`md?.CurrentUser?.ID`), degrading to its existing "No user context available" path instead of throwing; and the debounce timer attaches a `.catch()` so no failure on that path — from this cause or any future one — can reach the process as an unhandled rejection.
+
+Impact was mostly felt in CI, where a timer firing after a test environment was torn down failed the whole run with every assertion green: `Test Files 8 passed (8) / Tests 57 passed (57) / Errors 1 error`. Because it depends on where the 500ms timer lands relative to teardown, it was intermittent and reproduced on `next` itself — the same commit failed one scheduled run and passed the next.

--- a/packages/MJCoreEntities/src/__tests__/UserInfoEngine.settingsFlush.test.ts
+++ b/packages/MJCoreEntities/src/__tests__/UserInfoEngine.settingsFlush.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ============================================================================
+// Mocks — must be defined before importing the module under test
+// ============================================================================
+
+/**
+ * The provider the mocked BaseEngine hands back from `ProviderToUse`. Tests set this to
+ * `undefined` to reproduce the real-world case this suite exists for: a host (or a test
+ * environment) where no metadata provider is configured, or one that has been torn down
+ * while a debounced flush timer is still armed.
+ */
+let mockProvider: { CurrentUser?: { ID: string } } | undefined;
+
+vi.mock('@memberjunction/global', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@memberjunction/global')>();
+    return {
+        ...actual,
+        RegisterClass: () => (target: unknown) => target,
+        MJGlobal: { Instance: { GetGlobalObjectStore: () => ({}) } },
+    };
+});
+
+vi.mock('@memberjunction/core', () => {
+    return {
+        BaseEngine: class MockBaseEngine {
+            static getInstance<T>(): T {
+                const ctor = this as unknown as { _testInstance?: T; new (): T };
+                if (!ctor._testInstance) {
+                    ctor._testInstance = new ctor();
+                }
+                return ctor._testInstance;
+            }
+            async Load(): Promise<void> {
+                // no-op in tests
+            }
+            get ProviderToUse() {
+                return mockProvider;
+            }
+        },
+        BaseEnginePropertyConfig: class {},
+        IMetadataProvider: class {},
+        Metadata: class MockMetadata {
+            get CurrentUser() {
+                return mockProvider?.CurrentUser;
+            }
+        },
+        LogStatus: () => undefined,
+        RunView: class {},
+        ApplicationInfo: class {},
+        RegisterForStartup: () => () => {},
+        UserInfo: class {},
+    };
+});
+
+vi.mock('../generated/entity_subclasses', () => ({
+    MJUserNotificationEntity: class {},
+    MJUserNotificationTypeEntity: class {},
+    MJWorkspaceEntity: class {},
+    MJUserApplicationEntity: class {},
+    MJUserFavoriteEntity: class {},
+    MJUserRecordLogEntity: class {},
+    MJUserSettingEntity: class {},
+    MJUserNotificationPreferenceEntity: class {},
+}));
+
+// ---------------------------------------------------------------------------
+// Import the module under test AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { UserInfoEngine } from '../engines/UserInfoEngine';
+
+/**
+ * Collects `unhandledRejection` events raised while a test body runs.
+ *
+ * This is the whole point of the suite: the defect being guarded against never failed an
+ * assertion. Every test in the affected package passed and the run still exited non-zero,
+ * because a debounced flush rejected with nothing attached to catch it. Asserting on
+ * return values alone would not have caught it.
+ */
+function captureUnhandledRejections(): { reasons: unknown[]; stop: () => void } {
+    const reasons: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+        reasons.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    return {
+        reasons,
+        stop: () => process.off('unhandledRejection', onUnhandled),
+    };
+}
+
+/** Lets any pending microtask-queue work settle so a rejection has a chance to surface. */
+async function drainMicrotasks(): Promise<void> {
+    await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('UserInfoEngine — settings flush resilience', () => {
+    let engine: UserInfoEngine;
+
+    beforeEach(() => {
+        engine = UserInfoEngine.Instance;
+        mockProvider = { CurrentUser: { ID: 'U0000000-0000-0000-0000-000000000001' } };
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    describe('SetSetting with no configured provider', () => {
+        it('returns false instead of throwing when ProviderToUse is undefined', async () => {
+            mockProvider = undefined;
+
+            // Before the guard, this threw `Cannot read properties of undefined (reading
+            // 'CurrentUser')` because only `CurrentUser` was optional-chained, not the provider.
+            await expect(engine.SetSetting('some-key', 'some-value')).resolves.toBe(false);
+            expect(console.error).toHaveBeenCalledWith('UserInfoEngine.SetSetting: No user context available');
+        });
+
+    });
+
+    describe('debounced flush timer', () => {
+        it('does not raise an unhandled rejection when the flush rejects', async () => {
+            vi.useFakeTimers();
+            const captured = captureUnhandledRejections();
+
+            try {
+                // Force the flush to reject so the timer's error path is genuinely exercised —
+                // the bare `setTimeout(() => this.FlushPendingSettings())` had nothing attached.
+                vi.spyOn(engine, 'FlushPendingSettings').mockRejectedValue(new Error('flush blew up'));
+
+                engine.SetSettingDebounced('some-key', 'some-value');
+                await vi.runAllTimersAsync();
+
+                vi.useRealTimers();
+                await drainMicrotasks();
+
+                expect(captured.reasons).toEqual([]);
+                expect(console.error).toHaveBeenCalledWith(
+                    'UserInfoEngine: debounced settings flush failed',
+                    expect.any(Error)
+                );
+            } finally {
+                captured.stop();
+            }
+        });
+
+        it('does not raise an unhandled rejection when the timer outlives its provider', async () => {
+            vi.useFakeTimers();
+            const captured = captureUnhandledRejections();
+
+            try {
+                engine.SetSettingDebounced('some-key', 'some-value');
+
+                // Simulate teardown between arming the timer and it firing — this is the exact
+                // sequence that reddened unrelated CI runs.
+                mockProvider = undefined;
+
+                await vi.runAllTimersAsync();
+                vi.useRealTimers();
+                await drainMicrotasks();
+
+                expect(captured.reasons).toEqual([]);
+            } finally {
+                captured.stop();
+            }
+        });
+    });
+});

--- a/packages/MJCoreEntities/src/engines/UserInfoEngine.ts
+++ b/packages/MJCoreEntities/src/engines/UserInfoEngine.ts
@@ -345,7 +345,12 @@ export class UserInfoEngine extends BaseEngine<UserInfoEngine> {
    */
   public async SetSetting(settingKey: string, value: string, contextUser?: UserInfo): Promise<boolean> {
     const md = this.ProviderToUse;
-    const userId = contextUser?.ID || md.CurrentUser?.ID;
+    // `ProviderToUse` falls back to the global `Metadata.Provider`, which is undefined when no
+    // provider is configured (a unit-test environment, or after one is torn down). Guard the
+    // provider itself and not just `CurrentUser`: `SetSetting` is reachable from the debounced
+    // flush timer below, which can outlive its provider, and an unguarded read throws there
+    // instead of taking the "no user context" path.
+    const userId = contextUser?.ID || md?.CurrentUser?.ID;
 
     if (!userId) {
       console.error('UserInfoEngine.SetSetting: No user context available');
@@ -480,8 +485,14 @@ export class UserInfoEngine extends BaseEngine<UserInfoEngine> {
       clearTimeout(this._settingsDebounceTimer);
     }
 
+    // Fire-and-forget: nothing awaits this timer, so an unhandled rejection here would surface as
+    // a process-level error rather than anything a caller can catch. Swallow it into a log so a
+    // flush that fails (or fires after the environment it belonged to has gone away) can never
+    // take down the host process or fail an unrelated test run.
     this._settingsDebounceTimer = setTimeout(() => {
-      this.FlushPendingSettings();
+      this.FlushPendingSettings().catch((err) => {
+        console.error('UserInfoEngine: debounced settings flush failed', err);
+      });
     }, this._settingsDebounceMs);
   }
 


### PR DESCRIPTION
## Summary

`UserInfoEngine`'s debounced settings flush can raise a process-level unhandled rejection. In CI this fails a whole test run **with every assertion green**, which is why it has been hard to pin down:

```
 Test Files  8 passed (8)
      Tests  57 passed (57)
     Errors  1 error
 ELIFECYCLE  Test failed.
```

```
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
TypeError: Cannot read properties of undefined (reading 'CurrentUser')
 ❯ UserInfoEngine.SetSetting            MJCoreEntities/src/engines/UserInfoEngine.ts:348
 ❯ UserInfoEngine.doFlushSettings       MJCoreEntities/src/engines/UserInfoEngine.ts:541
 ❯ UserInfoEngine.FlushPendingSettings  MJCoreEntities/src/engines/UserInfoEngine.ts:522
 ❯ Timeout.<anonymous>                  MJCoreEntities/src/engines/UserInfoEngine.ts:484
 ❯ listOnTimeout                        node:internal/timers:635:17
```

## Root cause

Two independent defects on the same path.

**1. The provider read is unguarded.** `SetSetting` did:

```ts
const md = this.ProviderToUse;
const userId = contextUser?.ID || md.CurrentUser?.ID;
```

`ProviderToUse` is `this._provider || Metadata.Provider` (`MJCore/src/generic/baseEngine.ts:440`), which is `undefined` when no provider is configured — a unit-test environment, or one torn down while a timer was still armed. The optional chain guards `CurrentUser` but not `md`, so this throws instead of falling through to the existing `No user context available` branch three lines below.

**2. The timer is fire-and-forget.** `SetSettingDebounced` armed:

```ts
this._settingsDebounceTimer = setTimeout(() => {
  this.FlushPendingSettings();          // async, unawaited, no .catch()
}, this._settingsDebounceMs);           // 500ms
```

Nothing awaits that promise and nothing catches it, so any rejection — from cause 1 or anything else inside the flush — escapes to the process.

## The fix

- `SetSetting` guards the provider itself (`md?.CurrentUser?.ID`), degrading to the existing "no user context" path.
- The debounce timer attaches a `.catch()` that logs, so no failure on this path can reach the process unhandled.

Deliberately minimal: cause 2 alone is sufficient to stop the CI failures, but cause 1 is the actual bug, and fixing only one would leave the other as a live trap.

## Why it looked like a flake

It depends on where the 500ms timer lands relative to teardown, so it is genuinely intermittent — and it reproduces on `next` with none of this change present:

| run | event | branch | head_sha | result |
|---|---|---|---|---|
| [32559057152](https://github.com/MemberJunction/MJ/actions/runs/32559057152) | `schedule` | `next` | `a8e326e811` | **failure** |
| [32625093852](https://github.com/MemberJunction/MJ/actions/runs/32625093852) | `schedule` | `next` | **`a8e326e811`** | success |

Same commit, opposite outcomes. It has also reddened unrelated PRs (#4011, #3609, #4012). Backstop issue #4017 fires and then auto-closes on the next green run, so the alarm never persists long enough to get triaged.

Triggered in practice via `record-attachments.component.ts:376,382` → `UserInfoEngine.Instance.SetSettingDebounced(...)`, but nothing about it is specific to that component.

## Tests

New `UserInfoEngine.settingsFlush.test.ts` (3 cases). It registers a `process.on('unhandledRejection')` listener and asserts nothing was captured — **necessary here**, because the defect never failed an assertion. A test that only checked return values would have passed against the broken code.

All three fail without the fix, reproducing the production error verbatim:

```
× returns false instead of throwing when ProviderToUse is undefined
    AssertionError: promise rejected "TypeError: Cannot read properties of unde…" instead of resolving
    Caused by: TypeError: Cannot read properties of undefined (reading 'CurrentUser')
× does not raise an unhandled rejection when the flush rejects
× does not raise an unhandled rejection when the timer outlives its provider
```

## Verification

- New suite: **3 passed**, no type errors.
- Reverted the source fix and re-ran: **3 failed** with the errors above — the tests genuinely discriminate.
- Neighbouring suites (`UserInfoEngine.applicationRoles`, `.applicationOrdering`, `.defaultApplications`, `.repairApplications`): **45 passed**.
- `node scripts/check-spec-antipatterns.mjs packages/MJCoreEntities` — clean.

## Noted, not changed

Five other sites in this file read `md.CurrentUser` with the same unguarded shape — `:161` (`Config`), `:831` (`UserHasApplicationAccess`), `:869` (`UserCanAdminApplication`), `:995` (`InstallApplication`), `:1256` (`doCreateDefaultApplications`). None is reachable from a fire-and-forget path, so none can produce an unhandled rejection, and I have left them alone rather than widening this diff. Worth a follow-up sweep if the pattern is considered undesirable generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EroBiLcz3tdoFjNLxTbvZi

---
_Generated by [Claude Code](https://claude.ai/code/session_01EroBiLcz3tdoFjNLxTbvZi)_