### PR TITLE
fix(forms): stop the chat-embedded form from clipping long text

### DIFF
--- a/.changeset/dynamic-form-text-truncation.md
+++ b/.changeset/dynamic-form-text-truncation.md
@@ -1,0 +1,14 @@
+---
+"@memberjunction/ng-forms": patch
+---
+
+Stop the chat-embedded interactive form from clipping long text. Agent-authored labels are routinely sentence-length, and the form's layout sized every option to its content width with no ability to shrink — so anything wider than the card ran off the edge and was silently chopped by the card's `overflow: hidden` (no ellipsis, no scrollbar, just missing words).
+
+- **Radio and checkbox options now wrap.** Options size to their content and share a row when they fit, but an option too wide for the row takes the row to itself and wraps its label rather than overflowing. Options and labels are top-aligned so the control lines up with the first line of a multi-line label.
+- **Dropdowns size to their widest option** (bounded by the card) instead of a fixed 350px cap that truncated the selected label. `widthHint: 'auto'` is legal on any question type, so text controls under that hint keep their previous bound — only the select needed the extra room.
+- **The form card allows more room** before its contents have to wrap (600px → 720px), and the default text-field width follows (450px → 560px).
+- **Button groups wrap to a second row** instead of scrolling horizontally. The previous `overflow-x` scroller sat inside a vertically-scrolling chat column, where overlay scrollbars hid the overflowing options entirely rather than signalling them; it also clipped the buttons' focus ring. Now consistent with `.footer-choice-button` and `.choice-button`, the sibling button paths in the same form.
+- **Radio/checkbox option labels are 14px**, matching every other control in the form. They were the only text here with no size of their own, so they inherited the host app's body size (~16px) and rendered larger than the question they answer.
+- **Single-line controls degrade to an ellipsis** rather than a mid-word cut when a value or placeholder still exceeds the field.
+- **The submitted-answer pill wraps too** — it was `white-space: nowrap` with no max-width, so a sentence-length answer ran past the message.
+- **The multi-field answer card no longer overflows a narrow message column.** Its `min-width: 400px` unconditionally beat its own `max-width: min(800px, 100%)` (min-width always wins), and the guards below it key off the viewport rather than the column — so a narrow chat panel on a wide screen never reached them. Now `min(400px, 100%)`.

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form-field/dynamic-form-field.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form-field/dynamic-form-field.component.css
@@ -30,6 +30,13 @@
   max-width: 100%;
 }
 
+/* A value or placeholder longer than the field reads as truncated rather than
+   chopped mid-word — single-line controls cannot wrap. */
+.question-input,
+.question-dropdown {
+  text-overflow: ellipsis;
+}
+
 .question-dropdown {
   padding: 8px 12px;
   border: 1px solid var(--mj-border-default);
@@ -73,35 +80,19 @@
 
 .question-buttongroup {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 8px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--mj-brand-primary) 30%, transparent) transparent;
 }
 
-.question-buttongroup::-webkit-scrollbar {
-  height: 6px;
-}
-
-.question-buttongroup::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.question-buttongroup::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--mj-brand-primary) 30%, transparent);
-  border-radius: 3px;
-}
-
-.question-buttongroup::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--mj-brand-primary) 50%, transparent);
-}
-
+/* Wraps rather than scrolls: the previous overflow-x scroller sat inside a vertically
+   scrolling chat column, so overlay scrollbars hid the extra options outright. Matches
+   .footer-choice-button, the sibling button path in this same form. */
 .buttongroup-option {
-  flex: 0 0 auto;
-  white-space: nowrap;
+  flex: 0 1 auto;
+  max-width: 100%;
+  white-space: normal;
+  text-align: left;
+  line-height: 1.3;
 }
 
 .buttongroup-option i {
@@ -118,10 +109,21 @@
 .radio-option,
 .checkbox-option {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
-  min-width: 120px;
+  /* Basis is the option's own content width, but it may shrink: short options share a
+     row, while an option too wide for the row takes the row to itself and wraps its
+     label instead of overflowing (and being clipped by .response-form's overflow:hidden). */
+  flex: 0 1 auto;
+  min-width: min(120px, 100%);
+  max-width: 100%;
+}
+
+.radio-option > input,
+.checkbox-option > input {
   flex: 0 0 auto;
+  /* nudge the control onto the first text line now that options are top-aligned */
+  margin-top: 3px;
 }
 
 .radio-label,
@@ -130,13 +132,22 @@
   user-select: none;
   margin: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 6px;
+  /* the only text in the form that had no size of its own — it inherited the host app's
+     body size (~16px) while every sibling control here is 14px */
+  font-size: 14px;
+  /* without this the label is stuck at its content width and cannot wrap */
+  min-width: 0;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .radio-label i,
 .checkbox-label i {
   color: var(--mj-text-secondary);
+  flex: 0 0 auto;
+  margin-top: 2px;
 }
 
 .validation-error {
@@ -220,7 +231,7 @@
 
 /* Medium fields - for names, cities, phone numbers (DEFAULT) */
 .input-container.width-medium {
-  max-width: 450px;
+  max-width: 560px;
 }
 
 .input-container.width-medium .question-input,
@@ -251,13 +262,32 @@
 
 /* Auto-width - for dropdowns, radio, checkbox (sizes to content) */
 .input-container.width-auto {
-  max-width: 350px;
+  max-width: 100%;
   min-width: 150px;
   width: auto;
 }
 
-.input-container.width-auto .question-dropdown {
-  width: 100%;
+/* widthHint: 'auto' is legal on any question type, and this container used to cap
+   every control it held at 350px. Keep that cap as the default so lifting it off the
+   container changes only the controls this fix targets — not sliders, date ranges or
+   the markdown panel, which also live here. */
+.input-container.width-auto > * {
+  max-width: 350px;
+}
+
+/* The select sizes to its widest option rather than to a fixed cap, so a long
+   selected label stays readable; the container is what bounds it. */
+.input-container.width-auto > .question-dropdown {
+  width: auto;
+  max-width: 100%;
+}
+
+/* Choice groups need the full width to lay their options out — that is the whole
+   point of the wrapping rules above. */
+.input-container.width-auto > .question-radio-group,
+.input-container.width-auto > .question-checkbox-group,
+.input-container.width-auto > .question-buttongroup {
+  max-width: 100%;
 }
 
 /* Responsive adjustments for smaller screens */
@@ -266,6 +296,11 @@
   .input-container.width-medium,
   .input-container.width-wide,
   .input-container.width-auto {
+    max-width: 100%;
+  }
+
+  /* release the width-auto child cap too, or it binds where the container no longer does */
+  .input-container.width-auto > * {
     max-width: 100%;
   }
 }

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form-response/dynamic-form-response.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form-response/dynamic-form-response.component.css
@@ -7,7 +7,7 @@
 /* Single field - inline pill */
 .form-response-pill.single-field {
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   vertical-align: middle;
   gap: 6px;
   padding: 4px 12px;
@@ -19,12 +19,18 @@
   font-weight: 600;
   box-shadow: var(--mj-shadow-md);
   cursor: default;
-  white-space: nowrap;
+  /* A chosen option can be a full sentence — wrap it instead of running past the message. */
+  max-width: 100%;
+  white-space: normal;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .form-response-pill.single-field i {
   font-size: 11px;
   opacity: 0.95;
+  flex: 0 0 auto;
+  margin-top: 3px;
 }
 
 /* Multi-field - card layout */
@@ -32,7 +38,10 @@
   display: inline-block;
   max-width: min(800px, 100%);
   width: auto;
-  min-width: 400px;
+  /* min-width beats max-width, so an unconditional 400px overflows any container
+     narrower than that — and the media queries below key off the viewport, not the
+     message column, so a narrow chat panel on a wide screen never reaches them. */
+  min-width: min(400px, 100%);
   margin: 8px 0;
   vertical-align: top;
 }
@@ -117,7 +126,7 @@
 /* Responsive adjustments */
 @media (max-width: 600px) {
   .form-response-pill.multi-field {
-    min-width: 300px;
+    min-width: min(300px, 100%);
   }
 }
 

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form/dynamic-form.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form/dynamic-form.component.css
@@ -1,8 +1,11 @@
 .dynamic-form {
   margin-top: 16px;
   display: block;
+  /* Sizes to content, so a short form stays compact — but agent-authored labels are
+     often sentence-length, so give the card enough room before its contents have to wrap. */
   width: fit-content;
-  max-width: 600px;
+  min-width: 0;
+  max-width: 720px;
 }
 
 /* Simple Choice Mode */


### PR DESCRIPTION
## Summary

Agent-authored option labels are routinely sentence-length, but the chat-embedded interactive form sized every option to its content width with no ability to shrink. Anything wider than the card ran off the edge and was silently chopped by the card's `overflow: hidden` — no ellipsis, no scrollbar, just missing words.

- **Radio/checkbox options wrap.** They share a row when they fit; one too wide for the row takes the row to itself and wraps its label. Options are top-aligned so the control sits on the first line of a multi-line label.
- **Dropdowns size to their widest option** instead of a fixed 350px cap that truncated the selected label. `widthHint: 'auto'` is legal on *any* question type and that container previously capped every control it held, so the cap moved to the container's children and is lifted only for the select and the choice groups — and released again under the existing `<= 600px` media query, where the container no longer binds.
- **Button groups wrap to a second row** rather than scrolling horizontally. The `overflow-x` scroller sat inside a vertically-scrolling chat column, where overlay scrollbars hid the overflowing options outright instead of signalling them, and `overflow-y: hidden` clipped the buttons' focus ring. Now consistent with `.footer-choice-button` / `.choice-button`, the sibling button paths in the same form.
- **Option labels are 14px**, matching every other control here. They were the only text with no size of their own, so they inherited the host app's body size (~16px) and rendered larger than the question they answer.
- **Submitted answers wrap too.** The single-field pill was `white-space: nowrap` with no max-width; the multi-field card's `min-width: 400px` unconditionally beat its own `max-width: min(800px, 100%)` (min-width always wins), and the guards below it key off the viewport rather than the message column, so a narrow chat panel on a wide screen never reached them.
- Card `600px -> 720px`, default text field `450px -> 560px`, and single-line controls fall back to an ellipsis rather than a mid-word cut.

CSS-only; no template or TypeScript changes.

## Verification already done

Measured every option, label and control for overflow across 1100 / 620 / 430px message columns: **9 overflowing elements at every width before, 0 after.** Cascade behaviour under `width-auto` was probed against the real stylesheet via `getComputedStyle` (not a hand-transcription) to confirm sliders, date ranges and the markdown panel keep their prior 350px bound while the select and choice groups get the room.

`pnpm test` in `ng-forms`: **95/95 passing.** Package builds clean. `check-css-hex-tokens` and `check-mj-btn-override` clean on all three files.

> Note: the deterministic integration tier was **not** run — the dev database used here has drifted (`vwTestSuites` missing `RootParentID`), so `TestEngine` loads zero suites. Unrelated to this change; CI will be the first place that tier executes.

## Test plan

- [ ] In a chat conversation, have an agent emit a form with sentence-length radio options — confirm each label renders in full, wrapping to its own row rather than being cut off
- [ ] Confirm a dropdown with a long selected label (e.g. "Year-to-Date (YTD) with Prior Year Comparison") displays the whole value
- [ ] Confirm a `buttongroup` question with long labels wraps to a second row instead of scrolling, and that keyboard focus rings are not clipped
- [ ] Check short-label forms (`Yes`/`No`, `Low`/`Med`/`High`) are visually unchanged — no unwanted extra rows
- [ ] Submit a single-question form and a multi-question form; confirm neither the answer pill nor the summary card overflows the message bubble
- [ ] Narrow the chat panel (split view / overlay) on a wide monitor and re-check both — this is the case the viewport media queries never caught
- [ ] Verify at mobile width (<= 600px) that fields still fill the available width
- [ ] Confirm option label text now matches the size of the question label above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)