### PR TITLE
feat(codegen): IncludedSchemaNames heal scope and intra-schema cascades

### DIFF
--- a/.changeset/quiet-lenses-heal.md
+++ b/.changeset/quiet-lenses-heal.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/core": minor
+"@memberjunction/codegen-lib": patch
+---
+
+Add optional `@IncludedSchemaNames` to CodeGen metadata-heal stored procedures so Open App migrations can positively scope heals without photographing sibling apps. Cascade-delete SQL is intra-schema only unless `allowCrossSchemaCascadeDeletes` is set. Custom-view `sp_refreshview` in the migration log honors `excludeSchemas` and, when set, `includeSchemas`.

--- a/migrations/v6/V202608260829__v6.1.x__Heal_SPs_IncludedSchemaNames.sql
+++ b/migrations/v6/V202608260829__v6.1.x__Heal_SPs_IncludedSchemaNames.sql
@@ -1,0 +1,502 @@
+-- Optional @IncludedSchemaNames on CodeGen metadata-heal stored procedures.
+--
+-- These procs historically take only @ExcludedSchemaNames (a negative list). Open App
+-- CodeGen compiles includeSchemas into that list from whoever is installed on the
+-- publisher database, then logs the EXEC into a versioned migration. The compiled
+-- list names consumer apps (Orders inside Common, etc.) and is incomplete on a host
+-- with extra schemas.
+--
+-- @IncludedSchemaNames is a positive filter, default NULL = today's behavior.
+-- When non-empty, work is limited to those schemas AND still minus @ExcludedSchemaNames.
+-- Existing callers that omit the new parameter are unchanged.
+--
+-- CodeGen, when includeSchemas is set, now emits authored excludes (sys,staging,…)
+-- plus @IncludedSchemaNames for this app's schema — never a sibling snapshot.
+--
+-- Latest bodies reproduced from:
+--   spDeleteUnneededEntityFields          V202607031201
+--   spUpdateExistingEntityFieldsFromSchema V202605281538
+--   spUpdateExistingEntitiesFromSchema     V202507040917
+--   spSetDefaultColumnWidthWhereNeeded     V202407171600
+--   spUpdateSchemaInfoFromDatabase         V202606301331
+
+-- =============================================================================
+-- spDeleteUnneededEntityFields
+-- =============================================================================
+CREATE OR ALTER PROC [${flyway:defaultSchema}].[spDeleteUnneededEntityFields]
+    @ExcludedSchemaNames NVARCHAR(MAX),
+    @EntityIDs NVARCHAR(MAX) = NULL,
+    @IncludedSchemaNames NVARCHAR(MAX) = NULL
+AS
+SET NOCOUNT ON;
+
+IF OBJECT_ID('tempdb..#ef_spDeleteUnneededEntityFields') IS NOT NULL
+    DROP TABLE #ef_spDeleteUnneededEntityFields
+IF OBJECT_ID('tempdb..#actual_spDeleteUnneededEntityFields') IS NOT NULL
+    DROP TABLE #actual_spDeleteUnneededEntityFields
+IF OBJECT_ID('tempdb..#DeletedFields') IS NOT NULL
+    DROP TABLE #DeletedFields
+
+DECLARE @ScopedEntityIDs TABLE (EntityID UNIQUEIDENTIFIER PRIMARY KEY);
+DECLARE @IsScoped BIT = 0;
+IF @EntityIDs IS NOT NULL AND LEN(@EntityIDs) > 0
+BEGIN
+    INSERT INTO @ScopedEntityIDs (EntityID)
+    SELECT DISTINCT TRY_CONVERT(UNIQUEIDENTIFIER, LTRIM(RTRIM(value)))
+    FROM STRING_SPLIT(@EntityIDs, ',')
+    WHERE LTRIM(RTRIM(value)) <> ''
+      AND TRY_CONVERT(UNIQUEIDENTIFIER, LTRIM(RTRIM(value))) IS NOT NULL;
+    IF EXISTS (SELECT 1 FROM @ScopedEntityIDs) SET @IsScoped = 1;
+END
+
+DECLARE @IncludedSchemas TABLE (SchemaName NVARCHAR(255) PRIMARY KEY);
+DECLARE @HasInclude BIT = 0;
+IF @IncludedSchemaNames IS NOT NULL AND LEN(LTRIM(RTRIM(@IncludedSchemaNames))) > 0
+BEGIN
+    INSERT INTO @IncludedSchemas (SchemaName)
+    SELECT DISTINCT TRIM(value)
+    FROM STRING_SPLIT(@IncludedSchemaNames, ',')
+    WHERE TRIM(value) <> '';
+    IF EXISTS (SELECT 1 FROM @IncludedSchemas) SET @HasInclude = 1;
+END
+
+SELECT
+    ef.*
+INTO
+    #ef_spDeleteUnneededEntityFields
+FROM
+    vwEntityFields ef
+INNER JOIN
+    vwEntities e
+ON
+    ef.EntityID = e.ID
+LEFT JOIN
+    STRING_SPLIT(@ExcludedSchemaNames, ',') AS excludedSchemas
+ON
+    e.SchemaName = excludedSchemas.value
+WHERE
+    e.VirtualEntity = 0 AND
+    e.ExternalDataSourceID IS NULL AND
+    excludedSchemas.value IS NULL AND
+    (@HasInclude = 0 OR e.SchemaName IN (SELECT SchemaName FROM @IncludedSchemas)) AND
+    (@IsScoped = 0 OR ef.EntityID IN (SELECT EntityID FROM @ScopedEntityIDs))
+
+SELECT *
+INTO #actual_spDeleteUnneededEntityFields
+FROM vwSQLColumnsAndEntityFields
+WHERE @IsScoped = 0 OR EntityID IN (SELECT EntityID FROM @ScopedEntityIDs)
+
+SELECT ef.* INTO #DeletedFields
+    FROM
+      #ef_spDeleteUnneededEntityFields ef
+    LEFT JOIN
+      #actual_spDeleteUnneededEntityFields actual
+      ON
+      ef.EntityID=actual.EntityID AND
+      ef.Name = actual.EntityFieldName
+    WHERE
+      actual.column_id IS NULL
+
+UPDATE ${flyway:defaultSchema}.Entity SET __mj_UpdatedAt=GETUTCDATE() WHERE ID IN
+(
+  SELECT DISTINCT EntityID FROM #DeletedFields
+)
+
+DELETE FROM ${flyway:defaultSchema}.EntityFieldValue WHERE EntityFieldID IN (
+  SELECT ID FROM #DeletedFields
+)
+
+DELETE FROM ${flyway:defaultSchema}.EntityField WHERE ID IN
+(
+  SELECT ID FROM #DeletedFields
+)
+
+SELECT * FROM #DeletedFields
+
+DROP TABLE #ef_spDeleteUnneededEntityFields
+DROP TABLE #actual_spDeleteUnneededEntityFields
+DROP TABLE #DeletedFields
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spDeleteUnneededEntityFields] TO [cdp_Developer], [cdp_Integration]
+GO
+
+-- =============================================================================
+-- spUpdateExistingEntityFieldsFromSchema
+-- =============================================================================
+CREATE OR ALTER PROC [${flyway:defaultSchema}].[spUpdateExistingEntityFieldsFromSchema]
+    @ExcludedSchemaNames NVARCHAR(MAX),
+    @EntityIDs NVARCHAR(MAX) = NULL,
+    @IncludedSchemaNames NVARCHAR(MAX) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @ExcludedSchemas TABLE (SchemaName NVARCHAR(255));
+    INSERT INTO @ExcludedSchemas(SchemaName)
+    SELECT TRIM(value) FROM STRING_SPLIT(@ExcludedSchemaNames, ',');
+
+    DECLARE @ScopedEntityIDs TABLE (EntityID UNIQUEIDENTIFIER PRIMARY KEY);
+    DECLARE @IsScoped BIT = 0;
+    IF @EntityIDs IS NOT NULL AND LEN(@EntityIDs) > 0
+    BEGIN
+        INSERT INTO @ScopedEntityIDs (EntityID)
+        SELECT DISTINCT TRY_CONVERT(UNIQUEIDENTIFIER, LTRIM(RTRIM(value)))
+        FROM STRING_SPLIT(@EntityIDs, ',')
+        WHERE LTRIM(RTRIM(value)) <> ''
+          AND TRY_CONVERT(UNIQUEIDENTIFIER, LTRIM(RTRIM(value))) IS NOT NULL;
+        IF EXISTS (SELECT 1 FROM @ScopedEntityIDs) SET @IsScoped = 1;
+    END
+
+    DECLARE @IncludedSchemas TABLE (SchemaName NVARCHAR(255) PRIMARY KEY);
+    DECLARE @HasInclude BIT = 0;
+    IF @IncludedSchemaNames IS NOT NULL AND LEN(LTRIM(RTRIM(@IncludedSchemaNames))) > 0
+    BEGIN
+        INSERT INTO @IncludedSchemas (SchemaName)
+        SELECT DISTINCT TRIM(value)
+        FROM STRING_SPLIT(@IncludedSchemaNames, ',')
+        WHERE TRIM(value) <> '';
+        IF EXISTS (SELECT 1 FROM @IncludedSchemas) SET @HasInclude = 1;
+    END
+
+    DECLARE @FilteredRows TABLE (
+        EntityID UNIQUEIDENTIFIER,
+        EntityName NVARCHAR(500),
+        EntityFieldID UNIQUEIDENTIFIER,
+        EntityFieldName NVARCHAR(500),
+        AutoUpdateDescription BIT,
+        ExistingDescription NVARCHAR(MAX),
+        SQLDescription NVARCHAR(MAX),
+        Type NVARCHAR(255),
+        Length INT,
+        Precision INT,
+        Scale INT,
+        AllowsNull BIT,
+        DefaultValue NVARCHAR(MAX),
+        AutoIncrement BIT,
+        IsVirtual BIT,
+        IsComputed BIT,
+        Sequence INT,
+        RelatedEntityID UNIQUEIDENTIFIER,
+        RelatedEntityFieldName NVARCHAR(255),
+        IsPrimaryKey BIT,
+        IsUnique BIT
+    );
+
+    INSERT INTO @FilteredRows
+    SELECT
+        e.ID as EntityID,
+        e.Name as EntityName,
+        ef.ID AS EntityFieldID,
+        ef.Name as EntityFieldName,
+        ef.AutoUpdateDescription,
+        ef.Description AS ExistingDescription,
+        CONVERT(nvarchar(max),fromSQL.Description) AS SQLDescription,
+        fromSQL.Type,
+        fromSQL.Length,
+        fromSQL.Precision,
+        fromSQL.Scale,
+        fromSQL.AllowsNull,
+        CONVERT(nvarchar(max),fromSQL.DefaultValue),
+        fromSQL.AutoIncrement,
+        fromSQL.IsVirtual,
+        fromSQL.IsComputed,
+        fromSQL.Sequence,
+        re.ID AS RelatedEntityID,
+        fk.referenced_column AS RelatedEntityFieldName,
+        CASE WHEN pk.ColumnName IS NOT NULL THEN 1 ELSE 0 END AS IsPrimaryKey,
+        CASE
+            WHEN pk.ColumnName IS NOT NULL THEN 1
+            ELSE CASE WHEN uk.ColumnName IS NOT NULL THEN 1 ELSE 0 END
+        END AS IsUnique
+    FROM
+        [${flyway:defaultSchema}].EntityField ef
+    INNER JOIN
+        vwSQLColumnsAndEntityFields fromSQL
+        ON ef.EntityID = fromSQL.EntityID AND ef.Name = fromSQL.FieldName
+    INNER JOIN
+        [${flyway:defaultSchema}].Entity e ON ef.EntityID = e.ID
+    LEFT OUTER JOIN
+        vwForeignKeys fk
+        ON ef.Name = fk.[column]
+           AND e.BaseTable = fk.[table]
+           AND e.SchemaName = fk.[schema_name]
+    LEFT OUTER JOIN
+        [${flyway:defaultSchema}].Entity re
+        ON re.BaseTable = fk.referenced_table AND re.SchemaName = fk.[referenced_schema]
+    LEFT OUTER JOIN
+        [${flyway:defaultSchema}].vwTablePrimaryKeys pk
+        ON e.BaseTable = pk.TableName AND ef.Name = pk.ColumnName AND e.SchemaName = pk.SchemaName
+    LEFT OUTER JOIN
+        [${flyway:defaultSchema}].vwTableUniqueKeys uk
+        ON e.BaseTable = uk.TableName AND ef.Name = uk.ColumnName AND e.SchemaName = uk.SchemaName
+    LEFT OUTER JOIN
+        @ExcludedSchemas excludedSchemas ON e.SchemaName = excludedSchemas.SchemaName
+    WHERE
+        e.VirtualEntity = 0
+        AND excludedSchemas.SchemaName IS NULL
+        AND ef.ID IS NOT NULL
+        AND (@HasInclude = 0 OR e.SchemaName IN (SELECT SchemaName FROM @IncludedSchemas))
+        AND (@IsScoped = 0 OR e.ID IN (SELECT EntityID FROM @ScopedEntityIDs))
+        AND (
+          ISNULL(LTRIM(RTRIM(ef.Description)), '') <> ISNULL(LTRIM(RTRIM(IIF(ef.AutoUpdateDescription=1, CONVERT(NVARCHAR(MAX), fromSQL.Description), ef.Description))), '') OR
+          ef.Type <> fromSQL.Type OR
+          ef.Length <> fromSQL.Length OR
+          ef.Precision <> fromSQL.Precision OR
+          ef.Scale <> fromSQL.Scale OR
+          ef.AllowsNull <> fromSQL.AllowsNull OR
+          ISNULL(LTRIM(RTRIM(ef.DefaultValue)), '') <> ISNULL(LTRIM(RTRIM(CONVERT(NVARCHAR(MAX), fromSQL.DefaultValue))), '') OR
+          ef.AutoIncrement <> fromSQL.AutoIncrement OR
+          ef.IsVirtual <> fromSQL.IsVirtual OR
+          ef.IsComputed <> fromSQL.IsComputed OR
+          ef.Sequence <> fromSQL.Sequence OR
+          ISNULL(TRY_CONVERT(UNIQUEIDENTIFIER, ef.RelatedEntityID), '00000000-0000-0000-0000-000000000000') <> ISNULL(TRY_CONVERT(UNIQUEIDENTIFIER, re.ID), '00000000-0000-0000-0000-000000000000') OR
+          ISNULL(LTRIM(RTRIM(ef.RelatedEntityFieldName)), '') <> ISNULL(LTRIM(RTRIM(fk.referenced_column)), '') OR
+          ef.IsPrimaryKey <> CASE WHEN pk.ColumnName IS NOT NULL THEN 1 ELSE 0 END OR
+          ef.IsUnique <> CASE
+              WHEN pk.ColumnName IS NOT NULL THEN 1
+              ELSE CASE WHEN uk.ColumnName IS NOT NULL THEN 1 ELSE 0 END
+          END OR
+          (ef.AllowUpdateAPI = 1 AND fromSQL.IsVirtual = 1 AND ef.IsVirtual = 0)
+        );
+
+    UPDATE ef
+    SET
+        ef.Description = IIF(fr.AutoUpdateDescription=1, fr.SQLDescription, ef.Description),
+        ef.Type = fr.Type,
+        ef.Length = fr.Length,
+        ef.Precision = fr.Precision,
+        ef.Scale = fr.Scale,
+        ef.AllowsNull = fr.AllowsNull,
+        ef.DefaultValue = fr.DefaultValue,
+        ef.AutoIncrement = fr.AutoIncrement,
+        ef.IsVirtual = fr.IsVirtual,
+        ef.IsComputed = fr.IsComputed,
+        ef.Sequence = fr.Sequence,
+        ef.RelatedEntityID = IIF(ef.AutoUpdateRelatedEntityInfo = 1, fr.RelatedEntityID, ef.RelatedEntityID),
+        ef.RelatedEntityFieldName = IIF(ef.AutoUpdateRelatedEntityInfo = 1, fr.RelatedEntityFieldName, ef.RelatedEntityFieldName),
+        ef.IsPrimaryKey = fr.IsPrimaryKey,
+        ef.IsUnique = fr.IsUnique,
+        ef.AllowUpdateAPI = IIF(fr.IsVirtual = 1 AND ef.IsVirtual = 0, 0, ef.AllowUpdateAPI),
+        ef.__mj_UpdatedAt = GETUTCDATE()
+    FROM
+        [${flyway:defaultSchema}].EntityField ef
+    INNER JOIN
+        @FilteredRows fr ON ef.ID = fr.EntityFieldID;
+
+    SELECT * FROM @FilteredRows;
+END;
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateExistingEntityFieldsFromSchema] TO [cdp_Developer], [cdp_Integration]
+GO
+
+-- =============================================================================
+-- spUpdateExistingEntitiesFromSchema
+-- =============================================================================
+CREATE OR ALTER PROCEDURE [${flyway:defaultSchema}].spUpdateExistingEntitiesFromSchema
+    @ExcludedSchemaNames NVARCHAR(MAX),
+    @IncludedSchemaNames NVARCHAR(MAX) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @IncludedSchemas TABLE (SchemaName NVARCHAR(255) PRIMARY KEY);
+    DECLARE @HasInclude BIT = 0;
+    IF @IncludedSchemaNames IS NOT NULL AND LEN(LTRIM(RTRIM(@IncludedSchemaNames))) > 0
+    BEGIN
+        INSERT INTO @IncludedSchemas (SchemaName)
+        SELECT DISTINCT TRIM(value)
+        FROM STRING_SPLIT(@IncludedSchemaNames, ',')
+        WHERE TRIM(value) <> '';
+        IF EXISTS (SELECT 1 FROM @IncludedSchemas) SET @HasInclude = 1;
+    END
+
+    DECLARE @FilteredRows TABLE (
+        ID UNIQUEIDENTIFIER,
+        Name NVARCHAR(500),
+        CurrentDescription NVARCHAR(MAX),
+        NewDescription NVARCHAR(MAX),
+        EntityDescription NVARCHAR(MAX),
+        SchemaName NVARCHAR(MAX)
+    );
+
+    INSERT INTO @FilteredRows
+        SELECT
+            e.ID,
+            e.Name,
+            e.Description AS CurrentDescription,
+            IIF(e.AutoUpdateDescription = 1, CONVERT(NVARCHAR(MAX), fromSQL.EntityDescription), e.Description) AS NewDescription,
+            CONVERT(NVARCHAR(MAX),fromSQL.EntityDescription),
+            CONVERT(NVARCHAR(MAX),fromSQL.SchemaName)
+        FROM
+            [${flyway:defaultSchema}].[Entity] e
+        INNER JOIN
+            [${flyway:defaultSchema}].[vwSQLTablesAndEntities] fromSQL
+        ON
+            e.ID = fromSQL.EntityID
+        LEFT JOIN
+            STRING_SPLIT(@ExcludedSchemaNames, ',') AS excludedSchemas
+        ON
+            fromSQL.SchemaName = excludedSchemas.value
+        WHERE
+            e.VirtualEntity = 0
+            AND excludedSchemas.value IS NULL
+            AND (@HasInclude = 0 OR fromSQL.SchemaName IN (SELECT SchemaName FROM @IncludedSchemas))
+            AND ISNULL(IIF(e.AutoUpdateDescription = 1, CONVERT(NVARCHAR(MAX), fromSQL.EntityDescription), e.Description),'') <> ISNULL(e.Description,'')
+
+    UPDATE e
+    SET
+        Description = fr.NewDescription
+    FROM
+        [${flyway:defaultSchema}].[Entity] e
+    INNER JOIN
+        @FilteredRows fr
+    ON
+        e.ID = fr.ID;
+
+    SELECT * FROM @FilteredRows;
+END;
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateExistingEntitiesFromSchema] TO [cdp_Developer], [cdp_Integration]
+GO
+
+-- =============================================================================
+-- spSetDefaultColumnWidthWhereNeeded
+-- =============================================================================
+CREATE OR ALTER PROC [${flyway:defaultSchema}].[spSetDefaultColumnWidthWhereNeeded]
+    @ExcludedSchemaNames NVARCHAR(MAX),
+    @IncludedSchemaNames NVARCHAR(MAX) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @IncludedSchemas TABLE (SchemaName NVARCHAR(255) PRIMARY KEY);
+    DECLARE @HasInclude BIT = 0;
+    IF @IncludedSchemaNames IS NOT NULL AND LEN(LTRIM(RTRIM(@IncludedSchemaNames))) > 0
+    BEGIN
+        INSERT INTO @IncludedSchemas (SchemaName)
+        SELECT DISTINCT TRIM(value)
+        FROM STRING_SPLIT(@IncludedSchemaNames, ',')
+        WHERE TRIM(value) <> '';
+        IF EXISTS (SELECT 1 FROM @IncludedSchemas) SET @HasInclude = 1;
+    END
+
+    UPDATE
+        ef
+    SET
+        DefaultColumnWidth =
+        IIF(ef.Type = 'int', 50,
+            IIF(ef.Type = 'datetimeoffset', 100,
+                IIF(ef.Type = 'money', 100,
+                    IIF(ef.Type ='nchar', 75,
+                        150)))
+            ),
+        __mj_UpdatedAt = GETUTCDATE()
+    FROM
+        ${flyway:defaultSchema}.EntityField ef
+    INNER JOIN
+        ${flyway:defaultSchema}.Entity e
+    ON
+        ef.EntityID = e.ID
+    LEFT JOIN
+        STRING_SPLIT(@ExcludedSchemaNames, ',') AS excludedSchemas
+    ON
+        e.SchemaName = excludedSchemas.value
+    WHERE
+        ef.DefaultColumnWidth IS NULL AND
+        excludedSchemas.value IS NULL AND
+        (@HasInclude = 0 OR e.SchemaName IN (SELECT SchemaName FROM @IncludedSchemas))
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spSetDefaultColumnWidthWhereNeeded] TO [cdp_Developer], [cdp_Integration]
+GO
+
+-- =============================================================================
+-- spUpdateSchemaInfoFromDatabase
+-- =============================================================================
+CREATE OR ALTER PROCEDURE [${flyway:defaultSchema}].[spUpdateSchemaInfoFromDatabase]
+    @ExcludedSchemaNames NVARCHAR(MAX) = NULL,
+    @IncludedSchemaNames NVARCHAR(MAX) = NULL
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @ExcludedSchemas TABLE (SchemaName NVARCHAR(128))
+    IF @ExcludedSchemaNames IS NOT NULL AND LEN(@ExcludedSchemaNames) > 0
+    BEGIN
+        INSERT INTO @ExcludedSchemas (SchemaName)
+        SELECT TRIM(value) FROM STRING_SPLIT(@ExcludedSchemaNames, ',')
+        WHERE TRIM(value) <> ''
+    END
+
+    DECLARE @IncludedSchemas TABLE (SchemaName NVARCHAR(255) PRIMARY KEY);
+    DECLARE @HasInclude BIT = 0;
+    IF @IncludedSchemaNames IS NOT NULL AND LEN(LTRIM(RTRIM(@IncludedSchemaNames))) > 0
+    BEGIN
+        INSERT INTO @IncludedSchemas (SchemaName)
+        SELECT DISTINCT TRIM(value)
+        FROM STRING_SPLIT(@IncludedSchemaNames, ',')
+        WHERE TRIM(value) <> '';
+        IF EXISTS (SELECT 1 FROM @IncludedSchemas) SET @HasInclude = 1;
+    END
+
+    UPDATE si
+    SET si.Description = ss.SchemaDescription
+    FROM [${flyway:defaultSchema}].SchemaInfo si
+    INNER JOIN [${flyway:defaultSchema}].vwSQLSchemas ss
+        ON si.SchemaName = ss.SchemaName
+    WHERE
+        (si.Description IS NULL OR si.Description <> ISNULL(ss.SchemaDescription, ''))
+        AND ss.SchemaName NOT IN (SELECT SchemaName FROM @ExcludedSchemas)
+        AND (@HasInclude = 0 OR ss.SchemaName IN (SELECT SchemaName FROM @IncludedSchemas))
+
+    INSERT INTO [${flyway:defaultSchema}].SchemaInfo
+    (
+        SchemaName,
+        EntityIDMin,
+        EntityIDMax,
+        Comments,
+        Description
+    )
+    SELECT
+        ss.SchemaName,
+        1,
+        999999999,
+        'Auto-created by CodeGen. Please update EntityIDMin and EntityIDMax to appropriate values for this schema.',
+        ss.SchemaDescription
+    FROM
+        [${flyway:defaultSchema}].vwSQLSchemas ss
+    LEFT OUTER JOIN
+        [${flyway:defaultSchema}].SchemaInfo si ON ss.SchemaName = si.SchemaName
+    WHERE
+        si.ID IS NULL
+        AND ss.SchemaName NOT IN (SELECT SchemaName FROM @ExcludedSchemas)
+        AND (@HasInclude = 0 OR ss.SchemaName IN (SELECT SchemaName FROM @IncludedSchemas))
+
+    UPDATE si
+    SET si.CanonicalSchemaName = app.SchemaName
+    FROM [${flyway:defaultSchema}].SchemaInfo si
+    INNER JOIN [${flyway:defaultSchema}].OpenApp app
+        ON LOWER(si.SchemaName) = LOWER(app.SchemaName)
+    WHERE si.CanonicalSchemaName IS NULL
+      AND app.SchemaName IS NOT NULL
+      AND si.SchemaName NOT IN (SELECT SchemaName FROM @ExcludedSchemas)
+      AND (@HasInclude = 0 OR si.SchemaName IN (SELECT SchemaName FROM @IncludedSchemas))
+
+    SELECT
+        si.*
+    FROM
+        [${flyway:defaultSchema}].SchemaInfo si
+    INNER JOIN
+        [${flyway:defaultSchema}].vwSQLSchemas ss ON si.SchemaName = ss.SchemaName
+    WHERE
+        ss.SchemaName NOT IN (SELECT SchemaName FROM @ExcludedSchemas)
+        AND (@HasInclude = 0 OR ss.SchemaName IN (SELECT SchemaName FROM @IncludedSchemas))
+END
+GO
+
+GRANT EXECUTE ON [${flyway:defaultSchema}].[spUpdateSchemaInfoFromDatabase] TO [cdp_Developer], [cdp_Integration]
+GO

--- a/packages/CodeGenLib/README.md
+++ b/packages/CodeGenLib/README.md
@@ -71,7 +71,7 @@ flowchart TD
 - **Extensible Architecture**: Every generator (`SQLCodeGenBase`, `EntitySubClassGeneratorBase`, `AngularClientGeneratorBase`, etc.) can be subclassed and overridden via MJ's class factory
 - **Zod Validation Schemas**: Generates Zod schemas from SQL CHECK constraints with proper union types and refinements
 - **Recursive Foreign Key & Hierarchy Traversal Engine**: Automatically detects self-referential foreign keys and generates a 4-routine TVF suite (`GetHierarchyMeta`, `GetDescendants`, `GetAncestors`, `GetRootID`), 5 computed base-view columns (`Root<Field>`, `<Field>Depth`, `<Field>Path`, `<Field>IsLeaf`, `<Field>ChildCount`), and strongly typed TypeScript entity traversal methods (`GetDescendants()`, `GetAncestors()`, `GetChildren()`). See the [Recursive Foreign Keys & Hierarchy Traversal Guide](../../guides/RECURSIVE_FOREIGN_KEYS_AND_HIERARCHIES_GUIDE.md).
-- **Cascade Delete Generation**: Produces cursor-based cascade delete procedures that call child entity stored procedures, respecting business logic at every level
+- **Cascade Delete Generation**: Produces cursor-based cascade delete procedures that call child entity stored procedures, respecting business logic at every level. Default is **intra-schema only**; `allowCrossSchemaCascadeDeletes` (off) is required to walk FKs in other schemas.
 - **Force Regeneration**: Surgically regenerate specific SQL objects for specific entities without requiring schema changes
 - **Class Registration Manifests**: Prevents tree-shaking of `@RegisterClass`-decorated classes by generating static import manifests
 - **SQL Migration Logging**: Outputs all generated SQL as Flyway-compatible migration files with schema placeholder support
@@ -317,7 +317,8 @@ All configuration is validated at startup using Zod schemas, with clear error me
 | `SQLOutput` | Controls Flyway migration file generation from SQL logging |
 | `commands` | Shell commands to run before/after generation (typically package builds) |
 | `excludeSchemas` / `excludeTables` | Filter schemas and tables from metadata discovery |
-| `includeSchemas` | Opt-in positive scope: generate only these schemas (resolved into `excludeSchemas`) |
+| `includeSchemas` | Opt-in positive scope: generate only these schemas (resolved into `excludeSchemas` **for this run**). Heal SQL logged into migrations uses `@IncludedSchemaNames` from this list plus authored `excludeSchemas` — never a snapshot of sibling apps on the publisher DB. |
+| `allowCrossSchemaCascadeDeletes` | Default **false**. Cascade-delete SQL is intra-schema only. `true` restores the old walk of every FK pointing at the entity, including other Open Apps. Dangerous; leave off. |
 | `entityPackageName` | String: npm package this emit writes. Record: install-time host map (those schemas are also skipped for local generation) |
 | `entityImportPackages` | Schema → npm map for peer classes this emit does **not** generate (embeds + related-record collections). See below. |
 | `entityNaming` | Controls ALL CAPS normalization and compound word splitting for entity/field names |

--- a/packages/CodeGenLib/src/Config/config.ts
+++ b/packages/CodeGenLib/src/Config/config.ts
@@ -473,8 +473,21 @@ const configInfoSchema = z.object({
    * exclude list naming every other installed app — a list that is O(N²) to maintain and, more
    * importantly, cannot name schemas the app does not know about (such as a client's own schemas in
    * a deployed instance).
+   *
+   * The in-memory compile into `excludeSchemas` is for THIS CodeGen run only (which entities to
+   * generate). Heal stored-procedure EXEC statements logged into migrations use authored
+   * `excludeSchemas` plus `@IncludedSchemaNames` from this list — they must not snapshot sibling
+   * apps that happened to be installed on the publisher database.
    */
   includeSchemas: z.string().array().optional(),
+  /**
+   * When true, CodeGen cascade-delete SQL walks FKs pointing at the entity in
+   * EVERY schema in metadata. Default false: only same-schema children.
+   * Turning this on (and CascadeDeletes on an entity) will bake consumer
+   * schemas into a publisher's delete proc — a dangerous escape hatch.
+   * Leave off for Open Apps.
+   */
+  allowCrossSchemaCascadeDeletes: z.boolean().default(false),
   excludeTables: tableInfoSchema.array().default([
     { schema: '%', table: 'sys%' },
     { schema: '%', table: 'flyway_schema_history' }

--- a/packages/CodeGenLib/src/Database/heal-schema-params.ts
+++ b/packages/CodeGenLib/src/Database/heal-schema-params.ts
@@ -1,0 +1,67 @@
+/**
+ * Parameters for CodeGen's metadata-heal stored procedures
+ * (`spUpdateExistingEntitiesFromSchema`, `spUpdateExistingEntityFieldsFromSchema`,
+ * `spSetDefaultColumnWidthWhereNeeded`, `spUpdateSchemaInfoFromDatabase`,
+ * `spDeleteUnneededEntityFields`).
+ *
+ * `includeSchemas` is compiled into `excludeSchemas` in memory so this CodeGen
+ * *run* does not generate other apps. That expanded list is a photograph of
+ * whoever is installed on the publisher database and MUST NOT be serialized
+ * into a migration. Heal EXEC statements use:
+ *   - authored `excludeSchemas` from mj.config.cjs (`sys`, `staging`, …)
+ *   - `includeSchemas` as `@IncludedSchemaNames` when set
+ */
+
+export interface HealSchemaRoutineParams {
+    values: string[];
+    names: string[];
+}
+
+let authoredExcludeSchemas: string[] | null = null;
+
+/** Capture the config exclude list before `applyIncludeSchemaScope` mutates it. Idempotent. */
+export function snapshotAuthoredExcludeSchemas(excludeSchemas: string[] | undefined): void {
+    if (authoredExcludeSchemas === null) {
+        authoredExcludeSchemas = [...(excludeSchemas ?? [])];
+    }
+}
+
+/** Test-only: reset the snapshot between cases. */
+export function resetAuthoredExcludeSnapshot(): void {
+    authoredExcludeSchemas = null;
+}
+
+export function getAuthoredExcludeSchemas(fallback?: string[]): string[] {
+    if (authoredExcludeSchemas !== null) {
+        return authoredExcludeSchemas;
+    }
+    return [...(fallback ?? [])];
+}
+
+/**
+ * Named-parameter lists for a heal SP call.
+ * `@IncludedSchemaNames` is omitted when `includeSchemas` is empty so classic
+ * MJ (no include list) keeps the historical EXEC shape.
+ */
+export function buildHealSchemaRoutineParams(options: {
+    authoredExclude: string[];
+    includeSchemas?: string[] | null;
+    entityIDs?: string[];
+}): HealSchemaRoutineParams {
+    const exclude = options.authoredExclude.join(',');
+    const values: string[] = [`'${exclude}'`];
+    const names: string[] = ['ExcludedSchemaNames'];
+
+    if (options.entityIDs !== undefined && options.entityIDs.length > 0) {
+        values.push(`'${options.entityIDs.join(',')}'`);
+        names.push('EntityIDs');
+    }
+
+    const include = (options.includeSchemas ?? []).map((s) => s.trim()).filter((s) => s.length > 0);
+    if (include.length > 0) {
+        values.push(`'${include.join(',')}'`);
+        names.push('IncludedSchemaNames');
+    }
+
+    return { values, names };
+}

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -16,6 +16,7 @@ import { MJApplicationEntity, MJEntityFieldSchema, MJQueryParameterEntity } from
 import { logError, logMessage, logStatus, startSpinner, updateSpinner, succeedSpinner } from "../Misc/status_logging";
 import { SQLUtilityBase } from "./sql";
 import { applyIncludeSchemaScope } from "./schema-scope";
+import { buildHealSchemaRoutineParams, getAuthoredExcludeSchemas, snapshotAuthoredExcludeSchemas } from "./heal-schema-params";
 import { AdvancedGeneration, EntityDescriptionResult, EntityNameResult, SmartFieldIdentificationResult, FormLayoutResult, VirtualEntityDecorationResult } from "../Misc/advanced_generation";
 import { CodeGenReporter } from "../Misc/codegen-reporter";
 import {
@@ -2190,6 +2191,11 @@ export class ManageMetadataBase {
             return false;
          }
       }
+
+      // Authored exclude list (sys, staging, …) must be captured BEFORE includeSchemas is
+      // compiled into excludeSchemas. Heal EXEC statements use that original list plus
+      // @IncludedSchemaNames — never the sibling snapshot of this machine's database.
+      snapshotAuthoredExcludeSchemas(configInfo.excludeSchemas);
 
       // Resolve the opt-in `includeSchemas` positive scope into excludeSchemas, BEFORE the exclude
       // snapshot below and before createNewEntities() runs. The universe is queried from the DATABASE
@@ -4760,7 +4766,11 @@ export class ManageMetadataBase {
     */
    protected async setDefaultColumnWidthWhereNeeded(pool: CodeGenConnection, excludeSchemas: string[]): Promise<boolean> {
       try   {
-         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spSetDefaultColumnWidthWhereNeeded', [`'${excludeSchemas.join(',')}'`], ['ExcludedSchemaNames']);
+         const heal = buildHealSchemaRoutineParams({
+            authoredExclude: getAuthoredExcludeSchemas(excludeSchemas),
+            includeSchemas: configInfo.includeSchemas,
+         });
+         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spSetDefaultColumnWidthWhereNeeded', heal.values, heal.names);
          await this.LogSQLAndExecute(pool, sSQL, `SQL text to set default column width where needed`, true);
          return true;
       }
@@ -5024,7 +5034,11 @@ export class ManageMetadataBase {
    }
    protected async updateExistingEntitiesFromSchema(pool: CodeGenConnection, excludeSchemas: string[]): Promise<boolean> {
       try   {
-         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spUpdateExistingEntitiesFromSchema', [`'${excludeSchemas.join(',')}'`], ['ExcludedSchemaNames']);
+         const heal = buildHealSchemaRoutineParams({
+            authoredExclude: getAuthoredExcludeSchemas(excludeSchemas),
+            includeSchemas: configInfo.includeSchemas,
+         });
+         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spUpdateExistingEntitiesFromSchema', heal.values, heal.names);
          const result = await this.LogSQLAndExecute(pool, sSQL, `SQL text to update existing entities from schema`, true);
          // result contains the updated entities, and there is a property of each row called Name which has the entity name that was modified
          // add these to the modified entity list if they're not already in there
@@ -5055,14 +5069,13 @@ export class ManageMetadataBase {
          // string (mirrors the @ExcludedSchemaNames pattern). The SP fans the list out into
          // a table variable via STRING_SPLIT and joins once. This avoids both per-entity
          // round-trips (slow) and parallel calls (page-level lock contention on EntityField).
+         const heal = buildHealSchemaRoutineParams({
+            authoredExclude: getAuthoredExcludeSchemas(excludeSchemas),
+            includeSchemas: configInfo.includeSchemas,
+            entityIDs,
+         });
+         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spUpdateExistingEntityFieldsFromSchema', heal.values, heal.names);
          const isScoped = entityIDs !== undefined && entityIDs.length > 0;
-         const params = isScoped
-            ? [`'${excludeSchemas.join(',')}'`, `'${entityIDs!.join(',')}'`]
-            : [`'${excludeSchemas.join(',')}'`];
-         const paramNames = isScoped
-            ? ['ExcludedSchemaNames', 'EntityIDs']
-            : ['ExcludedSchemaNames'];
-         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spUpdateExistingEntityFieldsFromSchema', params, paramNames);
          const label = isScoped
             ? `SQL text to update existing entity fields from schema (${entityIDs!.length} scoped entities)`
             : `SQL text to update existing entity fields from schema`;
@@ -5090,7 +5103,11 @@ export class ManageMetadataBase {
     */
    protected async updateSchemaInfoFromDatabase(pool: CodeGenConnection, excludeSchemas: string[]): Promise<boolean> {
       try {
-         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spUpdateSchemaInfoFromDatabase', [`'${excludeSchemas.join(',')}'`], ['ExcludedSchemaNames']);
+         const heal = buildHealSchemaRoutineParams({
+            authoredExclude: getAuthoredExcludeSchemas(excludeSchemas),
+            includeSchemas: configInfo.includeSchemas,
+         });
+         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spUpdateSchemaInfoFromDatabase', heal.values, heal.names);
          const result = await this.LogSQLAndExecute(pool, sSQL, `SQL text to sync schema info from database schemas`, true);
 
          if (result && result.length > 0) {
@@ -5197,14 +5214,13 @@ export class ManageMetadataBase {
          // string (mirrors the @ExcludedSchemaNames pattern). The SP fans the list out into
          // a table variable via STRING_SPLIT and filters once. Avoids both per-entity
          // round-trips and parallel calls (page-level lock contention on EntityField).
+         const heal = buildHealSchemaRoutineParams({
+            authoredExclude: getAuthoredExcludeSchemas(excludeSchemas),
+            includeSchemas: configInfo.includeSchemas,
+            entityIDs,
+         });
+         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spDeleteUnneededEntityFields', heal.values, heal.names);
          const isScoped = entityIDs !== undefined && entityIDs.length > 0;
-         const params = isScoped
-            ? [`'${excludeSchemas.join(',')}'`, `'${entityIDs!.join(',')}'`]
-            : [`'${excludeSchemas.join(',')}'`];
-         const paramNames = isScoped
-            ? ['ExcludedSchemaNames', 'EntityIDs']
-            : ['ExcludedSchemaNames'];
-         const sSQL = this.dbProvider.callRoutineSQL(mj_core_schema(), 'spDeleteUnneededEntityFields', params, paramNames);
          const label = isScoped
             ? `SQL text to delete unneeded entity fields (${entityIDs!.length} scoped entities)`
             : `SQL text to delete unneeded entity fields`;

--- a/packages/CodeGenLib/src/Database/providers/postgresql/metadataSupportObjects.ts
+++ b/packages/CodeGenLib/src/Database/providers/postgresql/metadataSupportObjects.ts
@@ -195,9 +195,11 @@ FROM __mj."vwSQLTablesAndEntities" e
 -- ----------------------------------------------------------------------------
 DROP FUNCTION IF EXISTS __mj."spUpdateExistingEntityFieldsFromSchema"(TEXT);
 DROP FUNCTION IF EXISTS __mj."spUpdateExistingEntityFieldsFromSchema"(TEXT, TEXT);
+DROP FUNCTION IF EXISTS __mj."spUpdateExistingEntityFieldsFromSchema"(TEXT, TEXT, TEXT);
 CREATE OR REPLACE FUNCTION __mj."spUpdateExistingEntityFieldsFromSchema"(
   p_ExcludedSchemaNames TEXT,
-  p_EntityIDs TEXT DEFAULT NULL
+  p_EntityIDs TEXT DEFAULT NULL,
+  p_IncludedSchemaNames TEXT DEFAULT NULL
 )
 RETURNS TABLE(
   "EntityID" UUID,
@@ -225,6 +227,7 @@ RETURNS TABLE(
 LANGUAGE plpgsql AS $func$
 DECLARE
   v_is_scoped BOOLEAN := FALSE;
+  v_has_include BOOLEAN := FALSE;
 BEGIN
   -- [Large Schema Series] Force hash/merge joins for the catalog-introspection
   -- reconciliation below. In the scoped Pass-2 codegen path this SP runs AFTER
@@ -240,6 +243,13 @@ BEGIN
     SELECT TRIM(s) AS schema_name
     FROM unnest(string_to_array(COALESCE(p_ExcludedSchemaNames, ''), ',')) AS s
     WHERE TRIM(s) <> '';
+
+  DROP TABLE IF EXISTS _uef_included;
+  CREATE TEMP TABLE _uef_included AS
+    SELECT TRIM(s) AS schema_name
+    FROM unnest(string_to_array(COALESCE(p_IncludedSchemaNames, ''), ',')) AS s
+    WHERE TRIM(s) <> '';
+  v_has_include := EXISTS (SELECT 1 FROM _uef_included);
 
   DROP TABLE IF EXISTS _uef_scope;
   CREATE TEMP TABLE _uef_scope AS
@@ -355,6 +365,7 @@ BEGIN
   LEFT JOIN _uef_excluded ex ON e."SchemaName"::text = ex.schema_name
   WHERE e."VirtualEntity" = FALSE
     AND ex.schema_name IS NULL
+    AND (NOT v_has_include OR e."SchemaName"::text IN (SELECT i.schema_name FROM _uef_included i))
     AND (NOT v_is_scoped OR e."ID" IN (SELECT s.entity_id FROM _uef_scope s))
   ) chg
   -- Single source of truth for "this row changed": derived from the two flag columns computed
@@ -414,6 +425,7 @@ BEGIN
   DROP TABLE IF EXISTS _uef_filtered;
   DROP TABLE IF EXISTS _uef_scope;
   DROP TABLE IF EXISTS _uef_excluded;
+  DROP TABLE IF EXISTS _uef_included;
 END;
 $func$;
 
@@ -422,7 +434,11 @@ $func$;
 --    (consumer reads "Name" from result rows)
 -- ----------------------------------------------------------------------------
 DROP FUNCTION IF EXISTS __mj."spUpdateExistingEntitiesFromSchema"(TEXT);
-CREATE OR REPLACE FUNCTION __mj."spUpdateExistingEntitiesFromSchema"(p_ExcludedSchemaNames TEXT)
+DROP FUNCTION IF EXISTS __mj."spUpdateExistingEntitiesFromSchema"(TEXT, TEXT);
+CREATE OR REPLACE FUNCTION __mj."spUpdateExistingEntitiesFromSchema"(
+  p_ExcludedSchemaNames TEXT,
+  p_IncludedSchemaNames TEXT DEFAULT NULL
+)
 RETURNS TABLE(
   "ID" UUID,
   "Name" TEXT,
@@ -432,7 +448,16 @@ RETURNS TABLE(
   "SchemaName" TEXT
 )
 LANGUAGE plpgsql AS $func$
+DECLARE
+  v_has_include BOOLEAN := FALSE;
 BEGIN
+  DROP TABLE IF EXISTS _ues_included;
+  CREATE TEMP TABLE _ues_included AS
+    SELECT TRIM(s) AS schema_name
+    FROM unnest(string_to_array(COALESCE(p_IncludedSchemaNames, ''), ',')) AS s
+    WHERE TRIM(s) <> '';
+  v_has_include := EXISTS (SELECT 1 FROM _ues_included);
+
   DROP TABLE IF EXISTS _ues_filtered;
   CREATE TEMP TABLE _ues_filtered AS
   SELECT
@@ -448,6 +473,7 @@ BEGIN
     ON sq."SchemaName"::text = TRIM(ex.v)
   WHERE e."VirtualEntity" = FALSE
     AND ex.v IS NULL
+    AND (NOT v_has_include OR sq."SchemaName"::text IN (SELECT i.schema_name FROM _ues_included i))
     AND COALESCE(CASE WHEN e."AutoUpdateDescription" THEN sq."EntityDescription" ELSE e."Description" END, '')
         <> COALESCE(e."Description", '');
 
@@ -463,6 +489,7 @@ BEGIN
   FROM _ues_filtered fr;
 
   DROP TABLE IF EXISTS _ues_filtered;
+  DROP TABLE IF EXISTS _ues_included;
 END;
 $func$;
 
@@ -474,9 +501,11 @@ $func$;
 -- ----------------------------------------------------------------------------
 DROP FUNCTION IF EXISTS __mj."spDeleteUnneededEntityFields"(TEXT);
 DROP FUNCTION IF EXISTS __mj."spDeleteUnneededEntityFields"(TEXT, TEXT);
+DROP FUNCTION IF EXISTS __mj."spDeleteUnneededEntityFields"(TEXT, TEXT, TEXT);
 CREATE OR REPLACE FUNCTION __mj."spDeleteUnneededEntityFields"(
   p_ExcludedSchemaNames TEXT,
-  p_EntityIDs TEXT DEFAULT NULL
+  p_EntityIDs TEXT DEFAULT NULL,
+  p_IncludedSchemaNames TEXT DEFAULT NULL
 )
 RETURNS TABLE(
   "ID" UUID,
@@ -487,6 +516,7 @@ RETURNS TABLE(
 LANGUAGE plpgsql AS $func$
 DECLARE
   v_is_scoped BOOLEAN := FALSE;
+  v_has_include BOOLEAN := FALSE;
 BEGIN
   -- [Large Schema Series] Force hash/merge joins for this reconciliation.
   -- This SP runs in codegen Pass 2, immediately AFTER the SQL-generation phase
@@ -509,6 +539,13 @@ BEGIN
     FROM unnest(string_to_array(COALESCE(p_EntityIDs, ''), ',')) AS v
     WHERE TRIM(v) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
   v_is_scoped := EXISTS (SELECT 1 FROM _del_scope);
+
+  DROP TABLE IF EXISTS _del_included;
+  CREATE TEMP TABLE _del_included AS
+    SELECT TRIM(s) AS schema_name
+    FROM unnest(string_to_array(COALESCE(p_IncludedSchemaNames, ''), ',')) AS s
+    WHERE TRIM(s) <> '';
+  v_has_include := EXISTS (SELECT 1 FROM _del_included);
 
   -- External-data-source entities must be excluded from the field prune (they are remote; they have no
   -- physical table/view, so the orphan join would match every external EntityField and delete it). But
@@ -541,6 +578,7 @@ BEGIN
   WHERE e."VirtualEntity" = FALSE
     AND ef."EntityID" NOT IN (SELECT entity_id FROM _del_ext_entities) -- exclude external-data-source entities (see note above)
     AND ex.v IS NULL
+    AND (NOT v_has_include OR e."SchemaName"::text IN (SELECT i.schema_name FROM _del_included i))
     AND (NOT v_is_scoped OR ef."EntityID" IN (SELECT s.entity_id FROM _del_scope s));
   -- [Large Schema Series] ANALYZE so the planner has real cardinalities for the
   -- orphan join below. Without stats it estimates rows=1 and nested-loops.
@@ -582,6 +620,7 @@ BEGIN
   DROP TABLE IF EXISTS _del_actual;
   DROP TABLE IF EXISTS _del_ef;
   DROP TABLE IF EXISTS _del_scope;
+  DROP TABLE IF EXISTS _del_included;
 END;
 $func$;
 
@@ -589,7 +628,11 @@ $func$;
 -- 6. spSetDefaultColumnWidthWhereNeeded
 -- ----------------------------------------------------------------------------
 DROP FUNCTION IF EXISTS __mj."spSetDefaultColumnWidthWhereNeeded"(TEXT);
-CREATE OR REPLACE FUNCTION __mj."spSetDefaultColumnWidthWhereNeeded"(p_ExcludedSchemaNames TEXT)
+DROP FUNCTION IF EXISTS __mj."spSetDefaultColumnWidthWhereNeeded"(TEXT, TEXT);
+CREATE OR REPLACE FUNCTION __mj."spSetDefaultColumnWidthWhereNeeded"(
+  p_ExcludedSchemaNames TEXT,
+  p_IncludedSchemaNames TEXT DEFAULT NULL
+)
 RETURNS void
 LANGUAGE plpgsql AS $func$
 BEGIN
@@ -608,7 +651,13 @@ BEGIN
     ON e."SchemaName"::text = TRIM(ex.v)
   WHERE ef."EntityID" = e."ID"
     AND ef."DefaultColumnWidth" IS NULL
-    AND ex.v IS NULL;
+    AND ex.v IS NULL
+    AND (
+      COALESCE(p_IncludedSchemaNames, '') = ''
+      OR e."SchemaName"::text IN (
+        SELECT TRIM(s) FROM unnest(string_to_array(p_IncludedSchemaNames, ',')) AS s WHERE TRIM(s) <> ''
+      )
+    );
 END;
 $func$;
 
@@ -617,9 +666,15 @@ $func$;
 --    (consumer caches the returned SchemaInfo rows)
 -- ----------------------------------------------------------------------------
 DROP FUNCTION IF EXISTS __mj."spUpdateSchemaInfoFromDatabase"(TEXT);
-CREATE OR REPLACE FUNCTION __mj."spUpdateSchemaInfoFromDatabase"(p_ExcludedSchemaNames TEXT DEFAULT NULL)
+DROP FUNCTION IF EXISTS __mj."spUpdateSchemaInfoFromDatabase"(TEXT, TEXT);
+CREATE OR REPLACE FUNCTION __mj."spUpdateSchemaInfoFromDatabase"(
+  p_ExcludedSchemaNames TEXT DEFAULT NULL,
+  p_IncludedSchemaNames TEXT DEFAULT NULL
+)
 RETURNS SETOF __mj."SchemaInfo"
 LANGUAGE plpgsql AS $func$
+DECLARE
+  v_has_include BOOLEAN := FALSE;
 BEGIN
   DROP TABLE IF EXISTS _usi_excluded;
   CREATE TEMP TABLE _usi_excluded AS
@@ -627,13 +682,21 @@ BEGIN
     FROM unnest(string_to_array(COALESCE(p_ExcludedSchemaNames, ''), ',')) AS s
     WHERE TRIM(s) <> '';
 
+  DROP TABLE IF EXISTS _usi_included;
+  CREATE TEMP TABLE _usi_included AS
+    SELECT TRIM(s) AS schema_name
+    FROM unnest(string_to_array(COALESCE(p_IncludedSchemaNames, ''), ',')) AS s
+    WHERE TRIM(s) <> '';
+  v_has_include := EXISTS (SELECT 1 FROM _usi_included);
+
   UPDATE __mj."SchemaInfo" si SET
     "Description" = ss."SchemaDescription",
     "__mj_UpdatedAt" = now()
   FROM __mj."vwSQLSchemas" ss
   WHERE si."SchemaName" = ss."SchemaName"
     AND (si."Description" IS NULL OR si."Description" <> COALESCE(ss."SchemaDescription", ''))
-    AND ss."SchemaName" NOT IN (SELECT x.schema_name FROM _usi_excluded x);
+    AND ss."SchemaName" NOT IN (SELECT x.schema_name FROM _usi_excluded x)
+    AND (NOT v_has_include OR ss."SchemaName" IN (SELECT i.schema_name FROM _usi_included i));
 
   INSERT INTO __mj."SchemaInfo" ("SchemaName", "EntityIDMin", "EntityIDMax", "Comments", "Description")
   SELECT
@@ -645,7 +708,8 @@ BEGIN
   FROM __mj."vwSQLSchemas" ss
   LEFT JOIN __mj."SchemaInfo" si ON ss."SchemaName" = si."SchemaName"
   WHERE si."ID" IS NULL
-    AND ss."SchemaName" NOT IN (SELECT x.schema_name FROM _usi_excluded x);
+    AND ss."SchemaName" NOT IN (SELECT x.schema_name FROM _usi_excluded x)
+    AND (NOT v_has_include OR ss."SchemaName" IN (SELECT i.schema_name FROM _usi_included i));
 
   -- Backfill the case-stable canonical schema name from the installed Open App record.
   -- SchemaInfo.SchemaName is the physical (lowercased) name on PG; the app record carries
@@ -657,15 +721,19 @@ BEGIN
   FROM __mj."OpenApp" app
   WHERE LOWER(si."SchemaName") = LOWER(app."SchemaName")
     AND si."CanonicalSchemaName" IS NULL
-    AND app."SchemaName" IS NOT NULL;
+    AND app."SchemaName" IS NOT NULL
+    AND si."SchemaName" NOT IN (SELECT x.schema_name FROM _usi_excluded x)
+    AND (NOT v_has_include OR si."SchemaName" IN (SELECT i.schema_name FROM _usi_included i));
 
   RETURN QUERY
   SELECT si.*
   FROM __mj."SchemaInfo" si
   INNER JOIN __mj."vwSQLSchemas" ss ON si."SchemaName" = ss."SchemaName"
-  WHERE ss."SchemaName" NOT IN (SELECT x.schema_name FROM _usi_excluded x);
+  WHERE ss."SchemaName" NOT IN (SELECT x.schema_name FROM _usi_excluded x)
+    AND (NOT v_has_include OR ss."SchemaName" IN (SELECT i.schema_name FROM _usi_included i));
 
   DROP TABLE IF EXISTS _usi_excluded;
+  DROP TABLE IF EXISTS _usi_included;
 END;
 $func$;
 

--- a/packages/CodeGenLib/src/Database/schema-filters.ts
+++ b/packages/CodeGenLib/src/Database/schema-filters.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure schema-scope predicates used by CodeGen SQL generation.
+ * Kept out of sql_codegen.ts so unit tests do not load the full generator.
+ */
+
+/** Case-insensitive, trimmed membership in a schema-name list. */
+export function schemaNameInList(schema: string, list: string[] | undefined | null): boolean {
+    if (!list || list.length === 0) {
+        return false;
+    }
+    const key = schema.trim().toLowerCase();
+    return list.some((s) => s.trim().toLowerCase() === key);
+}
+
+/**
+ * Cascade SQL for a related entity whose FK points at `parentSchema`.
+ * Default is intra-schema only. `allowCrossSchemaCascadeDeletes` restores the
+ * historical walk across every schema in metadata — that is a dangerous
+ * escape hatch and must stay off for Open Apps.
+ */
+export function shouldEmitCascadeForRelatedEntity(
+    parentSchema: string,
+    relatedSchema: string,
+    allowCrossSchemaCascadeDeletes: boolean,
+): boolean {
+    if (allowCrossSchemaCascadeDeletes) {
+        return true;
+    }
+    return parentSchema.trim().toLowerCase() === relatedSchema.trim().toLowerCase();
+}
+
+/**
+ * Whether a custom/layered base view for `schemaName` may be `sp_refreshview`'d
+ * into the migration log (STEP 4.5).
+ *
+ * Always drop `excludeSchemas`. When `includeSchemas` is non-empty, keep only
+ * that positive list. When it is empty/unset, keep current "all modified
+ * custom views" behavior minus excludes.
+ */
+export function entityInCustomBaseViewRefreshScope(
+    schemaName: string,
+    excludeSchemas: string[],
+    includeSchemas?: string[] | null,
+): boolean {
+    if (schemaNameInList(schemaName, excludeSchemas)) {
+        return false;
+    }
+    if (includeSchemas && includeSchemas.length > 0) {
+        return schemaNameInList(schemaName, includeSchemas);
+    }
+    return true;
+}

--- a/packages/CodeGenLib/src/Database/schema-scope.ts
+++ b/packages/CodeGenLib/src/Database/schema-scope.ts
@@ -1,3 +1,5 @@
+import { snapshotAuthoredExcludeSchemas } from './heal-schema-params';
+
 /**
  * Schema-scope resolution helpers for CodeGen.
  *
@@ -70,6 +72,9 @@ export interface SchemaScopeConfig {
  * @returns the schema names that were newly appended (empty when the scope is unused or already applied)
  */
 export function applyIncludeSchemaScope(allSchemas: string[], config: SchemaScopeConfig): string[] {
+  // Capture authored excludes before this run mutates excludeSchemas. Heal EXEC
+  // statements must serialize that original list, not the sibling snapshot.
+  snapshotAuthoredExcludeSchemas(config.excludeSchemas);
   if (!config.includeSchemas || config.includeSchemas.length === 0) {
     return []; // classic exclude-only behavior, unchanged
   }

--- a/packages/CodeGenLib/src/Database/sql_codegen.ts
+++ b/packages/CodeGenLib/src/Database/sql_codegen.ts
@@ -7,6 +7,7 @@ import { SQLUtilityBase } from './sql';
 import { CodeGenDatabaseProvider, BaseViewGenerationContext, CascadeDeleteContext, CodeGenConnection, PhasedExecutionResult } from './codeGenDatabaseProvider';
 
 import { autoIndexForeignKeys, autoIndexSoftPrimaryKeys, configInfo, customSqlScripts, dbDatabase, mjCoreSchema, MAX_INDEX_NAME_LENGTH } from '../Config/config';
+import { entityInCustomBaseViewRefreshScope, shouldEmitCascadeForRelatedEntity } from './schema-filters';
 import { ManageMetadataBase, ViewRegenEntry } from './manage-metadata';
 
 import { UserCache } from '@memberjunction/generic-database-provider';
@@ -1087,7 +1088,12 @@ export class SQLCodeGenBase {
             modifiedOrNewNames.includes(e.Name) &&
             !e.BaseViewGenerated &&
             e.IncludeInAPI &&
-            !e.VirtualEntity
+            !e.VirtualEntity &&
+            entityInCustomBaseViewRefreshScope(
+                e.SchemaName,
+                configInfo.excludeSchemas ?? [],
+                configInfo.includeSchemas,
+            )
         );
     }
 
@@ -2286,6 +2292,13 @@ export class SQLCodeGenBase {
 
             // Find all fields in other entities that are foreign keys to this entity
             for (const e of md.Entities) {
+                if (!shouldEmitCascadeForRelatedEntity(
+                    entity.SchemaName,
+                    e.SchemaName,
+                    configInfo.allowCrossSchemaCascadeDeletes === true,
+                )) {
+                    continue;
+                }
                 for (const ef of e.Fields) {
                     if (UUIDsEqual(ef.RelatedEntityID, entity.ID) && ef.IsVirtual === false) {
                         const cascadeSql = await this.generateSingleCascadeOperation(entity, e, ef, pool);
@@ -2426,6 +2439,13 @@ export class SQLCodeGenBase {
 
             // Find all fields in other entities that are foreign keys to this entity
             for (const e of md.Entities) {
+                if (!shouldEmitCascadeForRelatedEntity(
+                    entity.SchemaName,
+                    e.SchemaName,
+                    configInfo.allowCrossSchemaCascadeDeletes === true,
+                )) {
+                    continue;
+                }
                 for (const ef of e.Fields) {
                     if (UUIDsEqual(ef.RelatedEntityID, entity.ID) && ef.IsVirtual === false) {
                         // Skip self-referential foreign keys (e.g., ParentID pointing to same entity)

--- a/packages/CodeGenLib/src/__tests__/schema-filters-and-heal-params.test.ts
+++ b/packages/CodeGenLib/src/__tests__/schema-filters-and-heal-params.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    shouldEmitCascadeForRelatedEntity,
+    entityInCustomBaseViewRefreshScope,
+} from '../Database/schema-filters';
+import {
+    buildHealSchemaRoutineParams,
+    snapshotAuthoredExcludeSchemas,
+    getAuthoredExcludeSchemas,
+    resetAuthoredExcludeSnapshot,
+} from '../Database/heal-schema-params';
+import { applyIncludeSchemaScope } from '../Database/schema-scope';
+import { SQLServerCodeGenProvider } from '../Database/providers/sqlserver/SQLServerCodeGenProvider';
+import { PostgreSQLCodeGenProvider } from '../Database/providers/postgresql/PostgreSQLCodeGenProvider';
+
+describe('shouldEmitCascadeForRelatedEntity', () => {
+    it('emits intra-schema cascade when the flag is off', () => {
+        expect(shouldEmitCascadeForRelatedEntity('__mj_BizAppsCommon', '__mj_BizAppsCommon', false)).toBe(true);
+    });
+
+    it('does not emit inter-schema cascade when the flag is off', () => {
+        expect(shouldEmitCascadeForRelatedEntity('__mj_BizAppsCommon', '__mj_BizAppsOrders', false)).toBe(false);
+    });
+
+    it('matches schema names case-insensitively', () => {
+        expect(shouldEmitCascadeForRelatedEntity('__mj_BizAppsCommon', '__MJ_BIZAPPSCOMMON', false)).toBe(true);
+    });
+
+    it('emits inter-schema cascade only when the flag is on', () => {
+        expect(shouldEmitCascadeForRelatedEntity('__mj_BizAppsCommon', '__mj_BizAppsOrders', true)).toBe(true);
+    });
+});
+
+describe('entityInCustomBaseViewRefreshScope', () => {
+    it('drops schemas in excludeSchemas even with no include list', () => {
+        expect(entityInCustomBaseViewRefreshScope('sys', ['sys', 'staging'])).toBe(false);
+        expect(entityInCustomBaseViewRefreshScope('__mj', ['sys', 'staging'])).toBe(true);
+    });
+
+    it('with includeSchemas set, keeps only that list (minus excludes)', () => {
+        expect(entityInCustomBaseViewRefreshScope(
+            '__mj_BizAppsCommon',
+            ['sys', 'staging'],
+            ['__mj_BizAppsCommon'],
+        )).toBe(true);
+        expect(entityInCustomBaseViewRefreshScope(
+            '__mj_BizAppsOrders',
+            ['sys', 'staging'],
+            ['__mj_BizAppsCommon'],
+        )).toBe(false);
+    });
+
+    it('still drops an included schema that is also excluded', () => {
+        expect(entityInCustomBaseViewRefreshScope(
+            '__mj_BizAppsCommon',
+            ['__mj_BizAppsCommon'],
+            ['__mj_BizAppsCommon'],
+        )).toBe(false);
+    });
+});
+
+describe('buildHealSchemaRoutineParams', () => {
+    it('omits IncludedSchemaNames when includeSchemas is empty (classic MJ)', () => {
+        const p = buildHealSchemaRoutineParams({
+            authoredExclude: ['sys', 'staging'],
+        });
+        expect(p.names).toEqual(['ExcludedSchemaNames']);
+        expect(p.values).toEqual([`'sys,staging'`]);
+    });
+
+    it('adds IncludedSchemaNames from includeSchemas and never a sibling snapshot', () => {
+        const p = buildHealSchemaRoutineParams({
+            authoredExclude: ['sys', 'staging'],
+            includeSchemas: ['__mj_BizAppsCommon'],
+        });
+        expect(p.names).toEqual(['ExcludedSchemaNames', 'IncludedSchemaNames']);
+        expect(p.values).toEqual([`'sys,staging'`, `'__mj_BizAppsCommon'`]);
+        expect(p.values.join(',')).not.toContain('Orders');
+        expect(p.values.join(',')).not.toContain('Accounting');
+    });
+
+    it('places EntityIDs before IncludedSchemaNames', () => {
+        const p = buildHealSchemaRoutineParams({
+            authoredExclude: ['sys'],
+            includeSchemas: ['__mj_BizAppsCommon'],
+            entityIDs: ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'],
+        });
+        expect(p.names).toEqual(['ExcludedSchemaNames', 'EntityIDs', 'IncludedSchemaNames']);
+    });
+
+    it('SQL Server named EXEC with include does not list sibling Open Apps', () => {
+        const p = buildHealSchemaRoutineParams({
+            authoredExclude: ['sys', 'staging'],
+            includeSchemas: ['__mj_BizAppsCommon'],
+        });
+        const sql = new SQLServerCodeGenProvider().callRoutineSQL(
+            '__mj',
+            'spUpdateExistingEntitiesFromSchema',
+            p.values,
+            p.names,
+        );
+        expect(sql).toBe(
+            `EXEC [__mj].[spUpdateExistingEntitiesFromSchema] @ExcludedSchemaNames='sys,staging', @IncludedSchemaNames='__mj_BizAppsCommon'`,
+        );
+        expect(sql).not.toMatch(/BizAppsOrders/);
+    });
+});
+
+describe('authored exclude snapshot vs include compile', () => {
+    beforeEach(() => {
+        resetAuthoredExcludeSnapshot();
+    });
+
+    it('heal params keep sys,staging after includeSchemas compiles siblings into excludeSchemas', () => {
+        const config = {
+            includeSchemas: ['__mj_BizAppsCommon'],
+            excludeSchemas: ['sys', 'staging'],
+        };
+        snapshotAuthoredExcludeSchemas(config.excludeSchemas);
+        applyIncludeSchemaScope(
+            ['__mj_BizAppsCommon', '__mj_BizAppsOrders', '__mj_BizAppsAccounting', 'sys', 'staging'],
+            config,
+        );
+        expect(config.excludeSchemas).toContain('__mj_BizAppsOrders');
+        expect(getAuthoredExcludeSchemas()).toEqual(['sys', 'staging']);
+
+        const p = buildHealSchemaRoutineParams({
+            authoredExclude: getAuthoredExcludeSchemas(),
+            includeSchemas: config.includeSchemas,
+        });
+        expect(p.values[0]).toBe(`'sys,staging'`);
+        expect(p.values.join(',')).not.toContain('Orders');
+    });
+});
+
+describe('PostgreSQL metadata support objects include the new parameter', () => {
+    it('declares p_IncludedSchemaNames on the heal functions', () => {
+        const sql = new PostgreSQLCodeGenProvider().getMetadataSupportObjectsSQL('__mj');
+        expect(sql).toBeTruthy();
+        expect(sql!).toContain('p_IncludedSchemaNames');
+        expect(sql!).toContain('spUpdateExistingEntitiesFromSchema');
+        expect(sql!).toContain('spDeleteUnneededEntityFields');
+    });
+});

--- a/packages/CodeGenLib/src/__tests__/schema-scope.test.ts
+++ b/packages/CodeGenLib/src/__tests__/schema-scope.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { applyIncludeSchemaScope, computeSchemasToExcludeForIncludeList } from '../Database/schema-scope';
+import { resetAuthoredExcludeSnapshot } from '../Database/heal-schema-params';
 
 /**
  * Unit tests for the `includeSchemas` → `excludeSchemas` resolution.
@@ -50,6 +51,10 @@ describe('computeSchemasToExcludeForIncludeList', () => {
 });
 
 describe('applyIncludeSchemaScope', () => {
+  beforeEach(() => {
+    resetAuthoredExcludeSnapshot();
+  });
+
   it('is a NO-OP when includeSchemas is absent — classic exclude-only behavior is unchanged', () => {
     const config = { excludeSchemas: ['sys', 'staging'] };
     const added = applyIncludeSchemaScope(['dbo', 'app_a', 'sys'], config);


### PR DESCRIPTION
## Summary
- Add optional `@IncludedSchemaNames` to the five CodeGen metadata-heal stored procedures (SQL Server migration; PG via `metadataSupportObjects.ts`). NULL/empty keeps today's exclude-only behavior.
- CodeGen logs authored `excludeSchemas` plus `@IncludedSchemaNames` from `includeSchemas`. It no longer photographs sibling Open Apps into a folded V.
- Cascade-delete SQL is intra-schema only unless `allowCrossSchemaCascadeDeletes` is true (default false; dangerous).
- STEP 4.5 `sp_refreshview` always honors `excludeSchemas`, and when `includeSchemas` is set only refreshes that list.

## Test plan
- [x] CodeGenLib unit tests for cascade filter, view-refresh scope, heal EXEC shape, include compile vs authored exclude snapshot
- [x] `tsc --noEmit` on CodeGenLib
- [x] PostgreSQLCodeGenProvider + scoped-entity-fields tests
- [ ] Apply the new v6 migration on a SQL Server DB and call each SP with only `@ExcludedSchemaNames` (backward compatible) and with `@IncludedSchemaNames`
- [ ] PG counterpart deferred to release build (`migrations-pg` not authored here)

PostgreSQL `migrations-pg` counterpart is deferred to the release build.