### PR TITLE
refactor(metadata): remove domain-specific claim types from core MJ

### DIFF
--- a/.changeset/remove-domain-claim-types.md
+++ b/.changeset/remove-domain-claim-types.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/core-entities": minor
+---
+
+Remove domain-specific `GuestOrder` and `PersonAccountLink` identity claim types from core MemberJunction metadata. These claim types are specific to BizApps applications (Orders/Common) and are managed in their respective app metadata seed files.

--- a/metadata/identity-claim-types/.identity-claim-types.json
+++ b/metadata/identity-claim-types/.identity-claim-types.json
@@ -41,7 +41,7 @@
       "Description": "General guest order claim for linking order records upon login or email verification.",
       "DriverClass": "GuestOrderClaimDriver",
       "DefaultExpirationDays": 30,
-      "IsActive": false
+      "IsActive": true
     },
     "primaryKey": {
       "ID": "D46BD001-B4F8-48FA-EC42-F44CB1923443"

--- a/metadata/identity-claim-types/.identity-claim-types.json
+++ b/metadata/identity-claim-types/.identity-claim-types.json
@@ -22,29 +22,5 @@
     "primaryKey": {
       "ID": "B249B88F-92D6-46D8-CA20-D22A9B701221"
     }
-  },
-  {
-    "fields": {
-      "Name": "PersonAccountLink",
-      "Description": "Associates guest purchase Person and entity records with authenticated User account.",
-      "DriverClass": "PersonAccountLinkClaimDriver",
-      "DefaultExpirationDays": 30,
-      "IsActive": false
-    },
-    "primaryKey": {
-      "ID": "C35AC990-A3E7-47E9-DB31-E33BA0812332"
-    }
-  },
-  {
-    "fields": {
-      "Name": "GuestOrder",
-      "Description": "General guest order claim for linking order records upon login or email verification.",
-      "DriverClass": "GuestOrderClaimDriver",
-      "DefaultExpirationDays": 30,
-      "IsActive": true
-    },
-    "primaryKey": {
-      "ID": "D46BD001-B4F8-48FA-EC42-F44CB1923443"
-    }
   }
 ]


### PR DESCRIPTION
## Summary

Removes domain-specific `GuestOrder` and `PersonAccountLink` identity claim types from core MemberJunction metadata (`metadata/identity-claim-types/.identity-claim-types.json`). These domain claim types belong in the metadata of their respective Open Apps (`bizapps-orders` / `bizapps-common`).

Includes a minor changeset for `@memberjunction/core-entities`.