### PR TITLE
fix(core): ProviderBase re-wires when the event bus is replaced

### DIFF
--- a/.changeset/eager-kings-run.md
+++ b/.changeset/eager-kings-run.md
@@ -2,4 +2,4 @@
 "@memberjunction/core": patch
 ---
 
-Patch for eventbus rewire
+`ProviderBase`'s write-invalidation fan-out now re-subscribes when the `MJGlobal` event bus is replaced. Its one-time wiring guard was a boolean, which cannot detect that `MJGlobal.Reset()` (or clearing the singleton from the global object store) has swapped `_events$` for a fresh `Subject` — leaving the fan-out attached to the discarded bus for the rest of the process, so `RunView` dedup/linger entries silently stopped being invalidated after a save, with no error. The guard now keys on the bus reference, unsubscribes the stale subscription when the bus changes, and is re-checked on every call so already-registered long-lived providers re-wire as well.

--- a/.changeset/eager-kings-run.md
+++ b/.changeset/eager-kings-run.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core": patch
+---
+
+Patch for eventbus rewire

--- a/packages/MJCore/src/__tests__/providerBase.invalidationSubscriptionScaling.test.ts
+++ b/packages/MJCore/src/__tests__/providerBase.invalidationSubscriptionScaling.test.ts
@@ -168,4 +168,74 @@ describe('ProviderBase write-invalidation event-bus subscription scaling', () =>
         // so all three re-executed instead of replaying a stale lingered result.
         expect(refetchCount).toBe(3);
     });
+
+    /**
+     * The process-wide subscription is guarded by the identity of the bus it attached to, NOT by a
+     * one-shot boolean. `MJGlobal.Reset()` replaces `_eventsSubject` — and therefore the `_events$`
+     * observable `GetEventListener()` hands back — with a brand-new Subject; `resetMJSingletons()`
+     * has the same effect by deleting the singleton out of the global object store. Under a boolean
+     * latch the fan-out stays attached to the orphaned Subject for the rest of the process, and the
+     * failure is silent: no error, just linger entries that quietly stop being invalidated.
+     */
+    it('re-wires to a replaced event bus — a provider minted after MJGlobal.Reset() still gets invalidated', async () => {
+        const user = makeUser();
+
+        // Wire the fan-out against the CURRENT bus.
+        await makeAndTouchProvider(user);
+
+        // Swap the bus out from under it.
+        MJGlobal.Instance.Reset();
+
+        const provider = await makeAndTouchProvider(user);
+
+        let refetchCount = 0;
+        vi.spyOn(provider as never, 'InternalRunViews').mockImplementation((async () => {
+            refetchCount++;
+            return [makeRunViewResult([{ ID: '1', Name: 'A' }])];
+        }) as never);
+        await provider.RunViews([{ EntityName: 'Customers', ResultType: 'simple' }], user);
+        refetchCount = 0;
+
+        // Raised on the NEW bus. With a boolean latch the fan-out is still listening to the
+        // discarded Subject, so this never reaches the provider and the lingered entry survives.
+        raiseEntityEvent('save', 'Customers');
+
+        await provider.RunViews([{ EntityName: 'Customers', ResultType: 'simple' }], user);
+
+        expect(refetchCount).toBe(1);
+    });
+
+    /**
+     * Companion to the test above, covering the OTHER half of the fix: the static bus check runs on
+     * every call, above the per-instance `_lingerInvalidationWired` guard. Without that hoist, only
+     * a brand-new provider can re-wire — so short-lived server providers self-heal on the next
+     * request, but a long-lived one (Explorer's client provider, MJServer's system provider) stays
+     * bound to the dead Subject indefinitely.
+     */
+    it('re-wires an ALREADY-registered provider — the static check runs on every call, not just the first', async () => {
+        const user = makeUser();
+
+        // Registers BEFORE the swap, so its `_lingerInvalidationWired` flag is already true.
+        const provider = await makeAndTouchProvider(user);
+
+        MJGlobal.Instance.Reset();
+
+        let refetchCount = 0;
+        vi.spyOn(provider as never, 'InternalRunViews').mockImplementation((async () => {
+            refetchCount++;
+            return [makeRunViewResult([{ ID: '1', Name: 'A' }])];
+        }) as never);
+
+        // A DIFFERENT dedup key, so this is a fresh execution rather than a linger hit —
+        // ensureInflightViewInvalidation() is only reached on the fresh-execution path in
+        // RunViewsUncoalesced, which is where the re-check has to happen.
+        await provider.RunViews([{ EntityName: 'Customers', ResultType: 'simple', ExtraFilter: 'Name IS NOT NULL' }], user);
+        refetchCount = 0;
+
+        raiseEntityEvent('save', 'Customers');
+
+        await provider.RunViews([{ EntityName: 'Customers', ResultType: 'simple', ExtraFilter: 'Name IS NOT NULL' }], user);
+
+        expect(refetchCount).toBe(1);
+    });
 });

--- a/packages/MJCore/src/generic/providerBase.ts
+++ b/packages/MJCore/src/generic/providerBase.ts
@@ -7,7 +7,7 @@ import { LocalCacheManager, CachedRunViewResult } from "./localCacheManager";
 import { ApplicationInfo } from "../generic/applicationInfo";
 import { AuditLogTypeInfo, AuthorizationInfo, AuthorizationRoleInfo, RoleInfo, RowLevelSecurityFilterInfo, UserInfo } from "./securityInfo";
 import { TransactionGroupBase } from "./transactionGroup";
-import { MJGlobal, MJEventType, NormalizeUUID, SafeJSONParse, UUIDsEqual, MJLruCache } from "@memberjunction/global";
+import { MJGlobal, MJEvent, MJEventType, NormalizeUUID, SafeJSONParse, UUIDsEqual, MJLruCache } from "@memberjunction/global";
 import { TelemetryManager } from "./telemetryManager";
 import { LogError, LogStatus, LogStatusEx } from "./logging";
 import { QueryCategoryInfo, QueryFieldInfo, QueryInfo, QueryPermissionInfo, QueryEntityInfo, QueryParameterInfo, QueryDependencyInfo, SQLDialectInfo, QuerySQLInfo } from "./queryInfo";
@@ -18,6 +18,7 @@ import { ExplorerNavigationItem } from "./explorerNavigationItem";
 import { Metadata } from "./metadata";
 import { RunView, RunViewParams, IsMaterializedDataSource } from "../views/runView";
 import { DatabasePlatform, PlatformSQL, IsPlatformSQL } from "./platformSQL";
+import { Observable, Subscription } from "rxjs";
 import { GetDataHooks, PreRunViewHook, PostRunViewHook } from "./dataHooks";
 import { TransformSimpleObjectToEntityObject } from "./util";
 import { LoadRelatedRecordsBatched } from "./relatedRecordBatchLoader";
@@ -390,25 +391,47 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
      */
     private static _invalidationTargets = new Set<WeakRef<ProviderBase>>();
 
-    /** Guards {@link ensureStaticInvalidationSubscription} to wire the bus listener at most once per process. */
-    private static _staticInvalidationWired = false;
+    /**
+     * The exact event-bus Observable the fan-out is currently subscribed to — identity, not a
+     * boolean "already wired" flag. `MJGlobal.GetEventListener(false)` returns `MJGlobal._events$`,
+     * and BOTH `MJGlobal.Reset()` and `resetMJSingletons()` (which drops the singleton out of the
+     * global object store entirely) replace that field with a fresh `Subject`. A boolean cannot
+     * tell that the bus underneath it changed, so it would leave the fan-out attached to the
+     * orphaned Subject for the rest of the process — no error, just linger entries that silently
+     * stop being invalidated. Comparing the reference detects the swap exactly.
+     */
+    private static _wiredBus: Observable<MJEvent> | null = null;
 
     /**
-     * Subscribes exactly ONCE per process (not once per provider instance) to BaseEntity
-     * events and fans each one out to every still-live registered provider. This is what
-     * keeps the number of `MJGlobal` event-bus subscribers constant regardless of how many
-     * short-lived provider instances get created — subscribing per-instance (the prior
-     * implementation) permanently pinned one subscription per instance on the process-wide
-     * `Subject`, which never releases subscribers on its own, so a fresh provider minted on
-     * every GraphQL request (or every durable task-graph task) leaked its entire object graph
-     * forever.
+     * The live fan-out subscription, retained so a bus swap can unsubscribe the stale one.
+     * Without this, every swap strands a subscriber on the dead Subject — a small instance of
+     * the very leak this fan-out exists to prevent.
+     */
+    private static _busSubscription: Subscription | null = null;
+
+    /**
+     * Subscribes exactly ONCE PER EVENT BUS (not once per provider instance) to BaseEntity
+     * events and fans each one out to every still-live registered provider. This is what keeps
+     * the number of `MJGlobal` event-bus subscribers constant regardless of how many short-lived
+     * provider instances get created — subscribing per-instance (the original implementation)
+     * permanently pinned one subscription per instance on the process-wide `Subject`, which never
+     * releases subscribers on its own, so a fresh provider minted on every GraphQL request (or
+     * every durable task-graph task) leaked its entire object graph forever.
+     *
+     * Keyed on the bus's identity rather than a one-shot boolean, because the bus is a
+     * replaceable slot and not a process constant. See {@link _wiredBus}.
      */
     private static ensureStaticInvalidationSubscription(): void {
-        if (ProviderBase._staticInvalidationWired) {
+        const bus = MJGlobal.Instance.GetEventListener(false);
+        if (ProviderBase._wiredBus === bus) {
             return;
         }
-        ProviderBase._staticInvalidationWired = true;
-        MJGlobal.Instance.GetEventListener(false).subscribe((event) => {
+        // The bus was replaced (MJGlobal.Reset / singleton clear). Drop the subscriber stranded on
+        // the dead Subject, then attach to the live one. Assign _wiredBus BEFORE subscribing so a
+        // re-entrant call cannot double-wire.
+        ProviderBase._busSubscription?.unsubscribe();
+        ProviderBase._wiredBus = bus;
+        ProviderBase._busSubscription = bus.subscribe((event) => {
             if (event.event !== MJEventType.ComponentEvent || event.eventCode !== BaseEntity.BaseEventCode) {
                 return;
             }
@@ -444,11 +467,17 @@ export abstract class ProviderBase implements IMetadataProvider, IRunViewProvide
      * step no-ops safely.
      */
     private ensureInflightViewInvalidation(): void {
+        // Deliberately ABOVE the per-instance guard: the static wiring is re-checked on every call,
+        // not just the first. A long-lived provider (Explorer's client provider, MJServer's system
+        // provider) that registered before a bus swap would otherwise stay wired to the dead Subject
+        // for the rest of the process — short-lived server providers self-heal via the next
+        // request's fresh instance, long-lived ones never would.
+        ProviderBase.ensureStaticInvalidationSubscription();
+
         if (this._lingerInvalidationWired) {
             return;
         }
         this._lingerInvalidationWired = true;
-        ProviderBase.ensureStaticInvalidationSubscription();
         ProviderBase._invalidationTargets.add(new WeakRef(this));
     }
 


### PR DESCRIPTION
## Summary

Follow-up hardening to #3831, which fixed a Critical per-request `ProviderBase` event-bus subscription leak by moving the wiring guard from instance scope to a process-wide static boolean. That was the right fix for the leak, but the boolean records *that* we subscribed, not *what to* — and the thing it guards is a reference to one specific `Subject`.

`MJGlobal.GetEventListener(false)` returns `MJGlobal._events$`, and that field is replaced in two places: `MJGlobal.Reset()`, and `resetMJSingletons()` in the UnitTesting package, which deletes the singleton from the global object store so the next `MJGlobal.Instance` is a new object with a new bus. After either, the boolean still reads `true`, so the fan-out stays attached to the orphaned Subject for the rest of the process. Providers keep registering and nothing reaches them — RunView linger entries silently stop being invalidated. No error, just stale reads inside the 5s window after a save.

The previous per-instance guard self-healed here by accident: MJServer mints a fresh provider per request, so the next one re-subscribed to the live bus. Promoting the guard to the class removed that.

Three changes, all in `packages/MJCore/src/generic/providerBase.ts`:

- **Key the guard on the bus's identity, not a boolean.** `_wiredBus` holds the `Observable` and is compared by reference, so a swap is detected exactly.
- **Retain the `Subscription` and unsubscribe the stale one on swap.** Otherwise each swap strands a subscriber on the dead Subject — a small instance of the leak #3831 fixed.
- **Run the static check above the per-instance guard.** Previously it was only reachable inside the `_lingerInvalidationWired` early-return, so healing depended on a brand-new provider arriving. Short-lived server providers self-heal that way; a long-lived one (Explorer's client provider, MJServer's system provider) never would.

**Severity: latent, not live.** No production code calls `Reset()` — only test helpers — and Vitest's default `isolate: true` keeps the latch from leaking across test files. The reason to fix it now is that `plans/MEMORY_LEAK_AUDIT.md` lists `ensureStaticInvalidationSubscription()` as the reference implementation for this pattern, so the boolean-latch shape is what future copies will inherit.

## Test plan

- [x] Two new regression tests in `providerBase.invalidationSubscriptionScaling.test.ts`, one per half of the fix:
  - A provider minted **after** `MJGlobal.Reset()` still gets its lingered entry dropped (covers the identity latch).
  - A provider registered **before** the reset also re-wires (covers the hoist). Uses a distinct dedup key, since `ensureInflightViewInvalidation()` is only reached on the fresh-execution path in `RunViewsUncoalesced` — a linger hit returns before it.
- [x] Verified each test fails without its corresponding change: reverting the hoist fails test 2 only; reducing the latch to one-shot fails both. Neither is decorative.
- [x] Both pre-existing tests in that file, and all 6 in `providerBase.lingerInvalidation.test.ts`, pass unchanged.
- [x] Full `@memberjunction/core` suite: 143 files / 2145 tests passing.
- [x] Full monorepo build (`pnpm run build`): 275/275 tasks successful, 0 TypeScript errors.
- [x] Changeset added (`@memberjunction/core: patch`).
- [ ] Deterministic integration tier not run — requires a live database. No migration, metadata, or schema impact; the change is confined to `ProviderBase`'s private write-invalidation wiring, which the unit tests exercise directly.

## Deliberately not included

- **Pruning dead `WeakRef`s from `_invalidationTargets` outside the fan-out loop.** A write-free workload accumulates ~100 bytes per provider. `FinalizationRegistry` is the idiomatic fix but is best-effort by spec and effectively untestable without `--expose-gc` — shipping an unverifiable guard cuts against the point of this PR. The residual self-corrects completely on the first write event. Happy to add it separately if preferred.
- **Updating the Recommended Remediation Patterns bullet in `plans/MEMORY_LEAK_AUDIT.md`** to say the latch keys on the bus reference. Left out to keep the diff tight, but worth doing so the pattern isn't copied in its original form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
