### PR TITLE
fix(pg): make spRebindLayeredOuterView actually run, and stop IT69 skipping silently

### DIFF
--- a/.changeset/fix-pg-layered-outer-rebind.md
+++ b/.changeset/fix-pg-layered-outer-rebind.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/open-app-engine": patch
+---
+
+Fix `spRebindLayeredOuterView` on PostgreSQL, which could never restar a layered outer view. It shipped with an undeclared `v_starred` variable — PL/pgSQL compiles the whole body on first call, so every invocation failed, including the `spRebindLayeredOuterViewsInSchema` call Open App's metadata refresh issues first in its batch (aborting the field-heal statements behind it). Removing that dead write exposed a second defect: single-argument `btrim()` strips spaces but not newlines, and `pg_get_viewdef` pretty-prints, so the SELECT-item scan stopped after one column and rebuilt the view as `SELECT g.*, <every inner column again>` — rejected as `column ... specified more than once`. Both are corrected in a new pg-only migration. Also makes integration checks LBV2–LBV5 run on PostgreSQL instead of silently skipping while still scoring as passed.

--- a/migrations-pg/v6/V202608252300__v6.1.x__Fix_spRebindLayeredOuterView_Undeclared_Variable.pg-only.sql
+++ b/migrations-pg/v6/V202608252300__v6.1.x__Fix_spRebindLayeredOuterView_Undeclared_Variable.pg-only.sql
@@ -1,0 +1,269 @@
+-- ============================================================================
+-- Fix: spRebindLayeredOuterView could never restar a layered outer view.
+-- ============================================================================
+--
+-- V202608252000 shipped this function with TWO defects. The first masked the
+-- second, so neither was visible: the function was never able to run at all,
+-- and once it could, it produced invalid SQL.
+--
+-- DEFECT 1 -- undeclared variable, so every call failed.
+--   The already-starred branch assigned `v_starred := true;`, but `v_starred`
+--   is never declared. PL/pgSQL compiles the WHOLE body on first invocation, so
+--   the branch was irrelevant -- every call raised:
+--       ERROR: "v_starred" is not a known variable
+--   PostgreSQL validates a plpgsql body only at execution, never at
+--   CREATE FUNCTION, so the migration applied green and the function died on
+--   first use. Fixed by removing the write: `v_starred` was only ever written,
+--   never read, and the surrounding logic is complete without it (v_consumed
+--   marks the starred case; extras are taken from v_consumed + 1 onward). The
+--   TypeScript reference, restarLayeredOuterView() in @memberjunction/sql-dialect,
+--   has no equivalent flag.
+--
+-- DEFECT 2 -- single-argument btrim() strips SPACES ONLY, not newlines.
+--   `pg_get_viewdef(oid, true)` pretty-prints, so every SELECT item after the
+--   first arrives with a leading newline. The consumption loop compares each
+--   trimmed item against the inner view's column list and EXITs on the first
+--   miss, so it consumed exactly one column and treated every remaining inner
+--   column as an application "extra". The rebuilt view was then:
+--       SELECT g.*, "MajorVersion", "MinorVersion", ...
+--   which PostgreSQL rejects:
+--       ERROR: column "MajorVersion" specified more than once
+--   Verified: btrim(E'\n  "MajorVersion"') does NOT strip the newline, while
+--   btrim(E'\n  "MajorVersion"', E' \t\r\n') does. Every trim that touches
+--   deparsed SQL text now passes an explicit whitespace character set. The
+--   TypeScript reference uses .trim(), which already handles all whitespace --
+--   which is why the CodeGen path worked while this one could not.
+--
+-- Shipped as a NEW migration rather than an edit to V202608252000: that file is
+-- already applied wherever it has run, and Skyway skips an applied version, so
+-- an in-place edit would repair fresh installs only and leave existing
+-- databases holding the broken function. CREATE OR REPLACE FUNCTION repairs both.
+--
+-- The body below is V202608252000's, with those two corrections and no others.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION ${flyway:defaultSchema}."spRebindLayeredOuterView"(
+    p_Schema text,
+    p_OuterView text,
+    p_InnerView text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $fn$
+DECLARE
+    v_outer_oid oid;
+    v_inner_oid oid;
+    v_def text;
+    v_from_pos int;
+    v_select_list text;
+    v_rest text;
+    v_alias text := 'g';
+    v_items text[];
+    v_item text;
+    v_extras text := '';
+    v_consumed int := 0;
+    v_inner_cols text[];
+    v_col text;
+    v_restarred text;
+    v_create text;
+    v_i int;
+    v_depth int;
+    v_ch text;
+    v_q text;
+    v_start int;
+    rec RECORD;
+BEGIN
+    v_outer_oid := to_regclass(format('%I.%I', p_Schema, p_OuterView));
+    v_inner_oid := to_regclass(format('%I.%I', p_Schema, p_InnerView));
+    IF v_outer_oid IS NULL OR v_inner_oid IS NULL THEN
+        RETURN;
+    END IF;
+
+    SELECT array_agg(a.attname ORDER BY a.attnum)
+      INTO v_inner_cols
+    FROM pg_attribute a
+    WHERE a.attrelid = v_inner_oid
+      AND a.attnum > 0
+      AND NOT a.attisdropped;
+
+    IF v_inner_cols IS NULL OR array_length(v_inner_cols, 1) IS NULL THEN
+        RETURN;
+    END IF;
+
+    v_def := btrim(pg_get_viewdef(v_outer_oid, true), E' \t\r\n');
+    IF right(v_def, 1) = ';' THEN
+        v_def := btrim(left(v_def, length(v_def) - 1), E' \t\r\n');
+    END IF;
+    IF v_def !~* '^select\y' THEN
+        RAISE NOTICE 'spRebindLayeredOuterView: %I.%I definition is not a SELECT', p_Schema, p_OuterView;
+        RETURN;
+    END IF;
+
+    -- Top-level FROM
+    v_depth := 0;
+    v_from_pos := 0;
+    v_i := 1;
+    WHILE v_i <= length(v_def) LOOP
+        v_ch := substr(v_def, v_i, 1);
+        IF v_ch IN ('''', '"') THEN
+            v_q := v_ch;
+            v_i := v_i + 1;
+            WHILE v_i <= length(v_def) LOOP
+                IF substr(v_def, v_i, 1) = v_q THEN
+                    IF substr(v_def, v_i + 1, 1) = v_q THEN
+                        v_i := v_i + 2;
+                        CONTINUE;
+                    END IF;
+                    v_i := v_i + 1;
+                    EXIT;
+                END IF;
+                v_i := v_i + 1;
+            END LOOP;
+            CONTINUE;
+        END IF;
+        IF v_ch = '(' THEN
+            v_depth := v_depth + 1;
+            v_i := v_i + 1;
+            CONTINUE;
+        END IF;
+        IF v_ch = ')' THEN
+            v_depth := v_depth - 1;
+            v_i := v_i + 1;
+            CONTINUE;
+        END IF;
+        IF v_depth = 0 AND lower(substr(v_def, v_i, 4)) = 'from'
+           AND (v_i = 1 OR substr(v_def, v_i - 1, 1) !~ '[[:alnum:]_$]')
+           AND (v_i + 4 > length(v_def) OR substr(v_def, v_i + 4, 1) !~ '[[:alnum:]_$]') THEN
+            v_from_pos := v_i;
+            EXIT;
+        END IF;
+        v_i := v_i + 1;
+    END LOOP;
+
+    IF v_from_pos = 0 THEN
+        RAISE NOTICE 'spRebindLayeredOuterView: no FROM in %I.%I', p_Schema, p_OuterView;
+        RETURN;
+    END IF;
+
+    v_select_list := btrim(substr(v_def, 1, v_from_pos - 1), E' \t\r\n');
+    v_select_list := btrim(regexp_replace(v_select_list, '^select\y', '', 'i'), E' \t\r\n');
+    v_rest := btrim(substr(v_def, v_from_pos), E' \t\r\n');
+
+    -- Alias after FROM <qual.inner> [AS] alias
+    IF v_rest ~* ('^from[[:space:]].*' || p_InnerView || '[[:space:]]+(as[[:space:]]+)?') THEN
+        v_alias := btrim(regexp_replace(
+            regexp_replace(v_rest, '^from[[:space:]]+\S+[[:space:]]+(as[[:space:]]+)?', '', 'i'),
+            '[[:space:]].*$',
+            ''
+        ));
+        v_alias := trim(both '"' from v_alias);
+        IF v_alias IS NULL OR v_alias = '' OR lower(v_alias) IN ('where', 'join', 'left', 'right', 'inner', 'full', 'cross', 'group', 'order', 'limit', 'offset') THEN
+            v_alias := 'g';
+        END IF;
+    END IF;
+
+    -- Split SELECT list on top-level commas
+    v_items := ARRAY[]::text[];
+    v_depth := 0;
+    v_start := 1;
+    v_i := 1;
+    WHILE v_i <= length(v_select_list) LOOP
+        v_ch := substr(v_select_list, v_i, 1);
+        IF v_ch IN ('''', '"') THEN
+            v_q := v_ch;
+            v_i := v_i + 1;
+            WHILE v_i <= length(v_select_list) LOOP
+                IF substr(v_select_list, v_i, 1) = v_q THEN
+                    IF substr(v_select_list, v_i + 1, 1) = v_q THEN
+                        v_i := v_i + 2;
+                        CONTINUE;
+                    END IF;
+                    v_i := v_i + 1;
+                    EXIT;
+                END IF;
+                v_i := v_i + 1;
+            END LOOP;
+            CONTINUE;
+        END IF;
+        IF v_ch = '(' THEN
+            v_depth := v_depth + 1;
+        ELSIF v_ch = ')' THEN
+            v_depth := v_depth - 1;
+        ELSIF v_ch = ',' AND v_depth = 0 THEN
+            v_items := array_append(v_items, btrim(substr(v_select_list, v_start, v_i - v_start), E' \t\r\n'));
+            v_start := v_i + 1;
+        END IF;
+        v_i := v_i + 1;
+    END LOOP;
+    v_items := array_append(v_items, btrim(substr(v_select_list, v_start), E' \t\r\n'));
+
+    IF v_items[1] ~ ('^"?' || v_alias || '"?\.\*$') OR btrim(v_items[1], E' \t\r\n') = '*' THEN
+        v_consumed := 1;
+    ELSE
+        FOREACH v_item IN ARRAY v_items LOOP
+            v_item := btrim(v_item, E' \t\r\n');
+            v_item := regexp_replace(v_item, '::[[:alnum:]_."[:space:]()]+$', '');
+            v_item := btrim(v_item, E' \t\r\n');
+            v_item := regexp_replace(v_item, '[[:space:]]+[Aa][Ss][[:space:]]+"?[A-Za-z_][A-Za-z0-9_$]*"?$', '');
+            -- strip alias.
+            IF v_item ~ ('^"?' || v_alias || '"?\.') THEN
+                v_item := regexp_replace(v_item, '^"?[A-Za-z_][A-Za-z0-9_$]*"?\.', '');
+            END IF;
+            v_col := trim(both '"' from v_item);
+            IF v_col = ANY (v_inner_cols) THEN
+                v_consumed := v_consumed + 1;
+            ELSE
+                EXIT;
+            END IF;
+        END LOOP;
+    END IF;
+
+    IF v_consumed = 0 THEN
+        RAISE NOTICE 'spRebindLayeredOuterView: %I.%I is not a g.* wrapper over %I', p_Schema, p_OuterView, p_InnerView;
+        RETURN;
+    END IF;
+
+    IF v_consumed < coalesce(array_length(v_items, 1), 0) THEN
+        v_extras := array_to_string(v_items[v_consumed + 1 : array_length(v_items, 1)], E',\n    ');
+    END IF;
+
+    IF v_extras IS NULL OR btrim(v_extras, E' \t\r\n') = '' THEN
+        v_restarred := format('SELECT %I.*%s%s', v_alias, E'\n', v_rest);
+    ELSE
+        v_restarred := format('SELECT %I.*,%s    %s%s%s', v_alias, E'\n', v_extras, E'\n', v_rest);
+    END IF;
+
+    v_create := format('CREATE OR REPLACE VIEW %I.%I AS %s', p_Schema, p_OuterView, v_restarred);
+
+    BEGIN
+        EXECUTE v_create;
+    EXCEPTION WHEN invalid_table_definition THEN
+        CREATE TEMP TABLE IF NOT EXISTS _rebind_fn_deps (
+            definition text
+        ) ON COMMIT DROP;
+        DELETE FROM _rebind_fn_deps;
+
+        INSERT INTO _rebind_fn_deps (definition)
+        SELECT DISTINCT pg_get_functiondef(pp.oid)
+        FROM pg_depend d
+        JOIN pg_proc pp ON pp.oid = d.objid AND d.classid = 'pg_proc'::regclass
+        WHERE d.refobjid = v_outer_oid
+        UNION
+        SELECT DISTINCT pg_get_functiondef(pp.oid)
+        FROM pg_proc pp
+        JOIN pg_type pt ON pp.prorettype = pt.oid
+        WHERE pt.typrelid = v_outer_oid;
+
+        EXECUTE format('DROP VIEW IF EXISTS %I.%I CASCADE', p_Schema, p_OuterView);
+        EXECUTE format('CREATE VIEW %I.%I AS %s', p_Schema, p_OuterView, v_restarred);
+
+        FOR rec IN SELECT definition FROM _rebind_fn_deps LOOP
+            BEGIN
+                EXECUTE rec.definition;
+            EXCEPTION WHEN OTHERS THEN
+                RAISE NOTICE 'spRebindLayeredOuterView: skipped function restore: %', SQLERRM;
+            END;
+        END LOOP;
+    END;
+END;
+$fn$;

--- a/packages/TestingFramework/integration-test-suite/src/checks/layered-base-views.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/layered-base-views.checks.ts
@@ -24,10 +24,14 @@
  * present in the catalog.
  *
  * ── PLATFORM ────────────────────────────────────────────────────────────────────────────────
- * Catalog inspection (LBV2–LBV5) uses `sys.columns` / `sys.sql_modules` and therefore needs
- * `ctx.Pool` (SQL Server). Those checks skip with a loud note when the pool is absent (PostgreSQL
- * run paths, or any path that did not bootstrap mssql). LBV1 and LBV6 are metadata + `RunView`
- * and run on every platform, including PostgreSQL after inner views + restarred outers exist.
+ * Catalog inspection (LBV2–LBV5) runs on BOTH platforms: `sys.columns` / `sys.sql_modules` via
+ * `ctx.Pool` on SQL Server, `pg_catalog` via the provider's `ExecuteSQL` on PostgreSQL. They skip
+ * only when neither seam is reachable. LBV1 and LBV6 are metadata + `RunView` and run everywhere.
+ *
+ * These checks previously skipped on PostgreSQL — and a skipped check still scores 1.0 and counts
+ * as passed, so the bundle reported 6/6 / 100% while only two of six ran. LBV5 was among the
+ * silent ones, which is the one that matters most here: PostgreSQL freezes `g.*` at CREATE VIEW,
+ * so an outer view silently failing to inherit a new inner column is a PG-only failure mode.
  *
  * ── CHECKS ──────────────────────────────────────────────────────────────────────────────────
  *   LBV1 layering metadata is coherent (BaseViewGenerated=0, names differ, EntityInfo agrees)
@@ -64,23 +68,80 @@ function requireLayered(ctx: IntegrationCheckContext): EntityInfo[] {
 }
 
 /**
- * The layered entities, or null when this run cannot reach the physical catalog.
+ * Structural view of the run provider's raw-SQL seam.
  *
- * Only LBV2–LBV5 need `sys.*`. They skip when `ctx.Pool` is absent. The skip is logged with the
- * provider name so a green result is never mistaken for a real one; LBV1 and LBV6 do not depend
- * on the pool, so they run on PostgreSQL as well.
+ * `IMetadataProvider` does not declare either member — both concrete database providers do
+ * (`ExecuteSQL` is the shared seam `UserCache` already relies on to serve SQL Server and
+ * PostgreSQL from one code path). Declared narrowly here rather than widening the interface,
+ * and rather than reaching for `any`.
+ */
+interface CatalogQueryProvider {
+    PlatformKey?: string;
+    ExecuteSQL?<T>(query: string): Promise<T[]>;
+}
+
+/** Which catalog dialect this run can interrogate, and how to reach it. */
+type CatalogAccess =
+    | { kind: 'sqlserver' }
+    | { kind: 'postgresql'; run: <T>(query: string) => Promise<T[]> };
+
+/**
+ * How this run reaches the physical catalog, or null when it cannot.
+ *
+ * SQL Server keeps its original `ctx.Pool` + `sys.*` path untouched. PostgreSQL goes through the
+ * provider's `ExecuteSQL` against `pg_catalog`, so LBV2-LBV5 assert on PG rather than skipping.
+ *
+ * That they skipped was not a cosmetic gap: a skipped check still scored 1.0 and counted as
+ * passed, so IT69 reported 6/6 / 100% on PostgreSQL while only LBV1 and LBV6 ran - including
+ * LBV5, which is precisely the silent-staleness failure PostgreSQL has and SQL Server does not.
+ */
+function catalogAccess(ctx: IntegrationCheckContext): CatalogAccess | null {
+    if (ctx.Pool) {
+        return { kind: 'sqlserver' };
+    }
+    const provider = ctx.Provider as unknown as CatalogQueryProvider;
+    if (provider?.PlatformKey === 'postgresql' && typeof provider.ExecuteSQL === 'function') {
+        const execute = provider.ExecuteSQL.bind(provider);
+        return { kind: 'postgresql', run: execute };
+    }
+    return null;
+}
+
+/**
+ * The layered entities, or null when this run genuinely cannot reach any catalog.
+ *
+ * The skip is logged with the provider name so a green result is never mistaken for a real one.
  */
 function catalogOrSkip(ctx: IntegrationCheckContext, checkId: string): EntityInfo[] | null {
-    if (!ctx.Pool) {
+    if (!catalogAccess(ctx)) {
         const providerName = ctx.Provider?.constructor?.name ?? 'unknown';
-        console.log(`      → ${checkId} SKIPPED (no assertions ran): no mssql pool on this run path (provider '${providerName}') — catalog inspection unavailable`);
+        console.log(`      → ${checkId} SKIPPED (no assertions ran): no catalog access on this run path (provider '${providerName}')`);
         return null;
     }
     return requireLayered(ctx);
 }
 
+/** Single-quote escape for an identifier interpolated into a catalog query as a literal. */
+function sqlLiteral(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
 /** Physical column names for a view, lowercased. Empty set when the object does not exist. */
 async function viewColumns(ctx: IntegrationCheckContext, schema: string, view: string): Promise<Set<string>> {
+    const access = catalogAccess(ctx);
+    if (access?.kind === 'postgresql') {
+        const rows = await access.run<{ name: string }>(
+            `SELECT a.attname AS "name"
+               FROM pg_attribute a
+               JOIN pg_class c ON c.oid = a.attrelid
+               JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname = '${sqlLiteral(schema)}'
+                AND c.relname = '${sqlLiteral(view)}'
+                AND a.attnum > 0
+                AND NOT a.attisdropped`
+        );
+        return new Set(rows.map(r => String(r.name).toLowerCase()));
+    }
     const result = await ctx.Pool!.request().query(
         `SELECT c.name FROM sys.columns c
          WHERE c.object_id = OBJECT_ID('[${schema}].[${view}]')`
@@ -88,8 +149,22 @@ async function viewColumns(ctx: IntegrationCheckContext, schema: string, view: s
     return new Set(result.recordset.map((r: { name: string }) => r.name.toLowerCase()));
 }
 
-/** The SQL text of a view, or null when it does not exist. */
+/**
+ * The SQL text of a view, or null when it does not exist.
+ *
+ * PostgreSQL uses `pg_get_viewdef`, not `information_schema.views`: the latter is portable but
+ * SQL Server truncates `VIEW_DEFINITION` at 4000 characters, and the FROM clause LBV3 looks for
+ * sits at the end of the definition - exactly what truncation would drop.
+ */
 async function viewDefinition(ctx: IntegrationCheckContext, schema: string, view: string): Promise<string | null> {
+    const access = catalogAccess(ctx);
+    if (access?.kind === 'postgresql') {
+        const rows = await access.run<{ definition: string | null }>(
+            `SELECT pg_get_viewdef(to_regclass('"${schema.replace(/"/g, '""')}"."${view.replace(/"/g, '""')}"'), true) AS "definition"`
+        );
+        const definition = rows.length > 0 ? rows[0].definition : null;
+        return definition ? String(definition) : null;
+    }
     const result = await ctx.Pool!.request().query(
         `SELECT m.definition FROM sys.sql_modules m
          WHERE m.object_id = OBJECT_ID('[${schema}].[${view}]')`
@@ -171,7 +246,7 @@ export const LayeredBaseViewChecks: NamedCheck[] = [
                 // The generated view selects from the BASE TABLE. If the outer view did too, CodeGen
                 // has replaced the wrapper with a generated view under the public name — hand-written
                 // SQL destroyed, and nothing would error until somebody looked.
-                const outerSelectsBaseTable = new RegExp(`\\[${e.BaseTable}\\]|\\b${e.BaseTable}\\b\\s+AS\\b`, 'i').test(outer!);
+                const outerSelectsBaseTable = new RegExp(`\\[${e.BaseTable}\\]|"${e.BaseTable}"|\\b${e.BaseTable}\\b\\s+AS\\b`, 'i').test(outer!);
                 Assert(!outerSelectsBaseTable || outer!.toLowerCase().includes(e.GeneratedViewName.toLowerCase()),
                     `${e.Name}: outer view [${e.BaseView}] reads the base table directly and does not reference the inner view — it looks like CodeGen overwrote the application's wrapper`);
                 Assert(inner!.toLowerCase().includes(e.BaseTable.toLowerCase()),


### PR DESCRIPTION
## Summary

Layered base views were enabled on PostgreSQL in 647bd710fe. Testing that end-to-end against a fresh PG database found the **CodeGen path works**, but the SQL function the same migration ships could never run, and the integration bundle that should have caught it reported a green 100%.

Two fixes:

1. **`spRebindLayeredOuterView` was dead on arrival** — and once revived, still produced invalid SQL.
2. **IT69's LBV2–LBV5 silently skipped on PostgreSQL** while still scoring as passed.

## 1. The function could never restar a view

`V202608252000` shipped it with two defects, the first masking the second.

**Undeclared variable.** The already-starred branch assigns `v_starred := true;`, but `v_starred` is never declared — it appears exactly once in the file, as that assignment. PL/pgSQL compiles the *whole* body on first invocation, so the branch is irrelevant: **every call failed.**

```
ERROR:  "v_starred" is not a known variable
CONTEXT: compilation of PL/pgSQL function "spRebindLayeredOuterView" near line 150
```

PostgreSQL validates a plpgsql body only at execution, never at `CREATE FUNCTION`, so the migration applied green and the function died on first use.

The blast radius reached production: [`open-app-metadata-refresh.ts`](packages/OpenApp/Engine/src/install/open-app-metadata-refresh.ts) issues `spRebindLayeredOuterViewsInSchema` **first** in a joined batch, so the batch aborted and every field-heal statement behind it — `AllowsNull`, orphan prune, `Sequence` heal — never ran.

**Whitespace trimming.** Removing the dead write exposed the real bug. Single-argument `btrim()` strips **spaces only**, and `pg_get_viewdef(oid, true)` pretty-prints, so every SELECT item after the first arrives with a leading newline. The consumption loop `EXIT`s on the first non-matching item, so it consumed exactly one column and treated all the rest as application extras:

```sql
CREATE VIEW ... AS SELECT g.*, "MajorVersion", "MinorVersion", ...
-- ERROR: column "MajorVersion" specified more than once
```

Every trim over deparsed SQL now passes an explicit whitespace set. The TypeScript reference `restarLayeredOuterView()` uses `.trim()` and was never affected — which is exactly why the CodeGen path worked while this one could not.

**Shipped as a new migration**, not an edit to `V202608252000`: that file is already applied wherever it has run, and Skyway skips an applied version (confirmed — it does not validate checksums), so an in-place edit would repair fresh installs only and leave existing databases holding the broken function. `CREATE OR REPLACE FUNCTION` repairs both.

## 2. IT69 reported a false 100% on PostgreSQL

LBV2–LBV5 query `sys.columns` / `sys.sql_modules` and skipped without an mssql pool — but **a skipped check still scores 1.0 and counts as passed**, so the bundle reported 6/6 / 100% while only LBV1 and LBV6 ran. LBV5 was among the silent ones, and it is the check for the exact failure mode PostgreSQL has and SQL Server does not: PG freezes `g.*` at `CREATE VIEW`, so an outer view can silently stop inheriting new inner columns.

It reported a green 100% with the broken function sitting in the same database.

SQL Server keeps its existing `ctx.Pool` path untouched. PostgreSQL reads `pg_catalog` through the provider's `ExecuteSQL` seam — the same one `UserCache` already uses to serve both platforms from one code path.

## Verification

Fresh `postgres:17`, built from migrations → `mj sync push` → `mj codegen`.

| | Before | After |
|---|---|---|
| `spRebindLayeredOuterView` | `ERROR: "v_starred" is not a known variable` | executes |
| `spRebindLayeredOuterViewsInSchema` | same error | executes |
| Drift an inner view, then rebind | n/a — could not run | outer gains the column |
| App extra (`CompleteVersion`) + 3 CRUD fns after DROP CASCADE | n/a | preserved / restored |
| Open App refresh batch | **exit 3**, `UPDATE` never ran | **exit 0**, `UPDATE` ran |
| IT69 on PG | 6/6, 100% — **4 checks skipped** | 6/6, **0 skipped** |
| IT69 with real drift injected | still 6/6 / 100% PASS | **LBV5 red, 0.8333, TEST_FAIL** |

That last row is the point: the check now tracks reality. Round trip verified green → drift → red → rebind → green.

Test suites: integration-test-suite 200 ✅ · SQLDialect 7 ✅ · CodeGenLib PG provider 105 ✅ · MJCore layered-view 12 ✅

## Notes for reviewers

- **Not included:** PG counterparts for the four v6 migrations added after `edge.3`. Those are release-time build-engineer work per `pg-migrations.yml`, not feature-PR work.
- **Related but separate:** `fix/pg-layered-view-silent-skip` fixes `vwEntities` not exposing `GeneratedBaseViewName` on PG — different file, no conflict.
- **Suggested follow-up:** nothing executes the plpgsql shipped by migrations; the only tests naming this function assert `expect(sql).toContain('spRebindLayeredOuterView')`. That string-containment coverage is what let both defects through, and it would be worth a check that actually invokes it.
- Doc nit spotted separately: `PG_MANUAL_FIXES_CATALOG.md` §B1 claims the baseline creates the `cdp_*` roles and that no bootstrap is needed; neither is true of the current v5.46 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)