### PR TITLE
fix(integration): give watermark connectors a mid-run durability floor

### DIFF
--- a/.changeset/watermark-durability-floor.md
+++ b/.changeset/watermark-durability-floor.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Mid-run watermark durability floor — the watermark twin of the keyset checkpoint. A watermark-based connector had no durable position at all until its run ended: a SIGKILL / OOM / container recycle mid-object threw away hours of applied batches, and the next run re-fetched the entire window from the last completed run's watermark. The 25-batch checkpoint now also persists the max watermark seen (`currentWatermark` only advances at the end of a fully-applied batch, so the floor can never point past an unwritten record). The floor is gated on no page-skip gap having occurred — a skipped page can hold records behind the max watermark seen, i.e. a hole behind the floor — and a floor already written is retracted to the pre-run value the moment the first gap appears, restoring the exact hold semantics the post-loop save has always had. Keyset connectors (their position is the seek key) and partition-reconcile maps (their watermark row stores the rollup snapshot) are excluded. `WatermarkService.RestoreValue` is new, accepting null because the prior state may be "no watermark yet".

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -2150,6 +2150,10 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
 
         // A6: Validate watermark before using it — skip entirely when FullSync requested
         let initialWatermark = config.fullSync ? null : (watermark?.WatermarkValue ?? null);
+        // The value the ROW held before this run touched it — the retract target if a mid-run
+        // durability floor (§8a below) has to be undone after a page-skip gap. Distinct from
+        // initialWatermark, which a fullSync nulls even though the row still holds a real value.
+        const preRunWatermarkValue = watermark?.WatermarkValue ?? null;
         if (initialWatermark && watermark) {
             const watermarkType = (watermark.WatermarkType ?? 'Timestamp') as WatermarkType;
             if (!this.watermarkService.ValidateWatermark(initialWatermark, watermarkType)) {
@@ -2242,6 +2246,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         let previousBatchFingerprint: string | undefined;
         let fetchCompletedCleanly = true; // flipped to false if fetch aborted or errored mid-way
         let hadFetchGap = false;          // ≥1 page was skipped after a persistent fetch error (offset/page paging)
+        let watermarkFloorSaved: string | null = null; // §8a durability floor last persisted mid-run (null = none)
         let fetchGapCount = 0;            // CONSECUTIVE skipped pages (reset on any clean fetch)
         const MAX_FETCH_GAPS = 25;        // give up + hold the watermark if this many pages fail in a row (API down)
         let consecutiveEmptyBatches = 0;  // P3-D: detect a connector that pages empty-but-HasMore forever
@@ -2382,6 +2387,15 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     fetchGapCount++;
                     hadFetchGap = true;
                     fetchCompletedCleanly = false;
+                    // A durability floor written before this gap may sit PAST the hole (the skipped
+                    // page can hold records behind the max watermark seen). Put the row back to what
+                    // it held before this run, exactly what the post-loop hold does for the in-memory
+                    // value — a crash from here on resumes from the pre-run watermark and re-covers
+                    // the gap. Later checkpoints stop writing floors (gate above).
+                    if (watermarkFloorSaved !== null) {
+                        await this.runWriteExclusive(() => this.watermarkService.RestoreValue(entityMapID, preRunWatermarkValue, contextUser));
+                        watermarkFloorSaved = null;
+                    }
                     logger?.warning(
                         entityMap.ExternalObjectName ?? entityMap.ID,
                         'FETCH_PAGE_SKIPPED',
@@ -2623,6 +2637,25 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 // between graceful checkpoints, costing at most ~25 batches of re-fetch on resume.
                 if (isKeysetConnector && currentAfterKey) {
                     await this.runWriteExclusive(() => this.watermarkService.SaveKeysetPosition(entityMapID, currentAfterKey, contextUser));
+                }
+                // The WATERMARK twin of the keyset floor above. Without it, a watermark-based
+                // connector had NO durable position at all until the run ended: a SIGKILL / OOM /
+                // container recycle mid-object threw away hours of applied batches and the next run
+                // re-fetched the entire window from the last completed run's watermark. Same safety
+                // argument as the graceful early-exit save below — currentWatermark only ever
+                // advances at the END of a fully-applied batch, so this floor can never point past a
+                // record that was not written. Gated on !hadFetchGap because a skipped page may
+                // contain records BEHIND the max watermark seen (fetch order is not watermark order
+                // on every source), i.e. a hole behind the floor; once a gap exists the floor stops
+                // moving, and the one already written is retracted at the gap site. Skipped for
+                // keyset connectors (their position IS the seek key above) and partition-reconcile
+                // maps (their watermark row stores the rollup snapshot, not a timestamp).
+                if (!isKeysetConnector && !partitionReconcile && !hadFetchGap
+                    && currentWatermark && currentWatermark !== initialWatermark
+                    && currentWatermark !== watermarkFloorSaved) {
+                    const floor = currentWatermark;
+                    await this.runWriteExclusive(() => this.watermarkService.Update(entityMapID, floor, contextUser, 'Pull'));
+                    watermarkFloorSaved = floor;
                 }
             }
             // P3-D: a connector returning empty pages with HasMore=true would otherwise spin silently

--- a/packages/Integration/engine/src/WatermarkService.ts
+++ b/packages/Integration/engine/src/WatermarkService.ts
@@ -65,6 +65,29 @@ export class WatermarkService {
     }
 
     /**
+     * Puts the watermark VALUE back to a prior state — the undo for a mid-run durability floor
+     * (IntegrationEngine §8a) after a page-skip gap makes that floor unsafe. Accepts null because
+     * the prior state may be "no watermark yet" (first run / the row was created BY the floor);
+     * a null value re-triggers a full window fetch on the next run, which is exactly the hold
+     * semantics the gap requires. A missing row means no floor was ever written — nothing to do.
+     */
+    public async RestoreValue(
+        entityMapID: string,
+        value: string | null,
+        contextUser: UserInfo,
+        direction: 'Pull' | 'Push' = 'Pull'
+    ): Promise<void> {
+        const existing = await this.Load(entityMapID, contextUser, direction);
+        if (!existing) return;
+        existing.WatermarkValue = value;
+        existing.LastSyncAt = new Date();
+        const saved = await existing.Save();
+        if (!saved) {
+            throw new Error(`Failed to restore watermark for EntityMapID=${entityMapID}`);
+        }
+    }
+
+    /**
      * Updates the progress fields on an existing watermark mid-sync without changing
      * the WatermarkValue. Updates RecordsSynced to the cumulative total written so far
      * and refreshes LastSyncAt so the DB reflects live progress between batches.

--- a/packages/Integration/engine/src/__tests__/IntegrationEngine.safefloor.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntegrationEngine.safefloor.test.ts
@@ -607,3 +607,222 @@ describe('IntegrationEngine — skip-and-continue on an offset-page fetch error 
         }
     });
 });
+
+// ---------------------------------------------------------------------------
+// §8a — mid-run watermark DURABILITY FLOOR (the watermark twin of the keyset
+// checkpoint). Before it, a watermark-based connector had no durable position
+// at all until the run ended: a SIGKILL / OOM / container recycle mid-object
+// threw away hours of applied batches, and the next run re-fetched the whole
+// window from the last completed run's watermark. The floor persists the max
+// watermark seen at the 25-batch checkpoint cadence — and is RETRACTED the
+// moment a page-skip gap appears, because a skipped page can hold records
+// BEHIND the max watermark seen (fetch order is not watermark order on every
+// source), i.e. a hole behind the floor.
+//
+// Source under test (IntegrationEngine.ts):
+//   - checkpoint block: `watermarkService.Update(entityMapID, floor, ...)` at
+//     batchCount % 25 === 0, gated !isKeysetConnector && !partitionReconcile &&
+//     !hadFetchGap
+//   - gap site: `watermarkService.RestoreValue(entityMapID, preRunWatermarkValue, ...)`
+//     when a floor was already written
+// ---------------------------------------------------------------------------
+
+/** WM for the n-th batch: strictly increasing, valid ISO timestamps. */
+const wmAt = (n: number) => `2024-06-15T10:${String(n).padStart(2, '0')}:00.000Z`;
+
+/**
+ * A 30-batch offset-paged connector, one clean record per batch, each batch advancing the
+ * watermark to wmAt(batchNumber). Non-keyset so the timestamp-watermark path runs.
+ */
+function createThirtyBatchConnector(): BaseIntegrationConnector {
+    let call = 0;
+    return {
+        TestConnection: vi.fn(),
+        DiscoverObjects: vi.fn(),
+        DiscoverFields: vi.fn(),
+        FetchChanges: vi.fn().mockImplementation(async (): Promise<FetchBatchResult> => {
+            call++;
+            return {
+                Records: [{ ExternalID: `ext-${call}`, ObjectType: 'Contact', Fields: { Name: `Contact ${call}` }, IsDeleted: false }],
+                HasMore: call < 30,
+                NextOffset: call,
+                NewWatermarkValue: wmAt(call),
+            };
+        }),
+        GetDefaultFieldMappings: vi.fn().mockReturnValue([]),
+        RateLimitPolicy: null,
+        ExtractRetryAfterMs: () => undefined,
+        PostProcessRecord: (r: ExternalRecord) => r,
+        StableOrderingKey: () => null,
+    } as unknown as BaseIntegrationConnector;
+}
+
+/**
+ * 25 clean batches (so the checkpoint floor fires once), then the page at offset 25 fails
+ * persistently (the gap); any later offset ends cleanly-empty so the run finishes fast.
+ */
+function createFloorThenGapConnector(): BaseIntegrationConnector {
+    let call = 0;
+    return {
+        TestConnection: vi.fn(),
+        DiscoverObjects: vi.fn(),
+        DiscoverFields: vi.fn(),
+        FetchChanges: vi.fn().mockImplementation(async (ctx: FetchContext): Promise<FetchBatchResult> => {
+            const offset = (ctx.CurrentOffset as number | undefined) ?? 0;
+            if (offset > 25) return { Records: [], HasMore: false };
+            if (offset === 25) throw new Error('simulated persistent page fetch failure at offset 25');
+            call++;
+            return {
+                Records: [{ ExternalID: `ext-${call}`, ObjectType: 'Contact', Fields: { Name: `Contact ${call}` }, IsDeleted: false }],
+                HasMore: true,
+                NextOffset: call === 25 ? 25 : call,
+                NewWatermarkValue: wmAt(call),
+            };
+        }),
+        GetDefaultFieldMappings: vi.fn().mockReturnValue([]),
+        RateLimitPolicy: null,
+        ExtractRetryAfterMs: () => undefined,
+        PostProcessRecord: (r: ExternalRecord) => r,
+        StableOrderingKey: () => null,
+    } as unknown as BaseIntegrationConnector;
+}
+
+describe('IntegrationEngine — mid-run watermark durability floor (§8a)', () => {
+    let orchestrator: IntegrationEngine;
+
+    beforeEach(() => {
+        orchestrator = new IntegrationEngine();
+        mockEntityInstances = new Map();
+        mockRunViewFn = vi.fn();
+        mockRunViewsFn = vi.fn(fanOutToRunView);
+        (IntegrationEngine as Record<string, unknown>)['activeSyncs'] = new Map();
+    });
+
+    /** Shared wiring: run-config reads, a captured watermark row, all-create record path. */
+    function wireRun(connector: BaseIntegrationConnector) {
+        const companyIntegration = createMockCompanyIntegration();
+        const integration = {
+            ID: 'int-1',
+            Get: vi.fn((f: string) => f === 'ID' ? 'int-1' : null),
+            Name: 'Test',
+            ClassName: 'TestConnector',
+        } as unknown as MJIntegrationEntity;
+
+        mockRunViewsFn.mockResolvedValueOnce([
+            { Success: true, Results: [companyIntegration] },
+            {
+                Success: true,
+                Results: [{
+                    Get: vi.fn((f: string) => f === 'ID' ? 'em-1' : null),
+                    CompanyIntegrationID: 'ci-1',
+                    EntityID: 'entity-1',
+                    ConflictResolution: 'SourceWins',
+                    DeleteBehavior: 'SoftDelete',
+                    Entity: 'Contacts',
+                    ExternalObjectName: 'contacts',
+                } as unknown as ICompanyIntegrationEntityMap],
+            },
+            { Success: true, Results: [integration] },
+            { Success: true, Results: [{ DriverClass: 'TestConnector' }] },
+        ]);
+
+        // EVERY value this run persists to the watermark row, in order. UpdateProgress saves
+        // interleave (they re-save the row without changing the value), so assertions read the
+        // sequence, not a single final capture.
+        const persistedValues: Array<string | null> = [];
+        const existingWatermark = {
+            ID: 'wm-1',
+            EntityMapID: 'em-1',
+            Direction: 'Pull' as const,
+            WatermarkType: 'Timestamp' as const,
+            WatermarkValue: PRIOR_WATERMARK as string | null,
+            LastSyncAt: new Date('2024-06-15T09:00:00.000Z'),
+            RecordsSynced: 0,
+            Get: vi.fn(),
+            Save: vi.fn().mockImplementation(async function (this: { WatermarkValue: string | null }) {
+                persistedValues.push(this.WatermarkValue);
+                return true;
+            }),
+        } as unknown as ICompanyIntegrationSyncWatermark;
+
+        mockRunViewFn.mockImplementation(async (params: Record<string, unknown>) => {
+            const entityName = params['EntityName'] as string;
+            if (entityName === 'MJ: Company Integration Field Maps') {
+                return {
+                    Success: true,
+                    Results: [{
+                        SourceFieldName: 'Name',
+                        DestinationFieldName: 'Name',
+                        TransformPipeline: null,
+                        IsKeyField: false,
+                        Status: 'Active',
+                        Priority: 0,
+                    } as unknown as ICompanyIntegrationFieldMap],
+                };
+            }
+            if (entityName === 'MJ: Company Integration Sync Watermarks') {
+                return { Success: true, Results: [existingWatermark] };
+            }
+            return { Success: true, Results: [] };
+        });
+
+        return { persistedValues, existingWatermark };
+    }
+
+    it('persists the max watermark seen at the 25-batch checkpoint, then the final value at the end', async () => {
+        const connector = createThirtyBatchConnector();
+        const { persistedValues } = wireRun(connector);
+
+        const { Metadata: MockMetadataClass } = await import('@memberjunction/core');
+        const origGetEntity = MockMetadataClass.prototype.GetEntityObject;
+        MockMetadataClass.prototype.GetEntityObject = vi.fn().mockImplementation(async () => createMockEntity({}));
+        const { ConnectorFactory } = await import('../ConnectorFactory.js');
+        const resolveOrig = ConnectorFactory.Resolve;
+        ConnectorFactory.Resolve = vi.fn().mockReturnValue(connector);
+
+        try {
+            const result = await orchestrator.RunSync('ci-1', contextUser, 'Manual', undefined, undefined, { FullSync: false });
+            expect(result.RecordsCreated).toBe(30);
+
+            // THE FLOOR: batch 25's watermark was durably written MID-RUN. Only the §8a checkpoint
+            // writes this value — the final save below writes wmAt(30) — so its presence proves a
+            // SIGKILL after batch 25 would resume from here, not from the last completed run.
+            expect(persistedValues).toContain(wmAt(25));
+            // Cadence, not per-batch: no other batch's watermark was floored.
+            for (const n of [1, 5, 24, 26, 29]) expect(persistedValues).not.toContain(wmAt(n));
+            // The run's final save still lands last, exactly as before the floor existed.
+            expect(persistedValues[persistedValues.length - 1]).toBe(wmAt(30));
+        } finally {
+            ConnectorFactory.Resolve = resolveOrig;
+            MockMetadataClass.prototype.GetEntityObject = origGetEntity;
+        }
+    });
+
+    it('retracts the floor to the pre-run value when a page-skip gap appears after it', async () => {
+        const connector = createFloorThenGapConnector();
+        const { persistedValues, existingWatermark } = wireRun(connector);
+
+        const { Metadata: MockMetadataClass } = await import('@memberjunction/core');
+        const origGetEntity = MockMetadataClass.prototype.GetEntityObject;
+        MockMetadataClass.prototype.GetEntityObject = vi.fn().mockImplementation(async () => createMockEntity({}));
+        const { ConnectorFactory } = await import('../ConnectorFactory.js');
+        const resolveOrig = ConnectorFactory.Resolve;
+        ConnectorFactory.Resolve = vi.fn().mockReturnValue(connector);
+
+        try {
+            const result = await orchestrator.RunSync('ci-1', contextUser, 'Manual', undefined, undefined, { FullSync: false });
+            expect(result.RecordsCreated).toBe(25);
+
+            // The floor WAS written at batch 25 — this is the value a gap makes unsafe.
+            expect(persistedValues).toContain(wmAt(25));
+            // THE RETRACTION: the gap put the row back to the pre-run value, and nothing wrote a
+            // watermark after it (the post-loop save is gated on !hadFetchGap). A crash after the
+            // gap resumes from PRIOR_WATERMARK and re-covers the skipped window.
+            expect(persistedValues[persistedValues.length - 1]).toBe(PRIOR_WATERMARK);
+            expect((existingWatermark as unknown as { WatermarkValue: string | null }).WatermarkValue).toBe(PRIOR_WATERMARK);
+        } finally {
+            ConnectorFactory.Resolve = resolveOrig;
+            MockMetadataClass.prototype.GetEntityObject = origGetEntity;
+        }
+    });
+});


### PR DESCRIPTION
## The gap

The keyset path has had this for a while: every 25 batches, the §8a checkpoint persists the seek position, so a hard process kill costs at most ~25 batches of re-fetch. A **watermark-based** connector had no equivalent — its position lived only in memory until the run ended. A SIGKILL / OOM / container recycle mid-object threw away hours of applied batches, and the next run re-fetched the entire window from the last completed run's watermark. On a large object, that's the difference between resuming near where it died and starting the day over.

## The fix

The 25-batch checkpoint now writes the watermark twin: persist the max watermark seen, deduplicated against the last floor written. The safety argument is the one the graceful early-exit save already relies on — `currentWatermark` only ever advances at the **end of a fully-applied batch**, so a floor can never point past a record that was not written.

### The subtle part: gaps

The early-exit save is gated on `!hadFetchGap` because a skipped page can hold records *behind* the max watermark seen (fetch order is not watermark order on every source) — a hole behind the floor. The mid-run floor honours the same gate, **but a floor may already be durably written when the first gap appears**, and merely not writing more floors would leave the row advanced past the hole. So the gap site retracts: `WatermarkService.RestoreValue` (new) puts the row back to the value it held before this run — captured separately from `initialWatermark`, which a fullSync nulls even though the row still holds a real value. From the gap onward, behaviour is exactly what it was before this change: watermark held, skipped window re-fetched next run.

`RestoreValue` accepts `null` because the prior state may be "no watermark yet" (first run, or the row was created by the floor); a null value re-triggers a full window fetch next run — exactly the hold semantics a gap requires.

### Excluded on purpose

- Keyset connectors — their position *is* the seek key the checkpoint already saves.
- Partition-reconcile maps — their watermark row stores the rollup snapshot, not a timestamp; a floor would clobber it.

## Tests

2 added to the safefloor suite, driving the real engine through `RunSync()`:
- a 30-batch run proving the floor lands at batch 25 — and **only** at the cadence, not per batch — with the run's final save still landing last;
- a floor-then-gap run proving the retraction puts the row back to the pre-run value with nothing written after it.

Engine suite 702 passing.