### PR TITLE
ci: build the release-lines.json append the process doc already promised

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,21 @@ on:
         description: 'Double-entry confirmation, required for every dispatch: type the line branch again for a line release, or "main" for a manual Edge publish (which must be dispatched from main).'
         required: false
         default: ''
+      # dbImpact recorded in release-lines.json for a LINE release (process doc §12).
+      # A line patch is normally code-only. If this one carries a labeled migration, say so
+      # here — the append step cross-checks the claim against the migrations actually in the
+      # release range and fails on a false `none`, so leaving the default alone cannot
+      # quietly write a wrong ledger entry.
+      db_impact:
+        description: 'LTS path: dbImpact for this line release.'
+        required: false
+        default: 'none'
+        type: choice
+        options:
+          - none
+          - metadata
+          - repair
+          - schema
 
 
 permissions:
@@ -495,6 +510,41 @@ jobs:
           git log -n1
           pnpm run mergemain:update-lock
 
+      # release-lines.json bookkeeping. Process doc §4.1 says publish workflows append the
+      # mechanical fields (`newest`, and the per-release `releases` ledger) via direct push.
+      # That was documented and never built, so the file drifted from the registry the moment
+      # anything shipped: `edge.newest` was still null after 6.1.0-edge.0 through edge.3, and
+      # 5.51.1 published on 2026-08-19 and was recorded by hand a week later.
+      #
+      # It writes to `next`, never to `main`. A push to main is this workflow's own Edge
+      # trigger, so a bookkeeping commit there would start a publish that consumes whatever
+      # changesets are banked on main. `next` carries no publish trigger, and main inherits
+      # the entry at the next release through the merge step above. The step above has already
+      # pushed HEAD:next, so HEAD is the branch tip here.
+      #
+      # LAST step in the job, deliberately, and fatal rather than continue-on-error. The
+      # packages are on npm by the time this runs, so a failure means "released, not yet
+      # recorded" — recoverable by hand — while a red run is the only signal that the ledger
+      # is behind. [skip ci] keeps a predictable two-field JSON edit from re-running every
+      # gate; `--mode push` proves the edit touched nothing else before it is committed.
+      - name: Record the release in release-lines.json
+        if: ${{ env.BRANCH == 'main' }}
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          if ! PREV=$(git describe --tags --abbrev=0 "${VERSION}^"); then
+            echo "::error::cannot resolve the release tag preceding ${VERSION}; record ${VERSION#v} in release-lines.json by hand"
+            exit 1
+          fi
+          echo "::notice::classifying dbImpact over ${PREV}..${VERSION}"
+          git fetch origin next
+          node ci/append-release-line.mjs --version "${VERSION#v}" --since "$PREV" --until "$VERSION"
+          node ci/validate-release-lines.mjs --base origin/next --mode push
+          git add release-lines.json
+          git commit -m "chore: record ${VERSION#v} in release-lines.json [skip ci]"
+          git push origin HEAD:next
+
   # ---------------------------------------------------------------------------
   # LTS line release (guides/RELEASE_ENGINEERING_RUNBOOK.md operation 3;
   # plans/lts-process.md §5.2 rule 3 / §14.1). Ported verbatim in behavior from
@@ -772,5 +822,32 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run docs.yml --repo "$GITHUB_REPOSITORY" --ref next
+
+      # Same bookkeeping as the edge path above — see that step for why it writes to `next`,
+      # why it is last, and why it is fatal. One difference: this job is checked out on the
+      # LINE branch, whose own release-lines.json is inert (`"lines": {}`) because the source
+      # of truth lives on next/main. So it switches to next before editing, and pushes there.
+      #
+      # dbImpact comes from the dispatch input rather than being classified, because on a line
+      # the operator already made that call when they applied the §12 label. The script still
+      # cross-checks it against the migrations in the range and refuses a `none` that
+      # contradicts them.
+      - name: Record the line release in release-lines.json
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          DB_IMPACT: ${{ github.event.inputs.db_impact }}
+        run: |
+          set -euo pipefail
+          if ! PREV=$(git describe --tags --abbrev=0 "${VERSION}^"); then
+            echo "::error::cannot resolve the release tag preceding ${VERSION}; record ${VERSION#v} in release-lines.json by hand"
+            exit 1
+          fi
+          git fetch origin next
+          git checkout -B record-release-lines origin/next
+          node ci/append-release-line.mjs --version "${VERSION#v}" --db-impact "${DB_IMPACT:-none}" --since "$PREV" --until "$VERSION"
+          node ci/validate-release-lines.mjs --base origin/next --mode push
+          git add release-lines.json
+          git commit -m "chore: record ${VERSION#v} in release-lines.json [skip ci]"
+          git push origin HEAD:next
 
 

--- a/ci/append-release-line.mjs
+++ b/ci/append-release-line.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Appends a published release to release-lines.json's MECHANICAL fields.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * plans/lts-process.md §4.1 states that publish workflows append `newest` and the
+ * per-release `releases` ledger via direct push. That machinery was never built, so
+ * the file drifted from the registry the moment anything shipped:
+ *
+ *   - `edge.newest` was still `null` after 6.1.0-edge.0 through edge.3 published.
+ *   - 5.51.1 published 2026-08-19 and was recorded by hand a week later.
+ *
+ * Nothing reads the file yet, so nothing was visibly broken — but it is the declared
+ * input for the CLI channel work (§15 item 7), and building that against a file no
+ * one maintains ships a CLI that is wrong on day one.
+ *
+ * WHAT IT TOUCHES
+ * ---------------
+ * ONLY `edge.newest` / `edge.releases` and `lines.<X.Y>.newest` /
+ * `lines.<X.Y>.releases`. Never `status`, `certifiedBuild`, or any date — those are
+ * certification decisions, CODEOWNERS-gated to the certification owner, and moving
+ * them is §8's whole point. assertOnlyMechanicalChange() enforces that here, and
+ * ci/validate-release-lines.mjs --mode push enforces it again in CI.
+ *
+ * dbImpact
+ * --------
+ * Pass --db-impact to state it. Otherwise it is classified from the migrations in the
+ * release range, by the regex tripwire §5.2 rule 4 describes:
+ *
+ *   no migration files changed          -> none
+ *   migrations changed, no DDL keyword  -> metadata
+ *   any DDL keyword                     -> schema
+ *
+ * The tripwire is not the gate, and it deliberately never emits `repair`. A
+ * generated-object repair (§12) is DDL by regex and schema-neutral in substance;
+ * only a human reading the diff can tell those apart, so this reports `schema` and
+ * says so, leaving the operator to correct it. Dynamic SQL (EXEC, sp_rename,
+ * string-built DDL) evades any regex — same caveat the process doc already carries.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+/** Every value the schema's dbImpact enum accepts. */
+export const DB_IMPACTS = ['none', 'metadata', 'repair', 'schema'];
+
+/** Runaway guards. A release touching more than this many migrations is not a release. */
+export const MAX_MIGRATION_FILES = 500;
+export const MAX_MIGRATION_BYTES = 8 * 1024 * 1024;
+
+const RX_EDGE = /^(\d+)\.(\d+)\.(\d+)-edge\.(\d+)$/;
+const RX_LINE = /^(\d+)\.(\d+)\.(\d+)$/;
+const RX_DDL = /\b(CREATE|ALTER|DROP|TRUNCATE|RENAME)\b/i;
+
+/**
+ * Which channel a version string belongs to, and for a line release, which line.
+ * @param {string} version
+ * @returns {{kind: 'edge'|'line', lineKey?: string}}
+ */
+export function classifyChannel(version) {
+    if (typeof version !== 'string' || version.length === 0) throw new Error('version is required');
+    if (RX_EDGE.test(version)) return { kind: 'edge' };
+    const line = RX_LINE.exec(version);
+    if (line) return { kind: 'line', lineKey: `${line[1]}.${line[2]}` };
+    throw new Error(`version "${version}" is neither X.Y.Z nor X.Y.Z-edge.N`);
+}
+
+/**
+ * Strip SQL comments so a keyword inside `-- drop this later` cannot trip the scan.
+ * @param {string} sql
+ */
+export function stripSqlComments(sql) {
+    return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+}
+
+/**
+ * The §5.2 rule 4 tripwire. Pure: the caller supplies the file list and a reader.
+ * @param {string[]} files migration paths changed in the release range
+ * @param {(path: string) => string} readFile
+ * @returns {{dbImpact: 'none'|'metadata'|'schema', evidence: string[]}}
+ */
+export function classifyDbImpact(files, readFile) {
+    if (files.length === 0) return { dbImpact: 'none', evidence: [] };
+    if (files.length > MAX_MIGRATION_FILES) {
+        throw new Error(`${files.length} migration files in range, over the ${MAX_MIGRATION_FILES} cap — classify by hand with --db-impact`);
+    }
+    const evidence = [];
+    for (const f of files) {
+        const sql = readFile(f);
+        if (sql.length > MAX_MIGRATION_BYTES) {
+            throw new Error(`${f} is ${sql.length} bytes, over the ${MAX_MIGRATION_BYTES} cap — classify by hand with --db-impact`);
+        }
+        const hit = RX_DDL.exec(stripSqlComments(sql));
+        if (hit) evidence.push(`${f}: ${hit[1].toUpperCase()}`);
+    }
+    if (evidence.length > 0) return { dbImpact: 'schema', evidence };
+    return { dbImpact: 'metadata', evidence: files.map((f) => `${f}: no DDL keyword`) };
+}
+
+/**
+ * Append the release to the mechanical fields. Pure — returns a new document.
+ * @param {object} doc parsed release-lines.json
+ * @param {string} version
+ * @param {'none'|'metadata'|'repair'|'schema'} dbImpact
+ */
+export function appendRelease(doc, version, dbImpact) {
+    if (!DB_IMPACTS.includes(dbImpact)) throw new Error(`dbImpact "${dbImpact}" not one of ${DB_IMPACTS.join('|')}`);
+    const next = structuredClone(doc);
+    const channel = classifyChannel(version);
+
+    const target = channel.kind === 'edge' ? next.edge : next.lines?.[channel.lineKey];
+    if (!target) {
+        throw new Error(
+            `line ${channel.lineKey} is not in release-lines.json. A line release for an unknown ` +
+            `line means the line branch was cut without its entry — add the entry in a reviewed PR first.`,
+        );
+    }
+    target.newest = version;
+    target.releases = { ...(target.releases ?? {}), [version]: { dbImpact } };
+    return next;
+}
+
+/**
+ * Refuse to write if anything outside the mechanical fields moved.
+ * @param {object} before
+ * @param {object} after
+ */
+export function assertOnlyMechanicalChange(before, after) {
+    const strip = (doc) => {
+        const c = structuredClone(doc);
+        for (const holder of [c.edge, ...Object.values(c.lines ?? {})]) {
+            if (!holder) continue;
+            delete holder.newest;
+            delete holder.releases;
+        }
+        return JSON.stringify(c);
+    };
+    if (strip(before) !== strip(after)) {
+        throw new Error('refusing to write: a non-mechanical field changed (status/certifiedBuild/dates are §8 territory)');
+    }
+}
+
+/**
+ * An operator's explicit --db-impact overrides the tripwire, with one exception: claiming
+ * `none` while migrations actually shipped is not an override, it is a false ledger entry.
+ * The reverse directions are legitimate — `repair` for a generated-object DROP/CREATE the
+ * regex reads as `schema`, or a deliberately stricter value.
+ * @param {string} explicit
+ * @param {string} classified
+ */
+export function reconcileDbImpact(explicit, classified) {
+    if (explicit === 'none' && classified !== 'none') {
+        throw new Error(
+            `--db-impact none contradicts the release contents (classified "${classified}"): ` +
+            `migrations shipped in this range. Record the real impact, or fix the range.`,
+        );
+    }
+    return explicit;
+}
+
+/** @param {string[]} argv */
+export function parseCliArgs(argv) {
+    const args = { version: null, dbImpact: null, file: 'release-lines.json', since: null, until: 'HEAD', dryRun: false };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--version') args.version = argv[++i];
+        else if (a === '--db-impact') args.dbImpact = argv[++i];
+        else if (a === '--file') args.file = argv[++i];
+        else if (a === '--since') args.since = argv[++i];
+        else if (a === '--until') args.until = argv[++i];
+        else if (a === '--dry-run') args.dryRun = true;
+        else throw new Error(`unknown argument "${a}"`);
+    }
+    if (!args.version) throw new Error('--version is required');
+    return args;
+}
+
+/** Migration files changed in a git range. Side-effectful: shells out to git. */
+function changedMigrationFiles(since, until) {
+    const out = execFileSync('git', ['diff', '--name-only', `${since}..${until}`, '--', 'migrations/'], {
+        encoding: 'utf8',
+        maxBuffer: MAX_MIGRATION_BYTES,
+    });
+    return out.split('\n').map((s) => s.trim()).filter((s) => s.endsWith('.sql'));
+}
+
+/**
+ * Read one migration at a git ref.
+ *
+ * `maxBuffer` is not optional here. MJ's metadata-sync migrations run past a megabyte
+ * routinely (v5.45's was 12,041 lines), and execFileSync's default buffer is smaller than
+ * that, so the default kills the process with a raw ENOBUFS before MAX_MIGRATION_BYTES is
+ * ever consulted — i.e. the cap has to live on the reader, not only in the classifier.
+ * Left unset this would have failed the first Edge publish that shipped a metadata sync,
+ * which is nearly all of them.
+ *
+ * @param {string} ref
+ * @param {string} path
+ * @param {(file: string, args: string[], opts: object) => string} [exec] injectable for tests
+ */
+export function readMigrationAtRef(ref, path, exec = execFileSync) {
+    try {
+        return exec('git', ['show', `${ref}:${path}`], { encoding: 'utf8', maxBuffer: MAX_MIGRATION_BYTES });
+    } catch (e) {
+        if (e && e.code === 'ENOBUFS') {
+            throw new Error(`${path} at ${ref} exceeds the ${MAX_MIGRATION_BYTES}-byte read cap — classify by hand with --db-impact`);
+        }
+        throw e;
+    }
+}
+
+function main(argv) {
+    const args = parseCliArgs(argv);
+    const before = JSON.parse(readFileSync(args.file, 'utf8'));
+
+    let dbImpact = args.dbImpact;
+    if (dbImpact !== null && args.since !== null) {
+        const files = changedMigrationFiles(args.since, args.until);
+        const verdict = classifyDbImpact(files, (f) => readMigrationAtRef(args.until, f));
+        reconcileDbImpact(dbImpact, verdict.dbImpact);
+        if (dbImpact !== verdict.dbImpact) {
+            console.log(`using stated dbImpact=${dbImpact} over classified ${verdict.dbImpact} (${files.length} migration file(s))`);
+        }
+    }
+    if (dbImpact === null) {
+        if (!args.since) throw new Error('pass --db-impact, or --since <ref> so the impact can be classified');
+        const files = changedMigrationFiles(args.since, args.until);
+        const verdict = classifyDbImpact(files, (f) => readMigrationAtRef(args.until, f));
+        dbImpact = verdict.dbImpact;
+        console.log(`classified dbImpact=${dbImpact} from ${files.length} migration file(s) in ${args.since}..${args.until}`);
+        for (const e of verdict.evidence) console.log(`  ${e}`);
+        if (dbImpact === 'schema') {
+            console.log('NOTE: a generated-object repair (§12) also matches this tripwire. If that is what');
+            console.log('      this release is, correct the entry to "repair" in a follow-up PR.');
+        }
+    }
+
+    const after = appendRelease(before, args.version, dbImpact);
+    assertOnlyMechanicalChange(before, after);
+    const json = JSON.stringify(after, null, 2) + '\n';
+    if (args.dryRun) {
+        console.log(json);
+        return;
+    }
+    writeFileSync(args.file, json);
+    console.log(`recorded ${args.version} (dbImpact: ${dbImpact}) in ${args.file}`);
+}
+
+// process.argv[1] is undefined when this module is imported without a script path
+// (`node -e`, a test runner harness); pathToFileURL throws on undefined, so check first.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        main(process.argv.slice(2));
+    } catch (e) {
+        console.error(`::error::append-release-line: ${e.message}`);
+        process.exit(1);
+    }
+}

--- a/ci/append-release-line.test.mjs
+++ b/ci/append-release-line.test.mjs
@@ -1,0 +1,161 @@
+// Tests for ci/append-release-line.mjs — run with: node --test ci/
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyChannel,
+  stripSqlComments,
+  classifyDbImpact,
+  appendRelease,
+  assertOnlyMechanicalChange,
+  parseCliArgs,
+  MAX_MIGRATION_FILES,
+  readMigrationAtRef,
+  reconcileDbImpact,
+} from './append-release-line.mjs';
+
+const doc = () => ({
+  edge: { newest: null },
+  eras: { 5: { platform: { angular: '21.1.3' } } },
+  lines: {
+    '5.51': {
+      status: 'certified',
+      certifiedBuild: '5.51.0',
+      newest: '5.51.1',
+      certifiedDate: '2026-08-14',
+      upgradeImpact: 'none',
+      releases: { '5.51.1': { dbImpact: 'none' } },
+      scorecard: 'certifications/5.51.0.md',
+    },
+  },
+});
+
+test('classifyChannel routes edge, line, and garbage', () => {
+  assert.deepEqual(classifyChannel('6.1.0-edge.3'), { kind: 'edge' });
+  assert.deepEqual(classifyChannel('5.51.2'), { kind: 'line', lineKey: '5.51' });
+  assert.deepEqual(classifyChannel('10.0.0'), { kind: 'line', lineKey: '10.0' });
+  assert.throws(() => classifyChannel('6.1.0-beta.1'), /neither X\.Y\.Z nor/);
+  assert.throws(() => classifyChannel(''), /version is required/);
+  assert.throws(() => classifyChannel(undefined), /version is required/);
+});
+
+test('stripSqlComments removes line and block comments', () => {
+  assert.match(stripSqlComments('-- DROP TABLE x\nSELECT 1'), /^\s+\nSELECT 1$/);
+  assert.equal(stripSqlComments('/* ALTER TABLE y */').trim(), '');
+});
+
+test('classifyDbImpact: no migrations means none', () => {
+  assert.deepEqual(classifyDbImpact([], () => ''), { dbImpact: 'none', evidence: [] });
+});
+
+test('classifyDbImpact: data-only migrations mean metadata', () => {
+  const v = classifyDbImpact(['migrations/v5/a.sql'], () => "INSERT INTO __mj.Entity (Name) VALUES ('x');");
+  assert.equal(v.dbImpact, 'metadata');
+  assert.equal(v.evidence.length, 1);
+});
+
+test('classifyDbImpact: DDL means schema, and names the file and keyword', () => {
+  const v = classifyDbImpact(['migrations/v5/b.sql'], () => 'ALTER TABLE __mj.Entity ADD Foo INT;');
+  assert.equal(v.dbImpact, 'schema');
+  assert.deepEqual(v.evidence, ['migrations/v5/b.sql: ALTER']);
+});
+
+test('classifyDbImpact: a DDL keyword inside a comment does not trip it', () => {
+  const v = classifyDbImpact(['migrations/v5/c.sql'], () => '-- we will DROP this next era\nUPDATE __mj.Entity SET Name=1;');
+  assert.equal(v.dbImpact, 'metadata');
+});
+
+test('classifyDbImpact: the file cap is enforced, not just documented', () => {
+  const many = Array.from({ length: MAX_MIGRATION_FILES + 1 }, (_, i) => `migrations/v5/${i}.sql`);
+  assert.throws(() => classifyDbImpact(many, () => ''), /over the .* cap/);
+});
+
+test('appendRelease records an edge release and moves edge.newest', () => {
+  const out = appendRelease(doc(), '6.1.0-edge.4', 'schema');
+  assert.equal(out.edge.newest, '6.1.0-edge.4');
+  assert.deepEqual(out.edge.releases, { '6.1.0-edge.4': { dbImpact: 'schema' } });
+});
+
+test('appendRelease records a line release without disturbing the existing ledger', () => {
+  const out = appendRelease(doc(), '5.51.2', 'none');
+  assert.equal(out.lines['5.51'].newest, '5.51.2');
+  assert.deepEqual(out.lines['5.51'].releases, {
+    '5.51.1': { dbImpact: 'none' },
+    '5.51.2': { dbImpact: 'none' },
+  });
+});
+
+test('appendRelease leaves certification fields alone', () => {
+  const out = appendRelease(doc(), '5.51.2', 'none');
+  assert.equal(out.lines['5.51'].status, 'certified');
+  assert.equal(out.lines['5.51'].certifiedBuild, '5.51.0');
+  assert.equal(out.lines['5.51'].certifiedDate, '2026-08-14');
+});
+
+test('appendRelease does not mutate its input', () => {
+  const before = doc();
+  appendRelease(before, '5.51.2', 'none');
+  assert.equal(before.lines['5.51'].newest, '5.51.1');
+});
+
+test('appendRelease refuses an unknown line rather than inventing one', () => {
+  assert.throws(() => appendRelease(doc(), '6.2.0', 'none'), /line 6\.2 is not in release-lines\.json/);
+});
+
+test('appendRelease rejects a dbImpact outside the enum', () => {
+  assert.throws(() => appendRelease(doc(), '5.51.2', 'huge'), /not one of none\|metadata\|repair\|schema/);
+});
+
+test('assertOnlyMechanicalChange accepts a mechanical append', () => {
+  const before = doc();
+  assertOnlyMechanicalChange(before, appendRelease(before, '5.51.2', 'none'));
+});
+
+test('assertOnlyMechanicalChange rejects a status or date move', () => {
+  const before = doc();
+  const status = appendRelease(before, '5.51.2', 'none');
+  status.lines['5.51'].status = 'eol';
+  assert.throws(() => assertOnlyMechanicalChange(before, status), /non-mechanical field changed/);
+
+  const dated = appendRelease(before, '5.51.2', 'none');
+  dated.lines['5.51'].certifiedDate = '2026-01-01';
+  assert.throws(() => assertOnlyMechanicalChange(before, dated), /non-mechanical field changed/);
+});
+
+test('parseCliArgs defaults, requires a version, and rejects typos', () => {
+  assert.deepEqual(parseCliArgs(['--version', '5.51.2']), {
+    version: '5.51.2', dbImpact: null, file: 'release-lines.json', since: null, until: 'HEAD', dryRun: false,
+  });
+  assert.deepEqual(parseCliArgs(['--version', '5.51.2', '--db-impact', 'metadata', '--since', 'v5.51.1', '--until', 'v5.51.2', '--dry-run']), {
+    version: '5.51.2', dbImpact: 'metadata', file: 'release-lines.json', since: 'v5.51.1', until: 'v5.51.2', dryRun: true,
+  });
+  assert.throws(() => parseCliArgs([]), /--version is required/);
+  assert.throws(() => parseCliArgs(['--dbimpact', 'none', '--version', 'x']), /unknown argument "--dbimpact"/);
+});
+
+test('readMigrationAtRef turns an ENOBUFS into an actionable message', () => {
+  const boom = () => { const e = new Error('spawnSync git ENOBUFS'); e.code = 'ENOBUFS'; throw e; };
+  assert.throws(
+    () => readMigrationAtRef('HEAD', 'migrations/v5/huge.sql', boom),
+    /exceeds the \d+-byte read cap — classify by hand with --db-impact/,
+  );
+});
+
+test('readMigrationAtRef passes a maxBuffer through, and rethrows anything else', () => {
+  let seen = null;
+  readMigrationAtRef('HEAD', 'migrations/v5/a.sql', (_f, _a, opts) => { seen = opts; return 'SELECT 1'; });
+  assert.ok(seen.maxBuffer > 1024 * 1024, 'maxBuffer must exceed 1MB or metadata syncs blow up');
+
+  const other = () => { const e = new Error('not a git repo'); e.code = 'ENOENT'; throw e; };
+  assert.throws(() => readMigrationAtRef('HEAD', 'x.sql', other), /not a git repo/);
+});
+
+test('reconcileDbImpact refuses a "none" claim when migrations actually shipped', () => {
+  assert.throws(() => reconcileDbImpact('none', 'schema'), /contradicts the release contents/);
+  assert.throws(() => reconcileDbImpact('none', 'metadata'), /contradicts the release contents/);
+});
+
+test('reconcileDbImpact allows a human to override the tripwire in the safe directions', () => {
+  assert.equal(reconcileDbImpact('repair', 'schema'), 'repair');
+  assert.equal(reconcileDbImpact('schema', 'metadata'), 'schema');
+  assert.equal(reconcileDbImpact('none', 'none'), 'none');
+});

--- a/release-lines.json
+++ b/release-lines.json
@@ -1,6 +1,22 @@
 {
   "$schema": "./ci/release-lines.schema.json",
-  "edge": { "newest": null },
+  "edge": {
+    "newest": "6.1.0-edge.3",
+    "releases": {
+      "6.1.0-edge.0": {
+        "dbImpact": "schema"
+      },
+      "6.1.0-edge.1": {
+        "dbImpact": "schema"
+      },
+      "6.1.0-edge.2": {
+        "dbImpact": "schema"
+      },
+      "6.1.0-edge.3": {
+        "dbImpact": "schema"
+      }
+    }
+  },
   "eras": {
     "5": {
       "platform": {


### PR DESCRIPTION
## The gap

`plans/lts-process.md` §4.1 states that publish workflows append the mechanical fields (`newest`, and the per-release `releases` ledger) via direct push. That machinery was never built. Consequences, both real:

- `edge.newest` was still `null` after `6.1.0-edge.0` through `edge.3` published.
- 5.51.1 shipped 2026-08-19 and was recorded by hand a week later (#4071).

Nothing reads the file yet — the only code that touches it is its own validator — so nothing was visibly broken for users. But it is the declared input for the CLI channel work (§15 item 7), and building that against a file nobody maintains ships a CLI that is wrong on day one.

## What it does

`ci/append-release-line.mjs` appends and nothing else. It touches only `edge.newest`/`edge.releases` and `lines.<X.Y>.newest`/`releases`. A `status`, `certifiedBuild` or date change is refused by `assertOnlyMechanicalChange` before the write and again by `validate-release-lines --mode push` in CI. An unknown line is refused rather than invented, since a line release for a line with no entry means the branch was cut without one.

**dbImpact** is stated for a line release and classified for an edge release:

- Line releases take it from a new `db_impact` dispatch input (default `none`), because the operator already made that call when they applied the §12 label.
- Edge releases get the regex tripwire §5.2 rule 4 describes: no migrations → `none`, migrations with no DDL keyword → `metadata`, any DDL → `schema`. Comments are stripped first so `-- we'll DROP this later` doesn't trip it.
- It **never emits `repair`**. A generated-object repair is DDL by regex and schema-neutral in substance, and only a human reading the diff can tell those apart, so it reports `schema` and logs that the operator may reclassify.
- A stated impact may override the tripwire in the safe directions, but a stated `none` over a range that actually shipped migrations is **refused** — that is a false ledger entry, not an override.

## Design decisions worth checking

**Both paths write to `next`, never to `main`.** A push to `main` is this workflow's own Edge trigger, so a bookkeeping commit there would start a publish that consumes whatever changesets are banked on main. `next` has no publish trigger, and main inherits the entry at the next release through the existing merge step.

**Both steps are last in their job, and fatal rather than `continue-on-error`.** The packages are already on npm when they run, so a failure means "released, not yet recorded" — recoverable by hand — rather than a failed release. It stays fatal because a red run is the only signal that the ledger is behind.

**`[skip ci]` on the commit**, since a two-field JSON edit does not need every gate re-run. `--mode push` proves the edit touched only mechanical fields before it is committed, so the check is not lost, just moved.

## Two bugs found by using it rather than reading it

`execFileSync`'s default `maxBuffer` is smaller than MJ's metadata-sync migrations (v5.45's was 12,041 lines), so reading one died with a raw `ENOBUFS` **before** the byte cap was ever consulted — the cap has to live on the reader, not only in the classifier. Left unset this would have failed the first Edge publish carrying a metadata sync, which is nearly all of them.

The main-module guard called `pathToFileURL(process.argv[1])`, which throws when the module is imported without a script path.

Both now have regression tests.

## Backfill

The four shipped edge releases, each classified `schema` by the tool itself with the DDL evidence logged. That leaves `edge.newest` at `6.1.0-edge.3`, which is exactly what the npm `edge` dist-tag points at.

## Verification

- `node --test ci/*.test.mjs` → **67 pass, 0 fail** (20 new).
- `node ci/validate-release-lines.mjs --base origin/next --mode pr` → OK on the backfilled file.
- End-to-end against real history, as the workflow invokes it: recording 5.51.1 over `v5.51.0..v5.51.1` classifies `none` and passes; recording `6.1.0-edge.3` over `edge.2..edge.3` classifies `schema` and names 13 migrations.
- Failure paths confirmed to **exit 1**, not just print: the false-`none` contradiction, and an unknown line.

## Reviewer attention

**This edits `publish.yml`, which is the highest-stakes workflow in the repo.** The two new steps are the last step of their respective jobs and both are `if`-gated the same way as their neighbours, so they cannot run on a path that wasn't already publishing. Worth reading the placement specifically.

**`node --test ci/` is broken on `next` today** and this PR does not fix it. Node 24 treats the directory argument as a module and dies with `MODULE_NOT_FOUND`; I confirmed it on a clean `origin/next` with none of these files present. The existing `ci/validate-release-lines.test.mjs` header documents that broken invocation. The working one is `node --test ci/*.test.mjs`, which is what my new file's header says. Flagging rather than fixing the older header.

**Not addressed:** the line guard (§15 item 6) is still unbuilt, so nothing enforces the §12 labels on `lts/*` PRs. This PR records `dbImpact` but does not gate it.