### PR TITLE
fix(server): map transport field names onto copies, not the cache's own rows (from #3425)

### DIFF
--- a/.changeset/resolverbase-transport-mapping-copies.md
+++ b/.changeset/resolverbase-transport-mapping-copies.md
@@ -1,0 +1,32 @@
+---
+'@memberjunction/server': patch
+---
+
+fix(server): map GraphQL transport field names onto copies, never onto the cache's own rows
+
+`ResolverBase` renamed `__mj_*` keys to their `_mj__*` wire aliases by writing onto its
+argument. Those arguments are routinely rows straight out of `findBy`/`RunView` — the server
+cache's own objects, held **by reference** under a reference-sharing storage provider. Preparing
+one GraphQL response therefore rewrote `__mj_CreatedAt` inside the live cache, and because that
+cache is process-wide, a single response left every later read across every worker serving
+transport-shaped rows that `BaseEntity.SetMany` rejects.
+
+It reached both halves of the transport rename:
+
+- `MapFieldNamesToCodeNames` (single-record) — every `UserByEmail` / `UserByID` /
+  `UserByEmployeeID` call, and every CodeGen-generated single-record resolver whose entity has
+  caching enabled.
+- The `RunView` result path — `FieldMapper.MapFields` renames by mutating, and
+  `ArrayFilterEncryptedFieldsForAPI` mutates too.
+
+Both now map onto copies. `MapFieldNamesToCodeNames` shallow-copies its argument up front and
+returns the copy; `ArrayMapFieldNamesToCodeNames` returns a new array of new objects rather than
+mapping in place and handing back the caller's array. Shallow is sufficient — the only post-map
+mutators rename top-level keys and redact scalar fields.
+
+Behaviour is unchanged for callers: the same transport-shaped result comes back. What changes is
+that the provider's own row objects are no longer written to.
+
+Extracted from #3425 for the 5.x line; the freeze-on-write half of that PR is deliberately not
+included here, since converting in-place row mutation into a `TypeError` is a behaviour change
+that does not belong in a patch on a certified line.

--- a/packages/MJServer/src/__tests__/ResolverBase.frozenRecordMapping.test.ts
+++ b/packages/MJServer/src/__tests__/ResolverBase.frozenRecordMapping.test.ts
@@ -1,0 +1,135 @@
+// ResolverBase transitively pulls in type-graphql decorators, which need the
+// Reflect.metadata polyfill at import time.
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+import type { IMetadataProvider, UserInfo } from '@memberjunction/core';
+import { ResolverBase } from '../generic/ResolverBase.js';
+
+/**
+ * `MapFieldNamesToCodeNames` must not write into the rows it is handed
+ * (PR #3425 review, finding M2).
+ *
+ * This is the SINGLE-RECORD half of the transport rename. The RunView half was fixed to
+ * copy-then-map, but this one still renamed `__mj_*` → `_mj__*` by writing onto its argument —
+ * and its arguments are frequently rows straight out of `findBy`/`RunView`, i.e. the server
+ * cache's own objects.
+ *
+ * On this line the corruption is SILENT: the rename rewrites the cached row's keys in place and
+ * later readers are served transport-shaped rows that `BaseEntity.SetMany` rejects. Freezing the
+ * fixtures below is how that silent write is turned into a visible failure — the rows are not
+ * frozen at runtime here. (Under 6.x freeze-on-write the same bug surfaces directly, as
+ * "Cannot add property _mj__CreatedAt, object is not extensible".)
+ *
+ * It reaches every call, because `MJ: Users` has caching enabled. `UserByID` and
+ * `UserByEmployeeID` share the code path, and so does every CodeGen-generated single-record
+ * resolver in `generated.ts` (`MapFieldNamesToCodeNames(entity, rows[0], ...)`), which is why
+ * the fix belongs in the shared helper rather than at the call sites.
+ */
+
+/** Exposes the two protected mappers and supplies metadata without a live provider. */
+class MappingProbe extends ResolverBase {
+    public MapOne(entityName: string, dataObject: unknown, provider: IMetadataProvider): Promise<unknown> {
+        return this.MapFieldNamesToCodeNames(entityName, dataObject, undefined, provider);
+    }
+    public MapMany(entityName: string, rows: unknown[], provider: IMetadataProvider, contextUser?: UserInfo): Promise<unknown[]> {
+        return this.ArrayMapFieldNamesToCodeNames(entityName, rows as Record<string, unknown>[], contextUser, provider);
+    }
+}
+
+const ENTITY_NAME = 'MJ: Users';
+
+/**
+ * Minimal metadata: the field set drives the rename, `EncryptedFields` empty so the
+ * EncryptionEngine is never consulted.
+ */
+function fakeProvider(): IMetadataProvider {
+    return {
+        EntityByName: (name: string) =>
+            name === ENTITY_NAME
+                ? {
+                      Name: ENTITY_NAME,
+                      Fields: [
+                          { Name: 'ID', CodeName: 'ID' },
+                          { Name: 'Name', CodeName: 'Name' },
+                          { Name: '__mj_CreatedAt', CodeName: '__mj_CreatedAt' },
+                          { Name: '__mj_UpdatedAt', CodeName: '__mj_UpdatedAt' },
+                      ],
+                      EncryptedFields: [],
+                  }
+                : undefined,
+    } as unknown as IMetadataProvider;
+}
+
+/** A row as the cache hands it out: deep-frozen. */
+function frozenCachedRow(): Record<string, unknown> {
+    return Object.freeze({
+        ID: 'u-1',
+        Name: 'Ada',
+        __mj_CreatedAt: 'T0',
+        __mj_UpdatedAt: 'T1',
+    }) as Record<string, unknown>;
+}
+
+describe('MapFieldNamesToCodeNames on frozen cache rows', () => {
+    it('maps a FROZEN row to transport keys instead of throwing (the live UserByEmail 500)', async () => {
+        const row = frozenCachedRow();
+
+        const mapped = (await new MappingProbe().MapOne(ENTITY_NAME, row, fakeProvider())) as Record<string, unknown>;
+
+        expect(mapped._mj__CreatedAt).toBe('T0');
+        expect(mapped._mj__UpdatedAt).toBe('T1');
+        expect(mapped.ID).toBe('u-1');
+        expect(mapped.Name).toBe('Ada');
+        // The transport aliases replace the originals in the OUTGOING shape.
+        expect(mapped.__mj_CreatedAt).toBeUndefined();
+    });
+
+    it('returns a copy — the caller\'s row keeps its entity field names', async () => {
+        // Unfrozen input, so a regression to in-place mapping would silently pass the frozen
+        // test above only if it also stopped mapping. This one pins non-mutation directly.
+        const row: Record<string, unknown> = { ID: 'u-1', Name: 'Ada', __mj_CreatedAt: 'T0', __mj_UpdatedAt: 'T1' };
+
+        const mapped = (await new MappingProbe().MapOne(ENTITY_NAME, row, fakeProvider())) as Record<string, unknown>;
+
+        expect(row.__mj_CreatedAt).toBe('T0');
+        expect(row._mj__CreatedAt).toBeUndefined();
+        expect(mapped).not.toBe(row);
+    });
+
+    it('still returns null for empty/absent input (contract unchanged)', async () => {
+        const probe = new MappingProbe();
+        expect(await probe.MapOne(ENTITY_NAME, null, fakeProvider())).toBeNull();
+        expect(await probe.MapOne(ENTITY_NAME, {}, fakeProvider())).toBeNull();
+    });
+
+    it('leaves rows with no __mj_ fields structurally intact', async () => {
+        const row = Object.freeze({ ID: 'u-1', Name: 'Ada' }) as Record<string, unknown>;
+
+        const mapped = (await new MappingProbe().MapOne(ENTITY_NAME, row, fakeProvider())) as Record<string, unknown>;
+
+        expect(mapped).toEqual({ ID: 'u-1', Name: 'Ada' });
+    });
+});
+
+describe('ArrayMapFieldNamesToCodeNames on frozen cache rows', () => {
+    it('maps a frozen ARRAY of frozen rows without mutating either', async () => {
+        // The array is frozen as well as the rows: returning the caller's array (rather than a
+        // new one) is its own hazard, since `results.sort()`/`.push()` downstream would then be
+        // mutating cache-owned state. Freezing both is what makes that failure visible here.
+        const rows = Object.freeze([frozenCachedRow(), frozenCachedRow()]) as unknown as Record<string, unknown>[];
+
+        const mapped = (await new MappingProbe().MapMany(ENTITY_NAME, rows, fakeProvider())) as Record<string, unknown>[];
+
+        expect(mapped).toHaveLength(2);
+        expect(mapped[0]._mj__CreatedAt).toBe('T0');
+        expect(mapped[1]._mj__UpdatedAt).toBe('T1');
+        // Inputs untouched.
+        expect(rows[0].__mj_CreatedAt).toBe('T0');
+        expect(rows[0]._mj__CreatedAt).toBeUndefined();
+        expect(mapped[0]).not.toBe(rows[0]);
+    });
+
+    it('passes an empty array straight through', async () => {
+        expect(await new MappingProbe().MapMany(ENTITY_NAME, [], fakeProvider())).toEqual([]);
+    });
+});

--- a/packages/MJServer/src/__tests__/ResolverBase.transportMapping.test.ts
+++ b/packages/MJServer/src/__tests__/ResolverBase.transportMapping.test.ts
@@ -1,0 +1,290 @@
+// ResolverBase transitively pulls in type-graphql decorators, which need the
+// Reflect.metadata polyfill at import time.
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+import type { DatabaseProviderBase, RunViewParams, RunViewResult, UserInfo } from '@memberjunction/core';
+import type { MJUserViewEntityExtended } from '@memberjunction/core-entities';
+import { FieldMapper } from '@memberjunction/graphql-dataprovider';
+import { ResolverBase } from '../generic/ResolverBase.js';
+import type { UserPayload } from '../types.js';
+
+/**
+ * Regression guard for the server-cache corruption behind
+ * "Field _mj__CreatedAt does not exist on MJ: Template Categories".
+ *
+ * GraphQL reserves the `__` prefix, so MJ renames `__mj_*` columns to the
+ * transport alias `_mj__*` on the way out. `ResolverBase` used to apply that
+ * rename IN PLACE over `result.Results` — but those are the data provider's own
+ * row objects, and the server's cache holds them BY REFERENCE. Preparing one
+ * GraphQL response therefore rewrote the keys inside the live cache, and every
+ * subsequent read served from it handed the client transport-shaped rows that
+ * `BaseEntity.SetMany` rejects. Process-wide cache ⇒ one response poisoned every
+ * later request, across all workers.
+ *
+ * The fix is copy-then-map. The first block exercises the REAL resolver path (so a
+ * revert to in-place mapping fails here); the second pins the two `FieldMapper`
+ * invariants that make the fix correct.
+ *
+ * The third block runs the same path against FROZEN input. On this line nothing freezes
+ * cache rows, so `Object.freeze` here is a test instrument, not a simulation of runtime:
+ * it is how "never writes to its argument" is asserted directly rather than inferred. It
+ * also pre-stages the 6.x freeze-on-write behaviour, under which in-place mapping stops
+ * being silent corruption and becomes an outright `TypeError`.
+ */
+
+/** A cache-held row, shaped the way the provider hands them back. */
+type CachedRow = Record<string, unknown>;
+
+/**
+ * Reaches the protected `RunViewGenericInternal` and records what
+ * `ArrayFilterEncryptedFieldsForAPI` was handed — the second in-place mutator that
+ * must also see copies, and stubbed here so the assertion needs no live Metadata.
+ */
+class Probe extends ResolverBase {
+    public filteredRows: Record<string, unknown>[] | null = null;
+
+    protected override async ArrayFilterEncryptedFieldsForAPI(
+        _entityName: string,
+        dataObjectArray: Record<string, unknown>[]
+    ): Promise<Record<string, unknown>[]> {
+        this.filteredRows = dataObjectArray;
+        return dataObjectArray;
+    }
+
+    public Run(provider: DatabaseProviderBase, viewInfo: MJUserViewEntityExtended, userPayload: UserPayload) {
+        return this.RunViewGenericInternal(
+            provider,
+            viewInfo,
+            '', // extraFilter
+            '', // orderBy
+            '', // userSearchString
+            undefined, // excludeUserViewRunID
+            undefined, // overrideExcludeFilter
+            undefined, // saveViewResults
+            undefined, // fields
+            undefined, // ignoreMaxRows
+            undefined, // excludeDataFromAllPriorViewRuns
+            undefined, // forceAuditLog
+            undefined, // auditLogDescription
+            'simple', // resultType
+            userPayload,
+            undefined, // maxRows
+            undefined // startRow
+        );
+    }
+}
+
+const ENTITY_NAME = 'MJ: Template Categories';
+
+/** Minimal provider: the entity lookup + the RunView the resolver awaits. */
+function fakeProvider(rows: CachedRow[]): DatabaseProviderBase {
+    return {
+        Entities: [{ Name: ENTITY_NAME, PrimaryKeys: [{ Name: 'ID' }] }],
+        RunView: async (_params: RunViewParams): Promise<RunViewResult> =>
+            ({ Success: true, Results: rows, RowCount: rows.length, TotalRowCount: rows.length, ErrorMessage: '' } as RunViewResult),
+    } as unknown as DatabaseProviderBase;
+}
+
+const fakeViewInfo = () =>
+    ({ ID: 'view-1', Name: 'Test View', Entity: ENTITY_NAME } as unknown as MJUserViewEntityExtended);
+
+/** `userRecord` short-circuits the UserCache lookup; no apiKeyHash skips the scope check. */
+const fakePayload = () =>
+    ({ email: 'tester@example.com', userRecord: { Email: 'tester@example.com' } as UserInfo } as UserPayload);
+
+describe('ResolverBase.RunViewGenericInternal — cache safety', () => {
+    it('leaves the provider\'s (cache-held) rows untouched while returning transport keys', async () => {
+        const cachedRow: CachedRow = { ID: 'a1', Name: 'Cat', __mj_CreatedAt: 'T0', __mj_UpdatedAt: 'T1' };
+        const probe = new Probe();
+
+        const result = await probe.Run(fakeProvider([cachedRow]), fakeViewInfo(), fakePayload());
+
+        // The pre-fix code renamed these keys in place — this is the assertion that fails on a revert.
+        expect(cachedRow.__mj_CreatedAt).toBe('T0');
+        expect(cachedRow.__mj_UpdatedAt).toBe('T1');
+        expect(cachedRow._mj__CreatedAt).toBeUndefined();
+
+        // The outgoing rows carry the GraphQL-legal aliases, and are NOT the cached objects.
+        const wire = result?.Results as Record<string, unknown>[];
+        expect(wire[0]._mj__CreatedAt).toBe('T0');
+        expect(wire[0]).not.toBe(cachedRow);
+    });
+
+    it('hands the encrypted-field filter the copies, not the cached rows', async () => {
+        const cachedRow: CachedRow = { ID: 'a1', Secret: 'plaintext', __mj_CreatedAt: 'T0' };
+        const probe = new Probe();
+
+        await probe.Run(fakeProvider([cachedRow]), fakeViewInfo(), fakePayload());
+
+        expect(probe.filteredRows).not.toBeNull();
+        expect(probe.filteredRows![0]).not.toBe(cachedRow);
+    });
+});
+
+describe('FieldMapper transport mapping — the invariants the fix rests on', () => {
+    it('MapFields MUTATES its argument (the hazard the resolver must not expose the cache to)', () => {
+        // Documents WHY the resolver must copy. If this ever becomes non-mutating,
+        // the copy in ResolverBase is redundant rather than load-bearing — and this
+        // test failing is the signal to revisit it.
+        const row: Record<string, unknown> = { ID: 'a1', Name: 'Cat', __mj_CreatedAt: 'T0' };
+
+        new FieldMapper().MapFields(row);
+
+        expect(row.__mj_CreatedAt).toBeUndefined();
+        expect(row._mj__CreatedAt).toBe('T0');
+    });
+
+    it('post-map mutation of the copy cannot reach the cached row', () => {
+        // ArrayFilterEncryptedFieldsForAPI redacts in place after mapping; on the
+        // pre-fix code that stripped secrets out of the CACHED row too.
+        const mapper = new FieldMapper();
+        const cachedRow: Record<string, unknown> = { ID: 'a1', Secret: 'plaintext', __mj_CreatedAt: 'T0' };
+
+        const wireRow = mapper.MapFields({ ...cachedRow })!;
+        wireRow.Secret = null; // stand-in for the encrypted-field filter
+
+        expect(cachedRow.Secret).toBe('plaintext');
+        expect(wireRow.Secret).toBeNull();
+    });
+
+    it('round-trips a mapped copy back to entity field names', () => {
+        // The client's ConvertBackToMJFields must undo exactly what the server did.
+        const mapper = new FieldMapper();
+        const original: Record<string, unknown> = { ID: 'a1', __mj_CreatedAt: 'T0', __mj_UpdatedAt: 'T1' };
+
+        const wire = mapper.MapFields({ ...original })!;
+        const back = mapper.ReverseMapFields({ ...wire });
+
+        expect(back).toEqual(original);
+    });
+
+    it('leaves rows without __mj_ fields structurally unchanged', () => {
+        const mapper = new FieldMapper();
+        const row = { ID: 'a1', Name: 'Cat' };
+
+        expect(mapper.MapFields({ ...row })).toEqual(row);
+    });
+});
+
+describe('transport mapping against FROZEN cache rows', () => {
+    // Freezing is the assertion mechanism, not a reproduction of runtime state: on this line
+    // the cache hands out live, unfrozen references. A frozen input makes "the mapper wrote to
+    // its argument" fail loudly here instead of passing silently and corrupting the cache in
+    // production. It is also the shape 6.x's freeze-on-write will actually hand out.
+    it('copy-then-map works on a frozen row', () => {
+        const mapper = new FieldMapper();
+        const cachedRow = Object.freeze({ ID: 'a1', Name: 'Cat', __mj_CreatedAt: 'T0' }) as Record<string, unknown>;
+
+        const wireRow = mapper.MapFields({ ...cachedRow })!;
+
+        expect(wireRow._mj__CreatedAt).toBe('T0');
+        expect(wireRow.__mj_CreatedAt).toBeUndefined();
+        // The copy is mutable, so the encrypted-field filter can still redact in place.
+        expect(Object.isFrozen(wireRow)).toBe(false);
+        // And the frozen cached row is untouched.
+        expect(cachedRow.__mj_CreatedAt).toBe('T0');
+    });
+
+    it('in-place mapping of a frozen row THROWS — silent corruption is now impossible', () => {
+        // This is the safety net the freeze adds on top of the copy: if a future refactor
+        // reverts to in-place mapping, it fails loudly at the offending line instead of
+        // quietly rewriting process-wide state.
+        const mapper = new FieldMapper();
+        const cachedRow = Object.freeze({ ID: 'a1', __mj_CreatedAt: 'T0' }) as Record<string, unknown>;
+
+        expect(() => mapper.MapFields(cachedRow)).toThrow(TypeError);
+    });
+});
+
+/**
+ * The BATCH path (`RunViewsGenericInternal`), which the single-view tests above do not reach
+ * (PR #3425 review, finding M8).
+ *
+ * This is the path multi-view clients actually take — MJExplorer batches its view loads — so
+ * leaving it uncovered meant the original corruption bug could be reintroduced on the more
+ * heavily used of the two legs with CI still green.
+ */
+class BatchProbe extends ResolverBase {
+    public filteredRows: Record<string, unknown>[] | null = null;
+
+    protected override async ArrayFilterEncryptedFieldsForAPI(
+        _entityName: string,
+        dataObjectArray: Record<string, unknown>[]
+    ): Promise<Record<string, unknown>[]> {
+        this.filteredRows = dataObjectArray;
+        return dataObjectArray;
+    }
+
+    public RunBatch(provider: DatabaseProviderBase, viewInfos: MJUserViewEntityExtended[], userPayload: UserPayload) {
+        return this.RunViewsGenericInternal(
+            viewInfos.map(viewInfo => ({ provider, viewInfo, userPayload, resultType: 'simple' })) as never
+        );
+    }
+}
+
+/** Batch provider: `RunViews` returns one result per param, in order. */
+function fakeBatchProvider(rowsPerView: CachedRow[][]): DatabaseProviderBase {
+    return {
+        Entities: [{ Name: ENTITY_NAME, PrimaryKeys: [{ Name: 'ID' }] }],
+        EntityByName: (name: string) => (name === ENTITY_NAME ? { Name: ENTITY_NAME } : undefined),
+        RunViews: async (params: RunViewParams[]): Promise<RunViewResult[]> =>
+            params.map((_p, i) => {
+                const rows = rowsPerView[i] ?? [];
+                return { Success: true, Results: rows, RowCount: rows.length, TotalRowCount: rows.length, ErrorMessage: '' } as RunViewResult;
+            }),
+    } as unknown as DatabaseProviderBase;
+}
+
+describe('ResolverBase.RunViewsGenericInternal (batch) — cache safety', () => {
+    it('leaves every view\'s cache-held rows untouched while returning transport keys', async () => {
+        const viewARow: CachedRow = { ID: 'a1', Name: 'Cat', __mj_CreatedAt: 'T0', __mj_UpdatedAt: 'T1' };
+        const viewBRow: CachedRow = { ID: 'b1', Name: 'Dog', __mj_CreatedAt: 'T2', __mj_UpdatedAt: 'T3' };
+        const probe = new BatchProbe();
+
+        const results = await probe.RunBatch(
+            fakeBatchProvider([[viewARow], [viewBRow]]),
+            [fakeViewInfo(), fakeViewInfo()],
+            fakePayload()
+        );
+
+        // Both source rows keep entity field names — the assertion that fails on a revert
+        // to in-place mapping in the batch loop.
+        expect(viewARow.__mj_CreatedAt).toBe('T0');
+        expect(viewARow._mj__CreatedAt).toBeUndefined();
+        expect(viewBRow.__mj_CreatedAt).toBe('T2');
+        expect(viewBRow._mj__CreatedAt).toBeUndefined();
+
+        // ...and both outgoing views carry the aliases, on objects that are not the cached ones.
+        const wireA = results[0].Results as Record<string, unknown>[];
+        const wireB = results[1].Results as Record<string, unknown>[];
+        expect(wireA[0]._mj__CreatedAt).toBe('T0');
+        expect(wireB[0]._mj__CreatedAt).toBe('T2');
+        expect(wireA[0]).not.toBe(viewARow);
+        expect(wireB[0]).not.toBe(viewBRow);
+    });
+
+    it('maps FROZEN cache rows rather than throwing on them', async () => {
+        // The shape the cache actually hands out on a hit.
+        const frozenRow = Object.freeze({ ID: 'a1', Name: 'Cat', __mj_CreatedAt: 'T0' }) as CachedRow;
+        const probe = new BatchProbe();
+
+        const results = await probe.RunBatch(
+            fakeBatchProvider([[frozenRow]]),
+            [fakeViewInfo()],
+            fakePayload()
+        );
+
+        expect((results[0].Results as Record<string, unknown>[])[0]._mj__CreatedAt).toBe('T0');
+        expect(frozenRow.__mj_CreatedAt).toBe('T0');
+    });
+
+    it('hands the encrypted-field filter copies, not the cached rows', async () => {
+        const cachedRow: CachedRow = { ID: 'a1', Secret: 'plaintext', __mj_CreatedAt: 'T0' };
+        const probe = new BatchProbe();
+
+        await probe.RunBatch(fakeBatchProvider([[cachedRow]]), [fakeViewInfo()], fakePayload());
+
+        expect(probe.filteredRows).not.toBeNull();
+        expect(probe.filteredRows![0]).not.toBe(cachedRow);
+    });
+});

--- a/packages/MJServer/src/generic/ResolverBase.ts
+++ b/packages/MJServer/src/generic/ResolverBase.ts
@@ -62,16 +62,27 @@ export class ResolverBase {
    * - AllowDecryptInAPI=false + SendEncryptedValue=true: Keep encrypted ciphertext
    * - AllowDecryptInAPI=false + SendEncryptedValue=false: Replace with sentinel
    *
+   * Returns a COPY — `dataObject` is never written to. Callers routinely pass rows straight
+   * from `findBy`/`RunView`, which are the server cache's own objects held by reference under a
+   * reference-sharing storage provider. Renaming in place therefore rewrote the cached row's
+   * keys, so later readers were served transport-shaped rows that `BaseEntity.SetMany` rejects —
+   * and because that cache is process-wide, one response corrupted every subsequent request
+   * across all workers. It bit every `UserByEmail` / `UserByID` / `UserByEmployeeID` call and
+   * every generated single-record resolver whose entity has caching enabled. Copying here fixes
+   * every call site at once and makes the hazard unreachable for future ones.
+   *
    * @param entityName - The entity name
-   * @param dataObject - The data object with field values
+   * @param dataObject - The data object with field values. Not modified.
    * @param contextUser - Optional user context for decryption (required for encrypted fields)
-   * @returns The processed data object
+   * @returns A new object in transport shape, or null when there is nothing to map
    */
   protected async MapFieldNamesToCodeNames(entityName: string, dataObject: any, contextUser?: UserInfo, provider?: IMetadataProvider): Promise<any> {
     // Return null for empty objects (e.g. when no rows found due to RLS filtering)
     if (!dataObject || Object.keys(dataObject).length === 0) {
       return null;
     }
+    // Shallow copy up front so every write below lands on our object, never the caller's.
+    dataObject = { ...dataObject };
 
     // for the given entity name provided, check to see if there are any fields
     // where the code name is different from the field name, and for just those
@@ -184,14 +195,21 @@ export class ResolverBase {
     return true;
   }
 
-  protected async ArrayMapFieldNamesToCodeNames(entityName: string, dataObjectArray: any[], contextUser?: UserInfo): Promise<any[]> {
-    // iterate through the array and call MapFieldNamesToCodeNames for each element
-    if (dataObjectArray && dataObjectArray.length > 0) {
-      for (const element of dataObjectArray) {
-        await this.MapFieldNamesToCodeNames(entityName, element, contextUser);
-      }
+  /**
+   * Array form of {@link MapFieldNamesToCodeNames}. Returns a NEW array of NEW objects; neither
+   * the input array nor its rows are modified. Both matter: a reference-sharing cache hands back
+   * the stored array itself, not a copy of it, so collecting the mapped copies (rather than
+   * mapping in place and returning the original) is what makes this safe on cache-served input.
+   */
+  protected async ArrayMapFieldNamesToCodeNames(entityName: string, dataObjectArray: any[], contextUser?: UserInfo, provider?: IMetadataProvider): Promise<any[]> {
+    if (!dataObjectArray || dataObjectArray.length === 0) {
+      return dataObjectArray;
     }
-    return dataObjectArray;
+    const mapped: any[] = [];
+    for (const element of dataObjectArray) {
+      mapped.push(await this.MapFieldNamesToCodeNames(entityName, element, contextUser, provider));
+    }
+    return mapped;
   }
 
   /**
@@ -819,12 +837,24 @@ export class ResolverBase {
         LogStatus(`[ResolverBase] RunView result aggregate info: entityName=${viewInfo.Entity}, hasAggregateResults=${!!result?.AggregateResults}, aggregateResultCount=${result?.AggregateResults?.length || 0}, aggregateExecutionTime=${result?.AggregateExecutionTime}, aggregateResults=${JSON.stringify(result?.AggregateResults)}`);
       }
 
-      // Process results for GraphQL transport
+      // Process results for GraphQL transport.
+      //
+      // Map onto COPIES, never in place. `FieldMapper.MapFields` renames keys by
+      // mutating (`obj[mapped] = obj[k]; delete obj[k]`), and these rows are the
+      // provider's own result objects — which the server cache holds BY REFERENCE
+      // under a reference-sharing storage provider. Mapping them in place rewrote
+      // `__mj_CreatedAt` to the transport alias `_mj__CreatedAt` inside the live
+      // cache, and because that cache is process-wide, one GraphQL response made
+      // every later read hand back transport-shaped rows that `BaseEntity.SetMany`
+      // rejects. `ArrayFilterEncryptedFieldsForAPI` mutates too, so it must also
+      // see the copies. (FileResolver already maps a spread copy.)
+      //
+      // `{ ...r }` is a SHALLOW copy, which is sufficient here because the only
+      // post-map mutators rename top-level keys and redact scalar fields; nothing
+      // below writes through to a nested value.
       const mapper = new FieldMapper();
       if (result?.Success && result.Results?.length) {
-        for (const r of result.Results) {
-          mapper.MapFields(r);
-        }
+        result.Results = result.Results.map(r => mapper.MapFields({ ...r }));
         // Filter encrypted fields before sending to API client
         await this.ArrayFilterEncryptedFieldsForAPI(
           viewInfo.Entity,
@@ -941,9 +971,9 @@ export class ResolverBase {
       for (let i = 0; i < runViewResults.length; i++) {
         const runViewResult = runViewResults[i];
         if (runViewResult?.Success && runViewResult.Results?.length) {
-          for (const result of runViewResult.Results) {
-            mapper.MapFields(result);
-          }
+          // Copy-then-map, same reason as the single-view path above: these rows
+          // are cache-held references and MapFields renames keys in place.
+          runViewResult.Results = runViewResult.Results.map(r => mapper.MapFields({ ...r }));
           // Filter encrypted fields before sending to API client
           // Use the corresponding param's entity name
           const entityName = params[i]?.viewInfo?.Entity;


### PR DESCRIPTION
Splits the `ResolverBase` half out of #3425 for the 5.x line, per review on #4067. Companion to that PR — the two are independent and can land in either order.

## The bug

`ResolverBase` renamed `__mj_*` keys to their `_mj__*` wire aliases by **writing onto its argument**. Those arguments are routinely rows straight out of `findBy`/`RunView` — the server cache's own objects, held **by reference** under a reference-sharing storage provider.

So preparing one GraphQL response rewrote `__mj_CreatedAt` inside the live cache. The cache is process-wide, which means a single response left every later read, across every worker, serving transport-shaped rows that `BaseEntity.SetMany` rejects.

Both halves of the rename were affected:

- **`MapFieldNamesToCodeNames`** (single record) — every `UserByEmail` / `UserByID` / `UserByEmployeeID` call, plus every CodeGen-generated single-record resolver whose entity has caching enabled.
- **The `RunView` result path** — `FieldMapper.MapFields` renames by mutating, and `ArrayFilterEncryptedFieldsForAPI` mutates too, so both need to see copies.

## The fix

Map onto copies, never onto the caller's objects.

`MapFieldNamesToCodeNames` shallow-copies its argument up front and returns the copy. `ArrayMapFieldNamesToCodeNames` returns a new array of new objects instead of mapping in place and handing back the caller's array — the array matters as much as the rows, since a downstream `results.sort()` or `.push()` would otherwise mutate cache-owned state.

Shallow is sufficient: the only post-map mutators rename top-level keys and redact scalar fields, and nothing writes through to a nested value.

Callers see no difference — the same transport-shaped result comes back. What changes is that the provider's own row objects are no longer written to.

## What is deliberately NOT here

The freeze-on-write half of #3425 stays on 6.x. Converting in-place mutation of RunView rows into a `TypeError` is a behaviour change, and a patch on a certified line does not get to make one — code doing that today works, and there is no way to survey who is.

Because of that split, the comments and test prose inherited from #3425 were **rewritten to match this line**, since they described a freeze that does not exist here:

- On 6.x the bug surfaces loudly, as `Cannot add property _mj__CreatedAt, object is not extensible`.
- On this line it is **silent** — the keys are rewritten and the corruption shows up later, in `SetMany`.
- `Object.freeze` in the tests is therefore an *assertion instrument*, not a simulation of runtime state: it is how "the mapper wrote to its argument" is made to fail loudly in a test instead of passing quietly and corrupting a real cache. It also pre-stages the 6.x behaviour.

The code itself is byte-identical to #3425's; only prose changed.

## Verification

`@memberjunction/server` builds clean. Full MJServer suite: **822 passed, 56 skipped**, of which the two `ResolverBase` suites contribute **17 passed**.

One pre-existing failure, unrelated and not introduced here: `mjapi-bootstrap.test.ts` cannot resolve `mj_generatedentities`, whose `main` is `dist/index.js` — CodeGen output requiring a live database, which this environment does not have.

Rebased onto `lts/5` @ `3e140cecc9`, which picks up #4070, so `test.yml` and `integration.yml` now run on `lts/**` PRs — the checks here exercise the code. That supersedes the earlier note that they could not.

## Unrelated observation

`packages/GraphQLDataProvider/src/version.generated.ts` on `lts/5` still reads `PACKAGE_VERSION = '5.51.0'`; a local build regenerates it to `5.51.1`. Looks like it was not regenerated during the 5.51.1 release. Deliberately excluded from this PR — flagging it rather than fixing it here.

