### PR TITLE
fix(explorer): sort AI Agent Run timeline by StartedAt, not persist time

### DIFF
--- a/.changeset/timeline-steps-by-startedat.md
+++ b/.changeset/timeline-steps-by-startedat.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/ng-core-entity-forms": patch
+---
+
+The AI Agent Run timeline lists steps by `StartedAt` (execution time), not persist time.
+
+A 1ms Artifact Tool whose fire-and-forget INSERT lost a race with the next Execute Agent Prompt was painted *after* that prompt even though its clock was 2ms earlier. `__mj_CreatedAt` is when the INSERT committed; `StartedAt` is when the step actually began. The query and a client-side sort both use `StartedAt` then `StepNumber`, so siblings (and loop children) read in the order the clocks already show.

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/__tests__/agent-run-step-order.test.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/__tests__/agent-run-step-order.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The timeline listed steps by persist time (`__mj_CreatedAt`) while painting `StartedAt`.
+ * A 1ms Artifact Tool whose INSERT lost a race with the next Execute Agent Prompt then
+ * rendered *after* that prompt, even though its clock was 2ms earlier. This is that pair.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+    CompareAgentRunStepsByExecutionOrder,
+    SortAgentRunStepsByExecutionOrder,
+} from '../agent-run-step-order';
+
+describe('SortAgentRunStepsByExecutionOrder', () => {
+    it('puts an artifact tool before the next prompt when persist order is inverted', () => {
+        // The screenshot: CreatedAt of the second prompt beat the tool's INSERT, so a
+        // `__mj_CreatedAt, StepNumber` query returned prompt then tool. StartedAt (and
+        // StepNumber) still know the tool ran first.
+        const validation = {
+            id: 'validation',
+            StartedAt: new Date('2026-08-28T12:28:33.737Z'),
+            StepNumber: 1,
+            __mj_CreatedAt: new Date('2026-08-28T12:28:33.740Z'),
+        };
+        const prompt1 = {
+            id: 'prompt-1',
+            StartedAt: new Date('2026-08-28T12:28:33.779Z'),
+            StepNumber: 2,
+            __mj_CreatedAt: new Date('2026-08-28T12:28:33.800Z'),
+        };
+        const prompt2 = {
+            id: 'prompt-2',
+            StartedAt: new Date('2026-08-28T12:28:37.371Z'),
+            StepNumber: 4,
+            __mj_CreatedAt: new Date('2026-08-28T12:28:37.380Z'),
+        };
+        const tool = {
+            id: 'tool',
+            StartedAt: new Date('2026-08-28T12:28:37.369Z'),
+            StepNumber: 3,
+            __mj_CreatedAt: new Date('2026-08-28T12:28:37.400Z'),
+        };
+
+        const sorted = SortAgentRunStepsByExecutionOrder([validation, prompt1, prompt2, tool]);
+
+        expect(sorted.map((s) => s.id)).toEqual(['validation', 'prompt-1', 'tool', 'prompt-2']);
+    });
+
+    it('uses StepNumber when two steps share a StartedAt millisecond', () => {
+        const t = new Date('2026-08-28T12:28:37.369Z');
+        const a = { id: 'a', StartedAt: t, StepNumber: 5 };
+        const b = { id: 'b', StartedAt: t, StepNumber: 4 };
+
+        expect(SortAgentRunStepsByExecutionOrder([a, b]).map((s) => s.id)).toEqual(['b', 'a']);
+    });
+
+    it('sorts unstarted steps last, not at the epoch', () => {
+        const running = { id: 'ran', StartedAt: new Date('2026-08-28T12:28:33.737Z'), StepNumber: 1 };
+        const pending = { id: 'pending', StartedAt: null, StepNumber: 2 };
+
+        expect(SortAgentRunStepsByExecutionOrder([pending, running]).map((s) => s.id)).toEqual([
+            'ran',
+            'pending',
+        ]);
+    });
+
+    it('does not mutate the input array', () => {
+        const a = { id: 'a', StartedAt: new Date('2026-08-28T12:28:37.371Z'), StepNumber: 2 };
+        const b = { id: 'b', StartedAt: new Date('2026-08-28T12:28:37.369Z'), StepNumber: 1 };
+        const input = [a, b];
+
+        const sorted = SortAgentRunStepsByExecutionOrder(input);
+
+        expect(input.map((s) => s.id)).toEqual(['a', 'b']);
+        expect(sorted.map((s) => s.id)).toEqual(['b', 'a']);
+        expect(sorted).not.toBe(input);
+    });
+
+    it('accepts ISO strings the same as Date instances', () => {
+        const a = { id: 'a', StartedAt: '2026-08-28T12:28:37.371Z', StepNumber: 2 };
+        const b = { id: 'b', StartedAt: '2026-08-28T12:28:37.369Z', StepNumber: 1 };
+
+        expect(CompareAgentRunStepsByExecutionOrder(a, b)).toBeGreaterThan(0);
+        expect(SortAgentRunStepsByExecutionOrder([a, b]).map((s) => s.id)).toEqual(['b', 'a']);
+    });
+});

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/agent-run-step-order.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/agent-run-step-order.ts
@@ -1,0 +1,50 @@
+/**
+ * Execution-order sort for agent-run steps.
+ *
+ * The timeline paints `StartedAt` on every row, but it used to *list* rows by `__mj_CreatedAt`
+ * (when the fire-and-forget INSERT committed). Those clocks disagree for fast sibling steps —
+ * an Artifact Tool that ran in 1ms, then the next Execute Agent Prompt 2ms later, routinely
+ * persisted in the opposite order because different step entities save concurrently. Sorting
+ * on persist time therefore showed the tool *after* the prompt that consumed it.
+ *
+ * `StartedAt` is stamped in memory at create time and is the clock the UI already shows.
+ * `StepNumber` is the in-memory sequence and the tie-break when two steps share a millisecond
+ * (parallel `Promise.all` tool calls). Unstarted rows (null/invalid `StartedAt`) sort last,
+ * matching `get-agent-run-tree.sql` — T-SQL otherwise puts NULLs first.
+ */
+
+/** The two fields the execution-order sort reads. Deliberately not the full entity. */
+export type AgentRunStepOrderFields = {
+    StartedAt?: Date | string | null;
+    StepNumber?: number | null;
+};
+
+/**
+ * Milliseconds of `StartedAt`, or +∞ when the step has not started / cannot be parsed.
+ *
+ * +∞, not 0: an unstarted row has no place among work that did run, and 0 would pin it at
+ * the epoch — the same class of lie the timeline used to render with a max-Date sentinel.
+ */
+function startedAtMs(value: Date | string | null | undefined): number {
+    if (value == null || value === '') return Number.POSITIVE_INFINITY;
+    const ms = value instanceof Date ? value.getTime() : new Date(value).getTime();
+    return Number.isNaN(ms) ? Number.POSITIVE_INFINITY : ms;
+}
+
+/** Compare two steps by execution order: `StartedAt` ascending, then `StepNumber`. */
+export function CompareAgentRunStepsByExecutionOrder(
+    a: AgentRunStepOrderFields,
+    b: AgentRunStepOrderFields,
+): number {
+    const byStart = startedAtMs(a.StartedAt) - startedAtMs(b.StartedAt);
+    if (byStart !== 0) return byStart;
+    return (a.StepNumber ?? 0) - (b.StepNumber ?? 0);
+}
+
+/**
+ * Returns a new array of steps in execution order. Does not mutate the input — RunView
+ * results are shared with other consumers, and a sort in place would reorder their view too.
+ */
+export function SortAgentRunStepsByExecutionOrder<T extends AgentRunStepOrderFields>(steps: T[]): T[] {
+    return [...steps].sort(CompareAgentRunStepsByExecutionOrder);
+}

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-data.service.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-data.service.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject, Observable } from 'rxjs';
 import { IMetadataProvider, Metadata, RunView } from '@memberjunction/core';
 import { MJAIAgentRunEntity, MJAIAgentRunStepEntity, MJActionExecutionLogEntity, MJAIPromptRunEntity } from '@memberjunction/core-entities';
+import { SortAgentRunStepsByExecutionOrder } from './agent-run-step-order';
 
 export interface AgentRunData {
   steps: MJAIAgentRunStepEntity[];
@@ -97,17 +98,21 @@ export class AIAgentRunDataHelper {
     const rv = RunView.FromMetadataProvider(this.Provider);
     
     // First, get all steps to determine what additional data we need
+    // StartedAt is execution time (what the timeline paints). __mj_CreatedAt is persist time
+    // and inverts for fast sibling steps whose fire-and-forget INSERTs race. StepNumber is
+    // the same-millisecond tie-break. Client-sort after the query as well — T-SQL NULLs
+    // sort first, and SQL datetime rounding can still disagree with JS Date.getTime().
     const stepsResult = await rv.RunView<MJAIAgentRunStepEntity>({
       EntityName: 'MJ: AI Agent Run Steps',
       ExtraFilter: `AgentRunID='${agentRunId}'`,
-      OrderBy: '__mj_CreatedAt, StepNumber'
+      OrderBy: 'StartedAt, StepNumber'
     });
     
     if (!stepsResult.Success) {
       throw new Error('Failed to load agent run steps');
     }
     
-    const steps = stepsResult.Results as MJAIAgentRunStepEntity[] || [];
+    const steps = SortAgentRunStepsByExecutionOrder(stepsResult.Results as MJAIAgentRunStepEntity[] || []);
     
     // Build filters for batch loading
     const actionLogIds = steps
@@ -211,14 +216,14 @@ export class AIAgentRunDataHelper {
     const stepsResult = await rv.RunView<MJAIAgentRunStepEntity>({
       EntityName: 'MJ: AI Agent Run Steps',
       ExtraFilter: `AgentRunID = '${subAgentRunId}'`,
-      OrderBy: '__mj_CreatedAt, StepNumber'
+      OrderBy: 'StartedAt, StepNumber'
     });
     
     if (!stepsResult.Success || !stepsResult.Results) {
       return { steps: [], promptRuns: [] };
     }
     
-    const steps = stepsResult.Results;
+    const steps = SortAgentRunStepsByExecutionOrder(stepsResult.Results);
     
     // Get prompt run IDs
     const promptRunIds = steps

--- a/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-timeline.component.ts
+++ b/packages/Angular/Explorer/core-entity-forms/src/lib/custom/ai-agent-run/ai-agent-run-timeline.component.ts
@@ -9,6 +9,7 @@ import { UUIDsEqual } from '@memberjunction/global';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import { FindAgentRunTreeNodes, type AgentRunTreeNode } from '@memberjunction/ai-core-plus';
 import { NormalizeStatus, ProjectRunTreeToTimeline } from './run-tree-timeline-projection';
+import { SortAgentRunStepsByExecutionOrder } from './agent-run-step-order';
 import { ActionEngineBase } from '@memberjunction/actions-base';
 
 /**
@@ -222,17 +223,22 @@ export class AIAgentRunTimelineComponent extends BaseAngularComponent implements
     baseLevel: number,
     promptRuns?: MJAIPromptRunEntity[]
   ): TimelineItem[] {
+    // Walk in execution order, not persist order. Children are pushed in this walk, so a
+    // loop's iterations and root siblings both inherit the sort. Query OrderBy is the
+    // same pair; this is the belt for a caller that handed us an unsorted array.
+    const ordered = SortAgentRunStepsByExecutionOrder(steps);
+
     // Create a map of all timeline items by step ID
     const itemMap = new Map<string, TimelineItem>();
 
     // First pass: create all timeline items
-    steps.forEach(step => {
+    ordered.forEach(step => {
       const item = this.createTimelineItemFromStep(step, baseLevel, promptRuns);
       itemMap.set(step.ID, item);
     });
 
     // Second pass: build parent-child relationships based on ParentID
-    steps.forEach(step => {
+    ordered.forEach(step => {
       if (step.ParentID) {
         const parentItem = itemMap.get(step.ParentID);
         const childItem = itemMap.get(step.ID);
@@ -254,7 +260,7 @@ export class AIAgentRunTimelineComponent extends BaseAngularComponent implements
 
     // Return only root-level items (those without a ParentID)
     const rootItems: TimelineItem[] = [];
-    steps.forEach(step => {
+    ordered.forEach(step => {
       if (!step.ParentID) {
         const item = itemMap.get(step.ID);
         if (item) {


### PR DESCRIPTION
## Summary
- The AI Agent Run timeline listed steps by `__mj_CreatedAt` (when the fire-and-forget INSERT committed) while painting `StartedAt` (when the step actually ran).
- Fast sibling steps invert those clocks: an Artifact Tool that ran in 1ms, then the next Execute Agent Prompt 2ms later, often persisted in the opposite order because different step entities save concurrently.
- Query and client now sort by `StartedAt`, then `StepNumber`. Unstarted rows sort last. Regression test is the screenshot pair (tool start 2ms earlier, persist time later → tool lists before the follow-up prompt).

## Test plan
- [ ] Open an AI Agent Run whose last prompt was forced by an Artifact Tool (`get_full` etc.) and confirm the tool row sits **above** the follow-up Execute Agent Prompt even when its clock is only 1–2ms earlier.
- [ ] Confirm a normal Prompt → Action → Prompt run is still chronological.
- [ ] Expand a sub-agent / ForEach and confirm children are also in start-time order.
- [ ] `pnpm exec vitest run src/lib/custom/ai-agent-run/__tests__/agent-run-step-order.test.ts` in `packages/Angular/Explorer/core-entity-forms`.