### PR TITLE
chore: refresh pnpm-lock.yaml for OpenApp/Engine mssql + pg (unblocks all CI)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12940,6 +12940,12 @@ importers:
       '@memberjunction/skyway-sqlserver':
         specifier: ^0.6.2
         version: 0.6.2
+      mssql:
+        specifier: ^11.0.1
+        version: 11.0.1
+      pg:
+        specifier: ^8.13.1
+        version: 8.18.0
 
   packages/PostgreSQLDataProvider:
     dependencies:


### PR DESCRIPTION
## The problem

`d90a3ea456` added `mssql@^11.0.1` and `pg@^8.13.1` to `packages/OpenApp/Engine/package.json` without regenerating the lockfile. The importer entry for that package lists eight dependencies and neither of those two.

**Every CI job that runs `pnpm install --frozen-lockfile` fails at the install step**, before executing anything:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/OpenApp/Engine/package.json
* 2 dependencies were added: mssql@^11.0.1, pg@^8.13.1
```

This blocks **all** PRs against `next`, not one. On #4052 it took out five checks — Run unit tests, adopted standards, Detect missing and unused dependencies, Integration (SQL Server, deterministic), and PG migration validation — none of which reached a line of that PR's code.

## The fix

`pnpm install --lockfile-only`. The diff is 6 lines: the two missing resolutions in the `packages/OpenApp/Engine` importer. No version churn anywhere else.

```
+      mssql:
+        specifier: ^11.0.1
+        version: 11.0.1
+      pg:
+        specifier: ^8.13.1
+        version: 8.18.0
```

## Verification

Ran CI's exact command locally against this branch:

| | Before | After |
|---|---|---|
| `pnpm install --frozen-lockfile --ignore-scripts` | exit **1**, `ERR_PNPM_OUTDATED_LOCKFILE` | exit **0** |

## Why it went unnoticed

The gate most likely to have caught it — PG migration validation — only triggers on `migrations-pg/**`, so it rarely runs. The drift surfaced when a migration change finally tripped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)