### PR TITLE
fix(ci): MJAPI tests must not depend on whether some other job built the package

### DIFF
--- a/packages/MJAPI/package.json
+++ b/packages/MJAPI/package.json
@@ -10,8 +10,9 @@
     "check-types": "tsc -noEmit",
     "zip": "zip -qr deploy.zip ./node_modules ./dist ./package.json ./config.json",
     "prestart": "mj codegen manifest --exclude-packages @memberjunction --output ./src/generated/class-registrations-manifest.ts",
-    "prebuild": "mj codegen manifest --exclude-packages @memberjunction --output ./src/generated/class-registrations-manifest.ts || echo 'Warning: mj codegen manifest not available, using existing manifest'",
+    "prebuild": "mj codegen manifest --exclude-packages @memberjunction --output ./src/generated/class-registrations-manifest.ts || echo 'Warning: mj codegen manifest not available'; node ./scripts/ensure-manifest.mjs",
     "build": "tsc && tsc-alias -f",
+    "pretest": "node ./scripts/ensure-manifest.mjs",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/MJAPI/scripts/ensure-manifest.mjs
+++ b/packages/MJAPI/scripts/ensure-manifest.mjs
@@ -1,0 +1,59 @@
+/**
+ * Guarantees `src/generated/class-registrations-manifest.ts` exists.
+ *
+ * The manifest is gitignored and produced by `mj codegen manifest`, which needs the workspace's
+ * built dists to resolve the dependency tree it scans. That makes it unavailable in two ordinary
+ * situations: a fresh checkout that has not built yet, and a CI job whose FILTERED build did not
+ * include this package (or the packages the generator reads). `src/index.ts` imports the manifest
+ * unconditionally, so when it is absent the import fails and every MJAPI test errors on a file
+ * that was never anyone's responsibility to create.
+ *
+ * The generator's own fallback — `|| echo 'using existing manifest'` — assumes an existing file,
+ * which is exactly the assumption a fresh checkout breaks. This closes that: if the generator did
+ * not produce one, write the empty manifest, which is a CORRECT manifest rather than a placeholder.
+ * The array is legitimately empty here because `--exclude-packages @memberjunction` excludes every
+ * package in this repo, so a real run emits the same shape. A later real run overwrites it.
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const target = resolve(here, '../src/generated/class-registrations-manifest.ts');
+
+if (existsSync(target)) {
+    process.exit(0);
+}
+
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(
+    target,
+    `/**
+ * AUTO-GENERATED FILE - DO NOT EDIT
+ * Written by scripts/ensure-manifest.mjs because 'mj codegen manifest' could not run
+ * (no built workspace dists — a fresh checkout, or a filtered CI build that skipped them).
+ *
+ * Empty is the CORRECT content here, not a placeholder: the generator is invoked with
+ * --exclude-packages @memberjunction, which excludes every package in this repository, so a
+ * real run emits this same empty array. A later real run overwrites this file.
+ */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+/**
+ * Runtime references to every @RegisterClass decorated class.
+ * This array creates a static code path the bundler cannot tree-shake.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const CLASS_REGISTRATIONS: any[] = [
+];
+
+/** Marker constant indicating the manifest has been loaded. */
+export const CLASS_REGISTRATIONS_MANIFEST_LOADED = true;
+
+/** Total @RegisterClass decorated classes discovered in dependency tree */
+export const CLASS_REGISTRATIONS_COUNT = 0;
+`,
+    'utf8'
+);
+console.log('[ensure-manifest] wrote the empty class-registrations manifest (generator unavailable).');


### PR DESCRIPTION
## The failure

A unit-test shard fails on a file nobody was responsible for creating:

```
Cannot find module './generated/class-registrations-manifest.js'
  imported from packages/MJAPI/src/index.ts:17
AssertionError: expected false to be true   (bootstrap.test.ts:40)
```

Both are the same cause — `index.ts` cannot import, so the bootstrap assertion is false.

## Why it happens, and why it looks intermittent

`packages/MJAPI/src/generated/class-registrations-manifest.ts` is **gitignored** and produced by `mj codegen manifest` in MJAPI's `prebuild`. `src/index.ts` imports it unconditionally. There is no `pretest`, so `test` is a bare `vitest run` — the manifest exists in a shard only if the **build** job happened to build MJAPI and ship it in the `generated-host-artifacts` tarball.

The build job runs a filtered build:

```
PR scope — affected packages + dependents: --filter=...[origin/next]
```

A PR that touches neither MJAPI nor anything it depends on leaves `mj_api` out of the affected set. Its `prebuild` never runs, the tarball's packaging step finds no `packages/MJAPI/src/generated` directory to include, and the shard that runs MJAPI's tests then runs them against a file that was never generated. The packaging step even names this case in its own log line — *"this build did not run the root postbuild (filtered path)"* — but nothing downstream acts on it.

So it is not flaky. **Any sufficiently narrow PR reproduces it deterministically**, which is exactly what it looks like from the outside: green on wide PRs, red on small ones, red again on re-run.

## Why `prebuild`'s existing fallback does not cover it

```
mj codegen manifest ... || echo 'Warning: mj codegen manifest not available, using existing manifest'
```

"Using existing manifest" assumes a file that a fresh checkout does not have. The generator also needs the workspace's built dists to resolve the dependency tree it scans, so on a filtered build it can fail for the same reason MJAPI was skipped — and the fallback then swallows that into a warning while leaving nothing behind.

## The change

`scripts/ensure-manifest.mjs` — if the manifest is absent, write the **empty** one.

Empty is the *correct* content here, not a placeholder. The generator is invoked with `--exclude-packages @memberjunction`, which excludes every package in this repository, so a real run emits the same shape — the current checked-out manifest says `0 packages contain @RegisterClass` and `CLASS_REGISTRATIONS: any[] = []`. A later real run overwrites it, and the script exits immediately when a file already exists, so it can never clobber a generated one.

Wired two ways:

- **`pretest`** — the tests now generate what they import, instead of depending on whether another job built this package.
- **appended to `prebuild`** — so the fallback guarantees a file rather than assuming one.

MJExplorer has the same generated-manifest pattern but `test` is `echo "No tests configured yet"`, so it is unaffected and left alone.

## Verification

Deleted `src/generated/class-registrations-manifest.ts` — the exact state a shard sees — and ran MJAPI's tests:

```
> node ./scripts/ensure-manifest.mjs
[ensure-manifest] wrote the empty class-registrations manifest (generator unavailable).
 Test Files  2 passed (2)
      Tests  5 passed (5)
```

That state previously produced the failure above.

No changeset: `mj_api` is a private package and is not published.
