### PR TITLE
fix(codegen): do not GRANT or integrity-check excludeSchemas entities

### DIFF
--- a/.changeset/quiet-schema-grants.md
+++ b/.changeset/quiet-schema-grants.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Stop generating and applying GRANT files for excludeSchemas entities. Open App CodeGen was failing with "Cannot find the object 'vw…'" on sibling-schema permission files, and the entity-field sequence integrity check was querying those same out-of-scope base views.

--- a/packages/CodeGenLib/src/Database/__tests__/exclude-schema-permissions.test.ts
+++ b/packages/CodeGenLib/src/Database/__tests__/exclude-schema-permissions.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { entitiesNotInExcludedSchemas } from '../sql_codegen';
+
+describe('excludeSchemas permission scope', () => {
+    const entities = [
+        { Name: 'MJ_BizApps_Orders: Products', SchemaName: '__mj_BizAppsOrders' },
+        { Name: 'MJ_BizApps_Common: Contact Methods', SchemaName: '__mj_BizAppsCommon' },
+        { Name: 'MJ: Users', SchemaName: '__mj' },
+        { Name: 'MJ_BizApps_Orders: Product Types', SchemaName: '__mj_BizAppsOrders' },
+    ];
+    const excludeSchemas = [
+        'sys',
+        'staging',
+        'dbo',
+        '__mj',
+        '__mj_UDT',
+        '__mj_BizAppsCommon',
+        '__mj_BizAppsAccounting',
+        '__mj_BizAppsTasks',
+    ];
+
+    it('keeps only this app schema when sibling and core schemas are excluded', () => {
+        const included = entitiesNotInExcludedSchemas(entities, excludeSchemas);
+        expect(included.map((e) => e.Name)).toEqual([
+            'MJ_BizApps_Orders: Products',
+            'MJ_BizApps_Orders: Product Types',
+        ]);
+    });
+
+    it('is case-insensitive on schema names', () => {
+        const included = entitiesNotInExcludedSchemas(
+            [{ Name: 'X', SchemaName: '__MJ_BizAppsOrders' }],
+            ['__mj_bizappsorders'],
+        );
+        expect(included).toEqual([]);
+    });
+});

--- a/packages/CodeGenLib/src/Database/sql_codegen.ts
+++ b/packages/CodeGenLib/src/Database/sql_codegen.ts
@@ -25,6 +25,19 @@ export const SPType = {
 
 export type SPType = typeof SPType[keyof typeof SPType];
 
+/**
+ * Entities whose SchemaName is not in excludeSchemas (case-insensitive).
+ * This is the CodeGen run's in-scope set: SQL objects and GRANTs are
+ * generated and executed only for these. excludeSchemas means "not this run".
+ */
+export function entitiesNotInExcludedSchemas<T extends { SchemaName: string }>(
+    entities: T[],
+    excludeSchemas: string[],
+): T[] {
+    const exclude = new Set(excludeSchemas.map((s) => s.toLowerCase()));
+    return entities.filter((e) => !exclude.has(e.SchemaName.toLowerCase()));
+}
+
 
 /**
  * This class is responsible for generating database level objects like views, stored procedures, permissions, etc. You can sub-class this class to create your own SQL generation logic or implement support for other
@@ -130,9 +143,7 @@ export class SQLCodeGenBase {
             const baselineEntities = entities.filter(e => e.IncludeInAPI);
 
             // OPTIMIZATION: Use a Set for O(1) lookups instead of O(n) array finds to improve performance
-            const excludeSchemasSet = new Set(configInfo.excludeSchemas.map(s => s.toLowerCase()));
-            const includedEntities = baselineEntities.filter(e => !excludeSchemasSet.has(e.SchemaName.toLowerCase())); //only include entities that are NOT in the excludeSchemas list
-            const excludedEntities = baselineEntities.filter(e => excludeSchemasSet.has(e.SchemaName.toLowerCase())); //only include entities that ARE in the excludeSchemas list in this array
+            const includedEntities = entitiesNotInExcludedSchemas(baselineEntities, configInfo.excludeSchemas);
 
             // Initialize temp batch files for each schema
             // These will be populated as SQL is generated and will be used for actual execution
@@ -169,18 +180,18 @@ export class SQLCodeGenBase {
 
             // Track per-batch success without short-circuiting. Historically,
             // any single batch failure here returned `false` immediately, which
-            // skipped the cascade-regen and excluded-perms batches and left
-            // their entities with no SQL emitted at all. The post-run CRUD
-            // validator (in runCodeGen.ts) is the authoritative ship-gate now,
-            // so we want every batch to attempt its work and surface the
-            // complete picture of what's missing — partial generation is
-            // strictly more useful than nothing.
+            // skipped the cascade-regen batch and left those entities with no
+            // SQL emitted at all. The post-run CRUD validator (in runCodeGen.ts)
+            // is the authoritative ship-gate now, so we want every in-scope
+            // batch to attempt its work and surface the complete picture of
+            // what's missing — partial generation is strictly more useful than
+            // nothing.
             let entityGenSuccess = true;
 
             // Build a UNION will-regenerate set across every batch we're about
-            // to launch (main + cascade-regen + excluded-perms). The PG view
-            // fallback's restoreDependents path uses this to skip restoring
-            // captured dependents that codegen will recreate later in the run.
+            // to launch (main + cascade-regen). The PG view fallback's
+            // restoreDependents path uses this to skip restoring captured
+            // dependents that codegen will recreate later in the run.
             // Without the union, batch 1's fallback only sees batch 1's
             // entities — so a dependent like vwAIAgentRuns (which lives in
             // batch 2 cascade-regen) is "missing from willRegenerate", the
@@ -192,7 +203,6 @@ export class SQLCodeGenBase {
             const allBatchEntities: EntityInfo[] = [
                 ...entitiesWithoutCascadeRegeneration,
                 ...entitiesForCascadeRegeneration,
-                ...excludedEntities,
             ];
             const globalWillRegenerate = new Set(
                 allBatchEntities
@@ -230,7 +240,7 @@ export class SQLCodeGenBase {
                 willRegenerate: globalWillRegenerate
             }); // enable sql logging for NEW entities....
             if (!genResult.Success) {
-                logError('Main entity SQL generation batch had failures — continuing with cascade-regen and excluded-perms batches; validator will report any missing routines.');
+                logError('Main entity SQL generation batch had failures — continuing with cascade-regen; validator will report any missing routines.');
                 entityGenSuccess = false;
             }
 
@@ -255,23 +265,19 @@ export class SQLCodeGenBase {
                 genResult.Files.push(...cascadeGenResult.Files);
             }
 
-            // STEP 2(c) - for the excludedEntities, while we don't want to generate SQL, we do want to generate the permissions files for them
-            updateSpinner(`Generating permissions for ${excludedEntities.length} excluded entities...`);
-            const genResult2 = await this.generateAndExecuteEntitySQLToSeparateFiles({
-                pool,
-                entities: excludedEntities,
-                directory,
-                onlyPermissions: true,
-                skipExecution: true, // skip execution because we execute it all in a giant batch below
-                batchSize: perEntityBatchSize,
-                writeFiles: true,
-                enableSQLLoggingForNewOrModifiedEntities: false, /*don't log this stuff, it is just permissions for excluded entities*/
-                willRegenerate: globalWillRegenerate
-            });
-            if (!genResult2.Success) {
-                logError('Excluded-entities permissions batch had failures — continuing; validator will report any missing routines.');
-                entityGenSuccess = false;
-            }
+            // STEP 2(c) used to generate+apply GRANT files for excludeSchemas entities
+            // ("we don't want to generate SQL, we do want to generate the permissions").
+            // That is wrong once excludeSchemas means "not this CodeGen run":
+            //
+            //   - Open Apps exclude sibling schemas (__mj_BizAppsCommon, …) and __mj.
+            //     GRANT SELECT ON [__mj_BizAppsCommon].[vwContactMethods] then runs from
+            //     the orders (or other) repo, pollutes SQL Scripts/generated/<sibling>/,
+            //     and fails the whole run (exit 1) when that object is missing or lives
+            //     in a schema the executing login does not resolve.
+            //   - Core (__mj) permissions already ship in MJ migrations. Refreshing them
+            //     from an app CodeGen is not this app's job.
+            //
+            // Permissions are applied in STEP 4 for includedEntities only.
             if (entityGenSuccess) {
                 succeedSpinner(`Entity generation completed (${(new Date().getTime() - step2StartTime.getTime())/1000}s)`);
             } else {
@@ -280,8 +286,8 @@ export class SQLCodeGenBase {
 
             // STEP 2(d) now that we've generated the SQL, let's create a combined file in each schema sub-directory for convenience for a DBA
             startSpinner('Creating combined SQL files...');
-            const allEntityFiles = this.createCombinedEntitySQLFiles(directory, baselineEntities);
-            succeedSpinner(`Created combined SQL files for ${allEntityFiles.length} schemas`);
+            const allEntityFiles = this.createCombinedEntitySQLFiles(directory, includedEntities);
+            succeedSpinner(`Created combined SQL files for ${allEntityFiles.length} file(s)`);
 
             // STEP 2(e) ---- FINALLY, we execute SQL in proper dependency order
             // Use temp batch files (which maintain CodeGen log order) if available, otherwise fall back to combined files
@@ -290,7 +296,7 @@ export class SQLCodeGenBase {
 
             let executionSuccess = false;
             if (useProviderPhasedExecution) {
-                // Per-entity phased execution already ran during steps 2(b)/(c).
+                // Per-entity phased execution already ran during step 2(b).
                 // Skip the bulk file re-execution — replaying the same SQL here
                 // would re-trigger 42P16 without the phased recovery wrapper and
                 // undo the work the phased executor just did.
@@ -403,10 +409,13 @@ export class SQLCodeGenBase {
                 }
             }
 
-            // STEP 4- Apply permissions, executing all .permissions files
+            // STEP 4- Apply permissions for THIS run's schemas only. Excluded-schema
+            // GRANT files are not generated (see STEP 2(c) note) and must not be
+            // executed: a missing sibling object would fail CodeGen with
+            // "Cannot find the object 'vw…'" even though this app's work succeeded.
             startSpinner('Applying permissions...');
             const step4StartTime: Date = new Date();
-            if (! await this.applyPermissions(pool, directory, baselineEntities)) {
+            if (! await this.applyPermissions(pool, directory, includedEntities)) {
                 failSpinner('Failed to apply permissions');
                 overallSuccess = false;
             }

--- a/packages/CodeGenLib/src/Misc/system_integrity.ts
+++ b/packages/CodeGenLib/src/Misc/system_integrity.ts
@@ -130,7 +130,15 @@ export class SystemIntegrityBase {
 
                 // loop through all the fields. Each time the entity changes, check to see if there are any duplicate fields
                 // that has the same sequence number and flag that as an error.
+                const excludedSchemas = new Set(
+                    (configInfo.excludeSchemas ?? []).map((s) => s.toLowerCase())
+                );
+
                 for (const row of result) {
+                    if (excludedSchemas.has(String(row.SchemaName ?? '').toLowerCase())) {
+                        lastEntity = row.Entity;
+                        continue;
+                    }
                     if (lastEntity !== row.Entity) {
                         // we have a new entity, check all the fields in this entity
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
- `excludeSchemas` means this CodeGen run does not own those schemas. We were still generating and executing GRANT files for every excluded entity (STEP 2(c) + `applyPermissions(baselineEntities)`).
- In a joined multi-app database that fails the whole run: `GRANT SELECT ON [__mj_BizAppsCommon].[vwContactMethods]` from an orders CodeGen exits 1 when the object is missing, and writes sibling files into `SQL Scripts/generated/<other-app>/`.
- The entity-field sequence integrity check had the same hole — it `SELECT TOP 1`s every entity's BaseView, including excluded schemas.
- Permissions and the sequence check now run only for included entities. Core GRANTs continue to ship with MJ migrations.

Verified locally: orders `mj codegen` against `bizapps_e2e_grok_0825` with sibling schemas excluded now exits 0 and no longer attempts the Contact Methods GRANT.

## Test plan
- [x] `vitest run src/Database/__tests__/exclude-schema-permissions.test.ts` in CodeGenLib
- [x] Rebuild `@memberjunction/codegen-lib` and re-run `mj codegen` from bizapps-orders with `excludeSchemas` listing `__mj` and sibling Open App schemas — exit 0, no sibling GRANT errors
- [ ] Confirm MJ-core CodeGen (where `__mj` is **included**) still applies core view/SP permissions as before