### PR TITLE
fix(forms): stop the chat-embedded form from clipping long text (clip-fix subset of #4085 for 5.51.x)

### DIFF
--- a/.changeset/dynamic-form-text-truncation.md
+++ b/.changeset/dynamic-form-text-truncation.md
@@ -1,0 +1,14 @@
+---
+"@memberjunction/ng-forms": patch
+---
+
+Stop the chat-embedded interactive form from clipping long text. Agent-authored labels are routinely sentence-length, and the form's layout sized every option to its content width with no ability to shrink — so anything wider than the card ran off the edge and was silently chopped by the card's `overflow: hidden` (no ellipsis, no scrollbar, just missing words).
+
+- **Radio and checkbox options now wrap.** Options size to their content and share a row when they fit, but an option too wide for the row takes the row to itself and wraps its label rather than overflowing. Options and labels are top-aligned so the control lines up with the first line of a multi-line label.
+- **Dropdowns size to their widest option** (bounded by the card) instead of a fixed 350px cap that truncated the selected label. `widthHint: 'auto'` is legal on any question type, so text controls under that hint keep their previous bound — only the select needed the extra room.
+- **The form card allows more room** before its contents have to wrap (600px → 720px), and the default text-field width follows (450px → 560px).
+- **Button groups wrap to a second row** instead of scrolling horizontally. The previous `overflow-x` scroller sat inside a vertically-scrolling chat column, where overlay scrollbars hid the overflowing options entirely rather than signalling them; it also clipped the buttons' focus ring. Now consistent with `.footer-choice-button` and `.choice-button`, the sibling button paths in the same form.
+- **Radio/checkbox option labels are 14px**, matching every other control in the form. They were the only text here with no size of their own, so they inherited the host app's body size (~16px) and rendered larger than the question they answer.
+- **Single-line controls degrade to an ellipsis** rather than a mid-word cut when a value or placeholder still exceeds the field.
+- **The submitted-answer pill wraps too** — it was `white-space: nowrap` with no max-width, so a sentence-length answer ran past the message.
+- **The multi-field answer card no longer overflows a narrow message column.** Its `min-width: 400px` unconditionally beat its own `max-width: min(800px, 100%)` (min-width always wins), and the guards below it key off the viewport rather than the column — so a narrow chat panel on a wide screen never reached them. Now `min(400px, 100%)`.

--- a/.changeset/dynamic-form-text-truncation.md
+++ b/.changeset/dynamic-form-text-truncation.md
@@ -4,11 +4,11 @@
 
 Stop the chat-embedded interactive form from clipping long text. Agent-authored labels are routinely sentence-length, and the form's layout sized every option to its content width with no ability to shrink — so anything wider than the card ran off the edge and was silently chopped by the card's `overflow: hidden` (no ellipsis, no scrollbar, just missing words).
 
-- **Radio and checkbox options now wrap.** Options size to their content and share a row when they fit, but an option too wide for the row takes the row to itself and wraps its label rather than overflowing. Options and labels are top-aligned so the control lines up with the first line of a multi-line label.
-- **Dropdowns size to their widest option** (bounded by the card) instead of a fixed 350px cap that truncated the selected label. `widthHint: 'auto'` is legal on any question type, so text controls under that hint keep their previous bound — only the select needed the extra room.
-- **The form card allows more room** before its contents have to wrap (600px → 720px), and the default text-field width follows (450px → 560px).
-- **Button groups wrap to a second row** instead of scrolling horizontally. The previous `overflow-x` scroller sat inside a vertically-scrolling chat column, where overlay scrollbars hid the overflowing options entirely rather than signalling them; it also clipped the buttons' focus ring. Now consistent with `.footer-choice-button` and `.choice-button`, the sibling button paths in the same form.
-- **Radio/checkbox option labels are 14px**, matching every other control in the form. They were the only text here with no size of their own, so they inherited the host app's body size (~16px) and rendered larger than the question they answer.
+This is the clip-fix subset of the change on `next` (#4085). Every rule here is a no-op unless the element is already overflowing; the restyle half of that PR — card and field widening, option-label typography, top-aligned option controls — is deliberately not included on this line.
+
+- **Radio and checkbox options now wrap.** Options size to their content and share a row when they fit, but an option too wide for the row takes the row to itself and wraps its label rather than overflowing.
+- **Button groups wrap to a second row** instead of scrolling horizontally. The previous `overflow-x` scroller sat inside a vertically-scrolling chat column, where overlay scrollbars hid the overflowing options entirely rather than signalling them; it also clipped the buttons' focus ring.
 - **Single-line controls degrade to an ellipsis** rather than a mid-word cut when a value or placeholder still exceeds the field.
 - **The submitted-answer pill wraps too** — it was `white-space: nowrap` with no max-width, so a sentence-length answer ran past the message.
 - **The multi-field answer card no longer overflows a narrow message column.** Its `min-width: 400px` unconditionally beat its own `max-width: min(800px, 100%)` (min-width always wins), and the guards below it key off the viewport rather than the column — so a narrow chat panel on a wide screen never reached them. Now `min(400px, 100%)`.
+- **The form card can shrink inside a narrow message column** (`min-width: 0`), which it previously could not as a flex item.

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form-field/dynamic-form-field.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form-field/dynamic-form-field.component.css
@@ -1,3 +1,11 @@
+/* NOTE (lts/5): this file carries the clip-fix subset of #4085 only. That PR also
+   restyled the form — card 600->720px, medium field 450->560px, 14px option labels,
+   and top-aligned option controls with their nudges — and those changes render
+   differently for deployments that were never clipping, so they stay on `next` and
+   are deliberately absent here. Every rule below is a no-op unless the element is
+   already overflowing. Expect a conflict when cherry-picking this file again; take
+   the wrap/min-width rules and leave the sizing and typography behind. */
+
 .form-question {
   margin-bottom: 16px;
 }
@@ -92,7 +100,6 @@
   max-width: 100%;
   white-space: normal;
   text-align: left;
-  line-height: 1.3;
 }
 
 .buttongroup-option i {
@@ -109,7 +116,7 @@
 .radio-option,
 .checkbox-option {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
   /* Basis is the option's own content width, but it may shrink: short options share a
      row, while an option too wide for the row takes the row to itself and wraps its
@@ -119,35 +126,24 @@
   max-width: 100%;
 }
 
-.radio-option > input,
-.checkbox-option > input {
-  flex: 0 0 auto;
-  /* nudge the control onto the first text line now that options are top-aligned */
-  margin-top: 3px;
-}
-
 .radio-label,
 .checkbox-label {
   cursor: pointer;
   user-select: none;
   margin: 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 6px;
-  /* the only text in the form that had no size of its own — it inherited the host app's
-     body size (~16px) while every sibling control here is 14px */
-  font-size: 14px;
   /* without this the label is stuck at its content width and cannot wrap */
   min-width: 0;
-  line-height: 1.4;
   overflow-wrap: anywhere;
 }
 
 .radio-label i,
 .checkbox-label i {
   color: var(--mj-text-secondary);
+  /* keep the icon at its intrinsic size when a long label puts the row under pressure */
   flex: 0 0 auto;
-  margin-top: 2px;
 }
 
 .validation-error {
@@ -231,7 +227,7 @@
 
 /* Medium fields - for names, cities, phone numbers (DEFAULT) */
 .input-container.width-medium {
-  max-width: 560px;
+  max-width: 450px;
 }
 
 .input-container.width-medium .question-input,
@@ -261,33 +257,17 @@
 }
 
 /* Auto-width - for dropdowns, radio, checkbox (sizes to content) */
+/* The 350px cap stays as-is on this line: a long selected label degrades to the
+   ellipsis above rather than being cut mid-word, so widening the container is a
+   layout improvement, not part of the clip fix. See #4085 on `next`. */
 .input-container.width-auto {
-  max-width: 100%;
+  max-width: 350px;
   min-width: 150px;
   width: auto;
 }
 
-/* widthHint: 'auto' is legal on any question type, and this container used to cap
-   every control it held at 350px. Keep that cap as the default so lifting it off the
-   container changes only the controls this fix targets — not sliders, date ranges or
-   the markdown panel, which also live here. */
-.input-container.width-auto > * {
-  max-width: 350px;
-}
-
-/* The select sizes to its widest option rather than to a fixed cap, so a long
-   selected label stays readable; the container is what bounds it. */
-.input-container.width-auto > .question-dropdown {
-  width: auto;
-  max-width: 100%;
-}
-
-/* Choice groups need the full width to lay their options out — that is the whole
-   point of the wrapping rules above. */
-.input-container.width-auto > .question-radio-group,
-.input-container.width-auto > .question-checkbox-group,
-.input-container.width-auto > .question-buttongroup {
-  max-width: 100%;
+.input-container.width-auto .question-dropdown {
+  width: 100%;
 }
 
 /* Responsive adjustments for smaller screens */
@@ -296,11 +276,6 @@
   .input-container.width-medium,
   .input-container.width-wide,
   .input-container.width-auto {
-    max-width: 100%;
-  }
-
-  /* release the width-auto child cap too, or it binds where the container no longer does */
-  .input-container.width-auto > * {
     max-width: 100%;
   }
 }

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form-field/dynamic-form-field.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form-field/dynamic-form-field.component.css
@@ -30,6 +30,13 @@
   max-width: 100%;
 }
 
+/* A value or placeholder longer than the field reads as truncated rather than
+   chopped mid-word — single-line controls cannot wrap. */
+.question-input,
+.question-dropdown {
+  text-overflow: ellipsis;
+}
+
 .question-dropdown {
   padding: 8px 12px;
   border: 1px solid var(--mj-border-default);
@@ -73,35 +80,19 @@
 
 .question-buttongroup {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 8px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--mj-brand-primary) 30%, transparent) transparent;
 }
 
-.question-buttongroup::-webkit-scrollbar {
-  height: 6px;
-}
-
-.question-buttongroup::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.question-buttongroup::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--mj-brand-primary) 30%, transparent);
-  border-radius: 3px;
-}
-
-.question-buttongroup::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--mj-brand-primary) 50%, transparent);
-}
-
+/* Wraps rather than scrolls: the previous overflow-x scroller sat inside a vertically
+   scrolling chat column, so overlay scrollbars hid the extra options outright. Matches
+   .footer-choice-button, the sibling button path in this same form. */
 .buttongroup-option {
-  flex: 0 0 auto;
-  white-space: nowrap;
+  flex: 0 1 auto;
+  max-width: 100%;
+  white-space: normal;
+  text-align: left;
+  line-height: 1.3;
 }
 
 .buttongroup-option i {
@@ -118,10 +109,21 @@
 .radio-option,
 .checkbox-option {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
-  min-width: 120px;
+  /* Basis is the option's own content width, but it may shrink: short options share a
+     row, while an option too wide for the row takes the row to itself and wraps its
+     label instead of overflowing (and being clipped by .response-form's overflow:hidden). */
+  flex: 0 1 auto;
+  min-width: min(120px, 100%);
+  max-width: 100%;
+}
+
+.radio-option > input,
+.checkbox-option > input {
   flex: 0 0 auto;
+  /* nudge the control onto the first text line now that options are top-aligned */
+  margin-top: 3px;
 }
 
 .radio-label,
@@ -130,13 +132,22 @@
   user-select: none;
   margin: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 6px;
+  /* the only text in the form that had no size of its own — it inherited the host app's
+     body size (~16px) while every sibling control here is 14px */
+  font-size: 14px;
+  /* without this the label is stuck at its content width and cannot wrap */
+  min-width: 0;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .radio-label i,
 .checkbox-label i {
   color: var(--mj-text-secondary);
+  flex: 0 0 auto;
+  margin-top: 2px;
 }
 
 .validation-error {
@@ -220,7 +231,7 @@
 
 /* Medium fields - for names, cities, phone numbers (DEFAULT) */
 .input-container.width-medium {
-  max-width: 450px;
+  max-width: 560px;
 }
 
 .input-container.width-medium .question-input,
@@ -251,13 +262,32 @@
 
 /* Auto-width - for dropdowns, radio, checkbox (sizes to content) */
 .input-container.width-auto {
-  max-width: 350px;
+  max-width: 100%;
   min-width: 150px;
   width: auto;
 }
 
-.input-container.width-auto .question-dropdown {
-  width: 100%;
+/* widthHint: 'auto' is legal on any question type, and this container used to cap
+   every control it held at 350px. Keep that cap as the default so lifting it off the
+   container changes only the controls this fix targets — not sliders, date ranges or
+   the markdown panel, which also live here. */
+.input-container.width-auto > * {
+  max-width: 350px;
+}
+
+/* The select sizes to its widest option rather than to a fixed cap, so a long
+   selected label stays readable; the container is what bounds it. */
+.input-container.width-auto > .question-dropdown {
+  width: auto;
+  max-width: 100%;
+}
+
+/* Choice groups need the full width to lay their options out — that is the whole
+   point of the wrapping rules above. */
+.input-container.width-auto > .question-radio-group,
+.input-container.width-auto > .question-checkbox-group,
+.input-container.width-auto > .question-buttongroup {
+  max-width: 100%;
 }
 
 /* Responsive adjustments for smaller screens */
@@ -266,6 +296,11 @@
   .input-container.width-medium,
   .input-container.width-wide,
   .input-container.width-auto {
+    max-width: 100%;
+  }
+
+  /* release the width-auto child cap too, or it binds where the container no longer does */
+  .input-container.width-auto > * {
     max-width: 100%;
   }
 }

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form-response/dynamic-form-response.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form-response/dynamic-form-response.component.css
@@ -7,7 +7,7 @@
 /* Single field - inline pill */
 .form-response-pill.single-field {
   display: inline-flex;
-  align-items: center;
+  align-items: flex-start;
   vertical-align: middle;
   gap: 6px;
   padding: 4px 12px;
@@ -19,12 +19,18 @@
   font-weight: 600;
   box-shadow: var(--mj-shadow-md);
   cursor: default;
-  white-space: nowrap;
+  /* A chosen option can be a full sentence — wrap it instead of running past the message. */
+  max-width: 100%;
+  white-space: normal;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .form-response-pill.single-field i {
   font-size: 11px;
   opacity: 0.95;
+  flex: 0 0 auto;
+  margin-top: 3px;
 }
 
 /* Multi-field - card layout */
@@ -32,7 +38,10 @@
   display: inline-block;
   max-width: min(800px, 100%);
   width: auto;
-  min-width: 400px;
+  /* min-width beats max-width, so an unconditional 400px overflows any container
+     narrower than that — and the media queries below key off the viewport, not the
+     message column, so a narrow chat panel on a wide screen never reaches them. */
+  min-width: min(400px, 100%);
   margin: 8px 0;
   vertical-align: top;
 }
@@ -117,7 +126,7 @@
 /* Responsive adjustments */
 @media (max-width: 600px) {
   .form-response-pill.multi-field {
-    min-width: 300px;
+    min-width: min(300px, 100%);
   }
 }
 

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form-response/dynamic-form-response.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form-response/dynamic-form-response.component.css
@@ -1,5 +1,8 @@
 /* ==================== Form Response Display ==================== */
 
+/* NOTE (lts/5): clip-fix subset of #4085 only — the restyle half of that PR stays on
+   `next`. See the matching note in dynamic-form-field.component.css. */
+
 .form-response-pill {
   transition: all 0.2s ease;
 }
@@ -7,7 +10,7 @@
 /* Single field - inline pill */
 .form-response-pill.single-field {
   display: inline-flex;
-  align-items: flex-start;
+  align-items: center;
   vertical-align: middle;
   gap: 6px;
   padding: 4px 12px;
@@ -22,15 +25,14 @@
   /* A chosen option can be a full sentence — wrap it instead of running past the message. */
   max-width: 100%;
   white-space: normal;
-  line-height: 1.4;
   overflow-wrap: anywhere;
 }
 
 .form-response-pill.single-field i {
   font-size: 11px;
   opacity: 0.95;
+  /* keep the icon at its intrinsic size when a long answer puts the pill under pressure */
   flex: 0 0 auto;
-  margin-top: 3px;
 }
 
 /* Multi-field - card layout */

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form/dynamic-form.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form/dynamic-form.component.css
@@ -1,11 +1,13 @@
+/* NOTE (lts/5): clip-fix subset of #4085 only — that PR also widened this card to
+   720px, which stays on `next`. See the matching note in dynamic-form-field.component.css. */
 .dynamic-form {
   margin-top: 16px;
   display: block;
-  /* Sizes to content, so a short form stays compact — but agent-authored labels are
-     often sentence-length, so give the card enough room before its contents have to wrap. */
   width: fit-content;
+  /* as a flex item the card would otherwise refuse to shrink below its content and
+     overflow a narrow message column; inert everywhere else */
   min-width: 0;
-  max-width: 720px;
+  max-width: 600px;
 }
 
 /* Simple Choice Mode */

--- a/packages/Angular/Generic/forms/src/lib/dynamic-form/dynamic-form.component.css
+++ b/packages/Angular/Generic/forms/src/lib/dynamic-form/dynamic-form.component.css
@@ -1,8 +1,11 @@
 .dynamic-form {
   margin-top: 16px;
   display: block;
+  /* Sizes to content, so a short form stays compact — but agent-authored labels are
+     often sentence-length, so give the card enough room before its contents have to wrap. */
   width: fit-content;
-  max-width: 600px;
+  min-width: 0;
+  max-width: 720px;
 }
 
 /* Simple Choice Mode */


### PR DESCRIPTION
Backport of #4085 to the 5.x LTS line (`lts/5`, which carries `v5.51.1`).

**Reduced to the clip-fix subset following review.** The original cherry-pick brought over the whole of #4085, which was a fix plus a restyle. On a certified line the restyle half changes rendering for deployments that were never clipping, so it stays on `next` and only the clip fix rides here.

Clipping is confirmed in production on a 5.51 deployment (MoreCheese demo site), which is what this PR is for. A truncated option label is not a cosmetic problem — the user answers a question whose choices they cannot fully read.

## What this ships

Every rule is a no-op unless the element is already overflowing:

- **Radio/checkbox options wrap** — they share a row when they fit, and an option too wide for the row takes the row to itself and wraps its label instead of being chopped by the card's `overflow: hidden`.
- **Labels can actually wrap** — `min-width: 0` and `overflow-wrap: anywhere`; without these the label is pinned to its content width.
- **Button groups wrap** instead of scrolling horizontally. The old `overflow-x` scroller sat inside a vertically-scrolling chat column, where overlay scrollbars hid the overflowing options outright rather than signalling them, and `overflow-y: hidden` clipped focus rings.
- **Single-line controls degrade to an ellipsis** rather than a mid-word cut.
- **The submitted-answer pill wraps** — it was `white-space: nowrap` with no max-width, so a sentence-length answer ran past the message.
- **The multi-field answer card no longer overflows a narrow message column** — its `min-width: 400px` unconditionally beat its own `max-width: min(800px, 100%)`, and the guards below it key off the viewport rather than the column, so a narrow chat panel on a wide screen never reached them. Now `min(400px, 100%)`.
- **The form card can shrink as a flex item** (`min-width: 0`).

## What was deliberately left on `next`

Reverted to `lts/5` values in 80ee8aa:

- Card `600px → 720px` and default text field `450px → 560px`
- `font-size: 14px` on radio/checkbox option labels — this overrides the host app's own body size, which is a typography decision to make on a major, not in a line patch
- `align-items: center → flex-start` with the 3px input nudge and 2px icon nudge — this shifted every single-line option including `Yes`/`No`
- The `.input-container.width-auto` restructure

Keeping `align-items: center` removes the reason for the `font-size`/`3px` coupling (the nudge was calibrated to reproduce centering at 14px/1.4, so splitting the two would have misaligned options in any host app with a different body size). Single-line options are now pixel-identical to 5.51.1.

Reverting `width-auto` also drops a side effect not raised in review: `width: auto` on the select made **short**-option dropdowns render narrower than the old 350px cap — a visible change for exactly the population this bar protects. Long selected labels now degrade to the ellipsis instead. Confirmed non-load-bearing for the clip fix: `WidthClass` routes `radio`/`checkbox`/`buttongroup` to `width-wide`, so only dropdowns ever reach `width-auto`.

## Divergence

`lts/5` and `next` now differ in these three files by design. Each file carries a `NOTE (lts/5)` comment naming #4085 and listing what was omitted, so a later cherry-pick conflict is self-explaining rather than looking like a botched backport.

## Verification

- `check-css-hex-tokens` and `check-mj-btn-override`: clean on all three files
- `npm test` in `packages/Angular/Generic/forms`: **94/94 passing** (94 on this line, not the 95 on `next` — line difference, not a regression)
- `npm run build` (ngc): clean

Note for anyone else working this line: `lts/5` is still an **npm** workspace (`packageManager: npm@11.7.0`, `package-lock.json`). The pnpm guidance in `CLAUDE.md` describes `next` only.

## Test plan

- [ ] In a 5.51.x build, have an agent emit a form with sentence-length radio options — confirm each label renders in full
- [ ] Confirm a `buttongroup` with long labels wraps rather than scrolling
- [ ] Confirm a long dropdown value ends in an ellipsis rather than a mid-word cut
- [ ] Check short-label forms (`Yes`/`No`) are pixel-unchanged vs 5.51.1 — no shifted controls, no extra rows, no changed label size
- [ ] Confirm short-option dropdowns are unchanged in width vs 5.51.1
- [ ] Submit single- and multi-question forms; confirm neither the pill nor the summary card overflows the message bubble
- [ ] Narrow the chat panel on a wide monitor and re-check — the case the viewport media queries never caught
- [ ] Verify at mobile width (<= 600px) that fields still fill the available width

🤖 Generated with [Claude Code](https://claude.com/claude-code)
