### PR TITLE
feat(conversations): clickable record-link tokens with optional labels

### DIFF
--- a/.changeset/clickable-record-links.md
+++ b/.changeset/clickable-record-links.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/ai-core-plus": minor
+"@memberjunction/ng-conversations": minor
+"@memberjunction/ng-explorer-core": minor
+---
+
+Clickable record-link tokens in Chat messages (`type: "record"`). Agents emit `@{…}` JSON; the renderer turns it into a pill that opens the row via OpenEntityRecord, including composite primary keys. `name` is optional — omit it for an icon-only pill when surrounding prose already names the record. Loop prompt teaches the grammar and asks for world-class UX: prefer icon-only, one citation per record per section.

--- a/metadata/prompts/.prompts.json
+++ b/metadata/prompts/.prompts.json
@@ -194,8 +194,8 @@
       "ID": "FF7D441F-36E1-458A-B548-0FC2208923BE"
     },
     "sync": {
-      "lastModified": "2026-08-11T22:50:39.875Z",
-      "checksum": "0741cdb058f79fefeb3db7dc2d73742385a74c5fa49fbdd7c1dafa24a054d601"
+      "lastModified": "2026-08-28T19:12:20.279Z",
+      "checksum": "434b7188f7987c4c6d632eadcf72dc2f5e7c25cce67f00584d10c56fbe1855b3"
     }
   },
   {

--- a/metadata/prompts/templates/system/loop-agent-type-system-prompt.template.md
+++ b/metadata/prompts/templates/system/loop-agent-type-system-prompt.template.md
@@ -463,6 +463,46 @@ Use `responseForm` to collect structured user input. Single question with button
 {% endif %}
 
 {% if __agentTypePromptParams.includeCommandDocs != false %}
+## Record links in Chat messages
+
+When you name a MemberJunction **record** in `message`, do not paste primary-key values as prose. Emit a record-link token. The conversation renderer turns it into a clickable pill; the host opens the record.
+
+Aim for **world-class UX**: clean, readable results. A record link is a citation, not chrome to repeat. The reader should never see the same name as both heading text and a labeled pill, or two pills for the same row in one breath.
+
+Tokens are `@{…}` JSON (same wrapper as mentions). They live **inside** `message` and must be JSON-escaped with the rest of that string.
+
+Required fields:
+
+- `"_mode": "mention"`
+- `"type": "record"` — this is a **row**, not an entity definition (`type: "entity"` is the table)
+- `"entityName"` — exact entity name from metadata (e.g. `"Customers"`, `"MJ: AI Agent Runs"`)
+
+Optional:
+
+- `"name"` — label inside the pill. **Omit it when the surrounding sentence already names the record.** The pill then renders as an icon with an arrow. **Err on omitting.** Include `name` only when the token *is* the mention (no nearby prose name).
+
+Primary key: add each PK field as a **sibling key**, using the field names from entity metadata.
+
+- Single PK named `ID`: include `"ID": "<value>"`.
+- Composite PK: include **every** PK field. The UI looks up `Entity.PrimaryKeys` and reads those keys from the token. Missing a composite part produces a dead link — omit the token rather than emit a partial one.
+- Do not invent PK field names. Use the names on the record you actually have.
+
+Preferred (prose names it; token is icon-only):
+
+Capex Drag @{"_mode":"mention","type":"record","entityName":"MJ_BizApps_FPNA: Planned Items","ID":"DE2D7A95-F5BC-4699-8B43-41D15516C29F"} of **-$25,000** lands on 2027-03-01.
+
+Labeled pill — only when the token *is* the name:
+
+See @{"_mode":"mention","type":"record","entityName":"Customers","name":"Acme Corp","ID":"abc-123"} for the open balance.
+
+Composite example (icon-only after the line name):
+
+Line Widget × 12 @{"_mode":"mention","type":"record","entityName":"Order Details","OrderID":"ord-1","LineNumber":4} drove the variance.
+
+**Cite each record once per section.** Do not put a token in a heading and again in the first sentence. Headings stay text; place one token next to the first prose mention. Never emit two nearby tokens for the same row.
+
+Use `actionableCommands` `open:resource` **in addition** when you want a button after the message ("Open this record"). Inline tokens are for names in the sentence; buttons are for a primary CTA. Prefer both when you created or materially changed a record.
+
 ## Commands
 
 After completing work, use `actionableCommands` for navigation buttons and `automaticCommands` for immediate UI updates (data refresh, notifications).
@@ -477,6 +517,7 @@ After completing work, use `actionableCommands` for navigation buttons and `auto
       "label": "View New Agent",
       "icon": "fa-robot",
       "resourceType": "Record",
+      "entityName": "MJ: AI Agents",
       "resourceId": "agent-789",
       "mode": "view"
     }
@@ -493,6 +534,20 @@ After completing work, use `actionableCommands` for navigation buttons and `auto
       "severity": "success"
     }
   ]
+}
+```
+
+Composite primary key (use `keys` instead of `resourceId`):
+
+```json
+{
+  "type": "open:resource",
+  "label": "Open order line",
+  "icon": "fa-file-lines",
+  "resourceType": "Record",
+  "entityName": "Order Details",
+  "keys": { "OrderID": "ord-1", "LineNumber": 4 },
+  "mode": "view"
 }
 ```
 
@@ -524,7 +579,9 @@ Pair this with `nextStep: 'Chat'` and a short `message` explaining why the snaps
 - Your **entire** response must be only JSON with no leading or trailing characters!
 - Must adhere to [LoopAgentResponse](#response-format)
 {% if __agentTypePromptParams.includeResponseFormDocs != false %}- Use `responseForm` when you need user input (replaces old suggestedResponses pattern){% endif %}
-{% if __agentTypePromptParams.includeCommandDocs != false %}- Use `actionableCommands` to provide navigation buttons after completing work
+{% if __agentTypePromptParams.includeCommandDocs != false %}- Use record-link tokens in `message` instead of raw primary keys
+- `open:resource` buttons need `entityName` plus `resourceId` or `keys`
+- Use `actionableCommands` to provide navigation buttons after completing work
 - Use `automaticCommands` to refresh data or show notifications{% endif %}
 
 {% if __agentTypePromptParams.includeScratchpadDocs != false %}

--- a/packages/AI/CorePlus/generated-for-prompt/ui-commands.ts.generated-for-prompt.md
+++ b/packages/AI/CorePlus/generated-for-prompt/ui-commands.ts.generated-for-prompt.md
@@ -10,7 +10,8 @@ interface OpenResourceCommand {
     icon?: string;  // Optional Font Awesome icon class to display on the button.
     resourceType: ResourceType;  // Type of resource to open.
     entityName?: string;  // Entity name (required for Record type).
-    resourceId: string;  // ID of the resource to open.
+    resourceId?: string;  // ID of the resource to open.
+    keys?: Record<string, string | number>;  // Composite (or explicit) primary-key fields for Record type.
     mode?: 'view' | 'edit';  // Mode for opening the resource.
     parameters?: Record<string, any>;  // Optional parameters to pass to the resource.
 }

--- a/packages/AI/CorePlus/src/__tests__/conversationUtility.test.ts
+++ b/packages/AI/CorePlus/src/__tests__/conversationUtility.test.ts
@@ -206,6 +206,140 @@ describe('ConversationUtility', () => {
         });
     });
 
+    describe('record links', () => {
+        it('parses a single-ID record token without requiring id', () => {
+            const text = '@{"_mode":"mention","type":"record","entityName":"Customers","name":"Acme Corp","ID":"abc-123"}';
+            const tokens = ConversationUtility.ParseSpecialContent(text);
+            expect(tokens).toHaveLength(1);
+            expect(tokens[0].mode).toBe('mention');
+            const content = tokens[0].content as { type: string; entityName: string; ID: string };
+            expect(content.type).toBe('record');
+            expect(content.entityName).toBe('Customers');
+            expect(content.ID).toBe('abc-123');
+        });
+
+        it('parses composite PK siblings', () => {
+            const text = '@{"_mode":"mention","type":"record","entityName":"Order Details","name":"Widget × 12","OrderID":"ord-1","LineNumber":4}';
+            const tokens = ConversationUtility.ParseSpecialContent(text);
+            expect(tokens).toHaveLength(1);
+            const ck = ConversationUtility.CompositeKeyFromRecordLink(
+                tokens[0].content as import('../conversation-utility').MentionContent,
+                ['OrderID', 'LineNumber']
+            );
+            expect(ck?.KeyValuePairs).toEqual([
+                { FieldName: 'OrderID', Value: 'ord-1' },
+                { FieldName: 'LineNumber', Value: '4' },
+            ]);
+        });
+
+        it('CreateRecordLink emits ID as a sibling', () => {
+            const token = ConversationUtility.CreateRecordLink('Customers', 'Acme Corp', { ID: 'abc-123' });
+            expect(token).toContain('"type":"record"');
+            expect(token).toContain('"entityName":"Customers"');
+            expect(token).toContain('"ID":"abc-123"');
+            expect(token).not.toContain('"id":');
+        });
+
+        it('CreateRecordLink puts reserved PK names in nested keys', () => {
+            const token = ConversationUtility.CreateRecordLink('Weird', 'Row', { type: 'x', ID: '1' });
+            expect(token).toContain('"ID":"1"');
+            expect(token).toContain('"keys":{"type":"x"}');
+        });
+
+        it('accepts id as an alias for ID', () => {
+            const text = '@{"_mode":"mention","type":"record","entityName":"Customers","name":"Acme","id":"abc"}';
+            const tokens = ConversationUtility.ParseSpecialContent(text);
+            const ck = ConversationUtility.CompositeKeyFromRecordLink(
+                tokens[0].content as import('../conversation-utility').MentionContent,
+                ['ID']
+            );
+            expect(ck?.KeyValuePairs).toEqual([{ FieldName: 'ID', Value: 'abc' }]);
+        });
+
+        it('returns null when a composite part is missing', () => {
+            const text = '@{"_mode":"mention","type":"record","entityName":"Order Details","name":"X","OrderID":"ord-1"}';
+            const tokens = ConversationUtility.ParseSpecialContent(text);
+            const ck = ConversationUtility.CompositeKeyFromRecordLink(
+                tokens[0].content as import('../conversation-utility').MentionContent,
+                ['OrderID', 'LineNumber']
+            );
+            expect(ck).toBeNull();
+        });
+
+        it('plain-text of a record link is the display name', () => {
+            const text = 'See @{"_mode":"mention","type":"record","entityName":"Customers","name":"Acme Corp","ID":"abc"}';
+            expect(ConversationUtility.ToPlainText(text)).toBe('See Acme Corp');
+        });
+
+        it('parses a record token with no name (icon-only)', () => {
+            const text = '@{"_mode":"mention","type":"record","entityName":"Customers","ID":"abc-123"}';
+            const tokens = ConversationUtility.ParseSpecialContent(text);
+            expect(tokens).toHaveLength(1);
+            const content = tokens[0].content as { type: string; entityName: string; name?: string; ID: string };
+            expect(content.type).toBe('record');
+            expect(content.entityName).toBe('Customers');
+            expect(content.name).toBeUndefined();
+            expect(content.ID).toBe('abc-123');
+        });
+
+        it('parses a record token with empty name as icon-only', () => {
+            const text = '@{"_mode":"mention","type":"record","entityName":"Customers","name":"","ID":"abc-123"}';
+            const tokens = ConversationUtility.ParseSpecialContent(text);
+            expect(tokens).toHaveLength(1);
+            expect((tokens[0].content as { type: string }).type).toBe('record');
+        });
+
+        it('CreateRecordLink omits name when it is empty', () => {
+            const token = ConversationUtility.CreateRecordLink('Customers', '', { ID: 'abc-123' });
+            expect(token).toContain('"entityName":"Customers"');
+            expect(token).toContain('"ID":"abc-123"');
+            expect(token).not.toMatch(/"name"\s*:/);
+        });
+
+        it('CreateRecordLink omits name when it is null', () => {
+            const token = ConversationUtility.CreateRecordLink('Customers', null, { ID: 'abc-123' });
+            expect(token).not.toMatch(/"name"\s*:/);
+        });
+
+        it('plain-text of an icon-only record link falls back to entityName', () => {
+            const text = 'See @{"_mode":"mention","type":"record","entityName":"Customers","ID":"abc"}';
+            expect(ConversationUtility.ToPlainText(text)).toBe('See Customers');
+        });
+
+        it('agent context keeps entity name and PK', () => {
+            const text = '@{"_mode":"mention","type":"record","entityName":"Customers","name":"Acme Corp","ID":"abc"}';
+            expect(ConversationUtility.ToAgentContext(text)).toBe('Acme Corp [Customers; ID=abc]');
+        });
+
+        it('agent context of an icon-only record link uses entityName as the label', () => {
+            const text = '@{"_mode":"mention","type":"record","entityName":"Customers","ID":"abc"}';
+            expect(ConversationUtility.ToAgentContext(text)).toBe('Customers [Customers; ID=abc]');
+        });
+
+        it('CompositeKeyFromOpenResource uses keys then resourceId', () => {
+            const composite = ConversationUtility.CompositeKeyFromOpenResource(
+                { keys: { OrderID: 'ord-1', LineNumber: 4 } },
+                ['OrderID', 'LineNumber']
+            );
+            expect(composite?.KeyValuePairs).toEqual([
+                { FieldName: 'OrderID', Value: 'ord-1' },
+                { FieldName: 'LineNumber', Value: '4' },
+            ]);
+
+            const single = ConversationUtility.CompositeKeyFromOpenResource(
+                { resourceId: 'abc-123' },
+                ['ID']
+            );
+            expect(single?.KeyValuePairs).toEqual([{ FieldName: 'ID', Value: 'abc-123' }]);
+
+            const missing = ConversationUtility.CompositeKeyFromOpenResource(
+                { resourceId: 'only-one' },
+                ['OrderID', 'LineNumber']
+            );
+            expect(missing).toBeNull();
+        });
+    });
+
     describe('CreateFormResponse', () => {
         it('should create a valid form response token', () => {
             const result = ConversationUtility.CreateFormResponse(

--- a/packages/AI/CorePlus/src/__tests__/uiCommands.test.ts
+++ b/packages/AI/CorePlus/src/__tests__/uiCommands.test.ts
@@ -31,6 +31,20 @@ describe('OpenResourceCommand', () => {
         expect(cmd.mode).toBe('view');
     });
 
+    it('should accept composite keys instead of resourceId', () => {
+        const cmd: OpenResourceCommand = {
+            type: 'open:resource',
+            label: 'Open order line',
+            resourceType: 'Record',
+            entityName: 'Order Details',
+            keys: { OrderID: 'ord-1', LineNumber: 4 },
+            mode: 'view'
+        };
+        expect(cmd.resourceId).toBeUndefined();
+        expect(cmd.keys?.OrderID).toBe('ord-1');
+        expect(cmd.keys?.LineNumber).toBe(4);
+    });
+
     it('should work without optional fields', () => {
         const cmd: OpenResourceCommand = {
             type: 'open:resource',

--- a/packages/AI/CorePlus/src/conversation-utility.ts
+++ b/packages/AI/CorePlus/src/conversation-utility.ts
@@ -21,6 +21,7 @@ import {
     createBase64DataUrl
 } from '@memberjunction/ai';
 import { UUIDsEqual } from '@memberjunction/global';
+import { CompositeKey, type KeyValuePair } from '@memberjunction/core';
 
 /**
  * Utility class for parsing and formatting special content in conversation messages
@@ -251,6 +252,134 @@ export class ConversationUtility {
     };
     // Use JSON.stringify directly - keep the braces
     return `@${JSON.stringify(content)}`;
+  }
+
+  /**
+   * Field names on a mention token that are never primary-key values.
+   * Composite PK fields that collide with these go under `keys` instead.
+   */
+  public static readonly RECORD_LINK_RESERVED_KEYS = [
+    '_mode',
+    'type',
+    'name',
+    'entityName',
+    'configurationId',
+    'configurationName',
+    'configId',
+    'config',
+    'keys',
+    'id',
+  ] as const;
+
+  /**
+   * Create a clickable record-link token for Chat `message`.
+   * Primary-key fields are siblings named as in entity metadata.
+   * Reserved names land in nested `keys`.
+   *
+   * `name` is the pill label. Omit it (or pass empty) for an icon-only pill —
+   * the right call when surrounding prose already names the record.
+   */
+  public static CreateRecordLink(
+    entityName: string,
+    name: string | null | undefined,
+    primaryKey: Record<string, string | number>
+  ): string {
+    const content: Record<string, unknown> = {
+      _mode: 'mention',
+      type: 'record',
+      entityName,
+    };
+    const trimmedName = (name ?? '').trim();
+    if (trimmedName) {
+      content.name = trimmedName;
+    }
+    const nested: Record<string, string | number> = {};
+    for (const [k, v] of Object.entries(primaryKey)) {
+      if ((ConversationUtility.RECORD_LINK_RESERVED_KEYS as readonly string[]).includes(k)) {
+        nested[k] = v;
+      } else {
+        content[k] = v;
+      }
+    }
+    if (Object.keys(nested).length > 0) {
+      content.keys = nested;
+    }
+    return `@${JSON.stringify(content)}`;
+  }
+
+  /**
+   * All PK-ish values on a record-link token: nested `keys`, sibling fields,
+   * and `id` as an alias for `ID`.
+   */
+  public static RecordLinkKeyMap(content: MentionContent): Record<string, string | number> {
+    const map: Record<string, string | number> = {};
+    if (content.keys && typeof content.keys === 'object') {
+      for (const [k, v] of Object.entries(content.keys)) {
+        if (v != null && v !== '') {
+          map[k] = v;
+        }
+      }
+    }
+    for (const [k, v] of Object.entries(content as unknown as Record<string, unknown>)) {
+      if ((ConversationUtility.RECORD_LINK_RESERVED_KEYS as readonly string[]).includes(k)) {
+        continue;
+      }
+      if (typeof v === 'string' || typeof v === 'number') {
+        map[k] = v;
+      }
+    }
+    if (map.ID == null && content.id) {
+      map.ID = content.id;
+    }
+    return map;
+  }
+
+  /**
+   * Build a CompositeKey from a record-link token using the entity's PK field names
+   * (from `EntityInfo.PrimaryKeys`). Returns null if any PK part is missing.
+   */
+  public static CompositeKeyFromRecordLink(
+    content: MentionContent,
+    primaryKeyNames: string[]
+  ): CompositeKey | null {
+    if (content.type !== 'record' || primaryKeyNames.length === 0) {
+      return null;
+    }
+    const map = this.RecordLinkKeyMap(content);
+    const pairs: KeyValuePair[] = [];
+    for (const name of primaryKeyNames) {
+      const value = map[name] ?? (name === 'ID' ? map['id'] : undefined);
+      if (value == null || value === '') {
+        return null;
+      }
+      pairs.push({ FieldName: name, Value: String(value) });
+    }
+    return new CompositeKey(pairs);
+  }
+
+  /**
+   * Build a CompositeKey from an `open:resource` Record command.
+   * `keys` wins per field; `resourceId` fills a single PK (or a PK named ID).
+   */
+  public static CompositeKeyFromOpenResource(
+    command: { resourceId?: string; keys?: Record<string, string | number> },
+    primaryKeyNames: string[]
+  ): CompositeKey | null {
+    if (primaryKeyNames.length === 0) {
+      return null;
+    }
+    const pairs: KeyValuePair[] = [];
+    for (const name of primaryKeyNames) {
+      const fromKeys = command.keys?.[name];
+      const fromResourceId =
+        name === 'ID' || primaryKeyNames.length === 1 ? command.resourceId : undefined;
+      const value = fromKeys ?? fromResourceId;
+      if (value == null || value === '') {
+        return null;
+      }
+      pairs.push({ FieldName: name, Value: String(value) });
+    }
+    return new CompositeKey(pairs);
   }
 
   // ==================== Attachment Methods ====================
@@ -533,7 +662,12 @@ export class ConversationUtility {
 
       // Validate based on mode
       if (mode === 'mention') {
-        if (parsed.type && parsed.id && parsed.name) {
+        if (parsed.type === 'record') {
+          // `name` is optional: omit it for an icon-only pill.
+          if (parsed.entityName) {
+            return parsed as MentionContent;
+          }
+        } else if (parsed.type && parsed.id && parsed.name) {
           return parsed as MentionContent;
         }
       } else if (mode === 'form') {
@@ -559,6 +693,12 @@ export class ConversationUtility {
    */
   private static getMode(content: SpecialContent): string {
     return content._mode || 'mention';
+  }
+
+  /** Visible label for a record link: explicit `name`, else the entity name. */
+  private static recordLinkLabel(content: MentionContent): string {
+    const n = (content.name ?? '').trim();
+    return n || content.entityName || 'record';
   }
 
   /**
@@ -588,13 +728,17 @@ export class ConversationUtility {
    * Format: "@Agent Name" or "@User Name"
    */
   private static mentionToPlainText(content: MentionContent, agents?: AgentInfo[], users?: UserInfo[]): string {
-    let name = content.name;
+    let name = content.name ?? '';
+
+    if (content.type === 'record') {
+      return ConversationUtility.recordLinkLabel(content);
+    }
 
     // Try to look up actual name if ID provided
-    if (content.type === 'agent' && agents) {
+    if (content.type === 'agent' && agents && content.id) {
       const agent = agents.find(a => UUIDsEqual(a.ID, content.id));
       if (agent) name = agent.Name;
-    } else if (content.type === 'user' && users) {
+    } else if (content.type === 'user' && users && content.id) {
       const user = users.find(u => UUIDsEqual(u.ID, content.id));
       if (user) name = user.Name;
     }
@@ -609,13 +753,19 @@ export class ConversationUtility {
    * Format: "Agent Name"
    */
   private static mentionToAgentContext(content: MentionContent, agents?: AgentInfo[], users?: UserInfo[]): string {
-    let name = content.name;
+    let name = content.name ?? '';
+
+    if (content.type === 'record') {
+      const keys = this.RecordLinkKeyMap(content);
+      const pk = Object.entries(keys).map(([k, v]) => `${k}=${v}`).join(', ');
+      return `${ConversationUtility.recordLinkLabel(content)} [${content.entityName || 'record'}${pk ? '; ' + pk : ''}]`;
+    }
 
     // Try to look up actual name if ID provided
-    if (content.type === 'agent' && agents) {
+    if (content.type === 'agent' && agents && content.id) {
       const agent = agents.find(a => UUIDsEqual(a.ID, content.id));
       if (agent) name = agent.Name;
-    } else if (content.type === 'user' && users) {
+    } else if (content.type === 'user' && users && content.id) {
       const user = users.find(u => UUIDsEqual(u.ID, content.id));
       if (user) name = user.Name;
     } else if (content.type === 'query') {
@@ -680,17 +830,28 @@ export interface SpecialContentToken {
 export type SpecialContent = MentionContent | FormResponseContent | AttachmentContent;
 
 /**
- * Mention content (@agent, @user, #entity, or #query)
+ * Mention content (@agent, @user, #entity, #query, or a clickable record row)
  */
 export interface MentionContent {
   /** Mode identifier (optional for backward compatibility) */
   _mode?: 'mention';
-  /** Type of mention */
-  type: 'agent' | 'user' | 'entity' | 'query';
-  /** ID of the mentioned entity */
-  id: string;
-  /** Name of the mentioned entity */
-  name: string;
+  /** Type of mention. `record` is a row (opens via OpenEntityRecord), not an entity definition. */
+  type: 'agent' | 'user' | 'entity' | 'query' | 'record';
+  /** ID of the mentioned agent/user/entity/query. Optional on `record` (PK fields are siblings). */
+  id?: string;
+  /**
+   * Display name. Required for agent/user/entity/query mentions.
+   * Optional on `type: "record"` — omit (or leave empty) for an icon-only pill
+   * when surrounding prose already names the record.
+   */
+  name?: string;
+  /** Entity name from metadata. Required on `type: "record"`. */
+  entityName?: string;
+  /**
+   * Escape hatch when a PK field name collides with a reserved mention key.
+   * Normal record links put PK fields as siblings instead.
+   */
+  keys?: Record<string, string | number>;
   /** Optional agent configuration ID */
   configurationId?: string;
   /** Optional agent configuration display name */

--- a/packages/AI/CorePlus/src/ui-commands.ts
+++ b/packages/AI/CorePlus/src/ui-commands.ts
@@ -100,10 +100,18 @@ export interface OpenResourceCommand {
 
     /**
      * ID of the resource to open.
-     * For Record type: Just the ID value (entityName is separate)
-     * For other types: The resource identifier (dashboard ID, report ID, etc.)
+     * For Record type with a single primary key: that key's value (`entityName` is separate).
+     * For other types: The resource identifier (dashboard ID, report ID, etc.).
+     * Optional on Record when {@link keys} supplies the primary key.
      */
-    resourceId: string;
+    resourceId?: string;
+
+    /**
+     * Composite (or explicit) primary-key fields for Record type.
+     * Keys are entity field names from metadata. When present, these win per field
+     * over {@link resourceId}. Use this when the entity PK is not a single `ID`.
+     */
+    keys?: Record<string, string | number>;
 
     /**
      * Mode for opening the resource.

--- a/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/chat-conversations-resource.component.ts
+++ b/packages/Angular/Explorer/explorer-core/src/lib/resource-wrappers/chat-conversations-resource.component.ts
@@ -1137,12 +1137,10 @@ export class ChatConversationsResource extends BaseResourceComponent implements 
   private handleActionableCommand(command: ActionableCommand): void {
     if (command.type === 'open:resource') {
       const resourceCommand = command as OpenResourceCommand;
-      if (resourceCommand.resourceType === 'Record' && resourceCommand.entityName) {
-        const compositeKey = new CompositeKey([{
-          FieldName: 'ID',
-          Value: resourceCommand.resourceId
-        }]);
-        this.navigationService.OpenEntityRecord(resourceCommand.entityName, compositeKey);
+      if (resourceCommand.resourceType === 'Record') {
+        // Record opens are emitted as openEntityRecord from mj-conversation-chat-area
+        // (composite-key aware). Handling them here too would open the record twice.
+        return;
       } else if (resourceCommand.resourceType === 'Report' || resourceCommand.resourceType === 'Dashboard') {
         // Reports and dashboards from agents are stored as conversation artifacts.
         // Find the most recent artifact in the active conversation and open it.

--- a/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter, OnInit, OnDestroy, ChangeDetect
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import { UserInfo, RunView, RunQuery, Metadata, CompositeKey, LogStatusEx, TransformSimpleObjectToEntityObject, DataSnapshot } from '@memberjunction/core';
 import { MJConversationEntity, MJConversationDetailEntity, MJAIAgentRunEntity, MJArtifactEntity, MJTaskEntity, ArtifactMetadataEngine, ConversationEngine, ConversationDetailComplete, RatingJSON, ArtifactJSON } from '@memberjunction/core-entities';
-import { MJAIAgentEntityExtended, MJAIAgentRunEntityExtended, CaptureDataSnapshotCommand, AppContextSnapshot } from "@memberjunction/ai-core-plus";
+import { MJAIAgentEntityExtended, MJAIAgentRunEntityExtended, CaptureDataSnapshotCommand, AppContextSnapshot, ConversationUtility, OpenResourceCommand } from "@memberjunction/ai-core-plus";
 import { ActionableCommandRequest, UICommandHandlerService } from '../../services/ui-command-handler.service';
 import { AIEngineBase } from '@memberjunction/ai-engine-base';
 import { GraphQLDataProvider } from '@memberjunction/graphql-dataprovider';
@@ -1175,6 +1175,13 @@ export class ConversationChatAreaComponent extends BaseAngularComponent implemen
             return;
           }
           void this.handleCaptureDataSnapshotCommand(command);
+          return;
+        }
+        if (command.type === 'open:resource' && command.resourceType === 'Record' && command.entityName) {
+          if (conversationId && !this.isActiveConversation(conversationId)) {
+            return;
+          }
+          this.emitOpenResourceRecord(command);
         }
       });
 
@@ -3667,6 +3674,25 @@ export class ConversationChatAreaComponent extends BaseAngularComponent implemen
   onOpenEntityRecord(event: {entityName: string; compositeKey: CompositeKey}): void {
     // Pass the event up to the parent component (workspace or explorer wrapper)
     this.openEntityRecord.emit(event);
+  }
+
+  /** Record `open:resource` buttons → same openEntityRecord chain as agent-run links. */
+  private emitOpenResourceRecord(command: OpenResourceCommand): void {
+    if (!command.entityName) return;
+    const entity = this.ProviderToUse.EntityByName(command.entityName);
+    if (!entity) {
+      console.warn('open:resource: unknown entity', command.entityName);
+      return;
+    }
+    const compositeKey = ConversationUtility.CompositeKeyFromOpenResource(
+      command,
+      entity.PrimaryKeys.map(pk => pk.Name)
+    );
+    if (!compositeKey) {
+      console.warn('open:resource: incomplete primary key', command.entityName, command);
+      return;
+    }
+    this.openEntityRecord.emit({ entityName: command.entityName, compositeKey });
   }
 
   onNavigationRequest(event: NavigationRequest): void {

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.css
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.css
@@ -127,6 +127,22 @@
   box-shadow: var(--mj-shadow-md);
 }
 
+:host ::ng-deep .mention-badge.record {
+  background: var(--mj-color-info, #2563eb);
+  color: var(--mj-text-inverse, #fff);
+  border: 2px solid color-mix(in srgb, var(--mj-color-info, #2563eb) 40%, transparent);
+  box-shadow: var(--mj-shadow-md);
+  text-decoration: none;
+}
+
+/* Icon-only record citation: surrounding prose already named the row. */
+:host ::ng-deep .mention-badge.record.icon-only {
+  padding: 4px 7px;
+  gap: 0;
+  min-width: 1.65em;
+  justify-content: center;
+}
+
 /* Skills: standard green fallback (AISkill.Color overrides via inline style) + sharp-cornered
    rectangle — the shape differentiates skills from the rounded agent/user/entity pills.
    Keep color + shape in sync with the composer chip (mention-editor's createMentionChip). */

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-item.component.ts
@@ -309,10 +309,44 @@ export class MessageItemComponent extends BaseAngularComponent implements OnInit
    * stuck or forever-spinning conversations without any code changes.
    */
   public onMessageBubbleClick(event: MouseEvent): void {
+    const recordBadge = (event.target as HTMLElement | null)?.closest?.('.mention-badge.record') as HTMLElement | null;
+    if (recordBadge) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.openRecordLinkBadge(recordBadge);
+      return;
+    }
     if (!event.shiftKey || !this.isAIMessage) return;
     event.preventDefault();
     event.stopPropagation();
     this.diagnosticRequested.emit(this.message.ID);
+  }
+
+  private openRecordLinkBadge(el: HTMLElement): void {
+    const entityName = el.getAttribute('data-record-entity');
+    const keysJson = el.getAttribute('data-record-keys');
+    if (!entityName) return;
+    let content: { type: 'record'; name: string; entityName: string; keys?: Record<string, string | number> };
+    try {
+      const keys = keysJson ? JSON.parse(keysJson) as Record<string, string | number> : {};
+      content = { type: 'record', name: el.textContent?.trim() || entityName, entityName, keys };
+    } catch {
+      return;
+    }
+    const entity = this.ProviderToUse.EntityByName(entityName);
+    if (!entity) {
+      console.warn('Record link: unknown entity', entityName);
+      return;
+    }
+    const compositeKey = ConversationUtility.CompositeKeyFromRecordLink(
+      content,
+      entity.PrimaryKeys.map(pk => pk.Name)
+    );
+    if (!compositeKey) {
+      console.warn('Record link: incomplete primary key', entityName, keysJson);
+      return;
+    }
+    this.openEntityRecord.emit({ entityName, compositeKey });
   }
 
   /**
@@ -577,7 +611,7 @@ export class MessageItemComponent extends BaseAngularComponent implements OnInit
   }
 
   private renderMentionHTML(content: any, agents: any[], users: any[]): string {
-    let name = content.name;
+    let name = typeof content.name === 'string' ? content.name : '';
     let iconClass = '';
     let logoURL = '';
     let configPresetName = '';
@@ -625,24 +659,36 @@ export class MessageItemComponent extends BaseAngularComponent implements OnInit
       if (skill?.Color) {
         inlineStyle = ` style="background: ${this.escapeHtml(skill.Color)}; border-color: rgba(255, 255, 255, 0.35);"`;
       }
+    } else if (content.type === 'record') {
+      name = (content.name ?? '').trim();
+      iconClass = this.normalizeIconClass('fa-solid fa-up-right-from-square');
     }
 
-    const escapedName = this.escapeHtml(name);
+    const iconOnly = content.type === 'record' && !name;
+    const escapedName = name ? this.escapeHtml(name) : '';
     const typeClass =
-      content.type === 'agent' || content.type === 'entity' || content.type === 'query' || content.type === 'skill' ? content.type : 'user';
+      (content.type === 'agent' || content.type === 'entity' || content.type === 'query' || content.type === 'skill' || content.type === 'record' ? content.type : 'user')
+      + (iconOnly ? ' icon-only' : '');
 
     // Build preset indicator HTML if present
     const presetIndicator = configPresetName
       ? `<span class="preset-indicator">${this.escapeHtml(configPresetName)}</span>`
       : '';
 
+    const recordOpenLabel = content.type === 'record'
+      ? (name ? `Open ${name}` : `Open ${content.entityName || 'record'}`)
+      : '';
+    const recordAttrs = content.type === 'record' && content.entityName
+      ? ` role="link" title="${this.escapeHtml(recordOpenLabel)}" aria-label="${this.escapeHtml(recordOpenLabel)}" data-record-entity="${this.escapeHtml(content.entityName)}" data-record-keys="${this.escapeHtml(JSON.stringify(ConversationUtility.RecordLinkKeyMap(content)))}"`
+      : '';
+
     // Generate HTML based on whether we have an icon
     if (logoURL) {
-      return `<span class="mention-badge ${typeClass}"${inlineStyle}><img src="${this.escapeHtml(logoURL)}" alt="" />${escapedName}${presetIndicator}</span>`;
+      return `<span class="mention-badge ${typeClass}"${inlineStyle}${recordAttrs}><img src="${this.escapeHtml(logoURL)}" alt="" />${escapedName}${presetIndicator}</span>`;
     } else if (iconClass) {
-      return `<span class="mention-badge ${typeClass}"${inlineStyle}><i class="${this.escapeHtml(iconClass)}" aria-hidden="true"></i>${escapedName}${presetIndicator}</span>`;
+      return `<span class="mention-badge ${typeClass}"${inlineStyle}${recordAttrs}><i class="${this.escapeHtml(iconClass)}" aria-hidden="true"></i>${escapedName}${presetIndicator}</span>`;
     } else {
-      return `<span class="mention-badge ${typeClass}"${inlineStyle}>${escapedName}${presetIndicator}</span>`;
+      return `<span class="mention-badge ${typeClass}"${inlineStyle}${recordAttrs}>${escapedName}${presetIndicator}</span>`;
     }
   }
 

--- a/packages/Angular/Generic/conversations/src/lib/components/workspace/conversation-workspace.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/workspace/conversation-workspace.component.ts
@@ -1077,14 +1077,18 @@ export class ConversationWorkspaceComponent extends BaseAngularComponent impleme
   }
 
   onOpenEntityRecord(event: {entityName: string; compositeKey: CompositeKey}): void {
-    // Convert to actionable command and emit
-    const firstKeyValue = event.compositeKey.KeyValuePairs[0]?.Value || '';
+    const pairs = event.compositeKey.KeyValuePairs || [];
+    const keys: Record<string, string | number> = {};
+    for (const p of pairs) {
+      if (p.FieldName) keys[p.FieldName] = p.Value;
+    }
     const command: ActionableCommand = {
       type: 'open:resource',
       label: `Open ${event.entityName}`,
       resourceType: 'Record',
       entityName: event.entityName,
-      resourceId: firstKeyValue,
+      resourceId: event.compositeKey.GetValueByFieldName('ID') ?? pairs[0]?.Value,
+      keys,
       mode: 'view'
     };
     this.actionableCommandExecuted.emit(command);
@@ -1266,6 +1270,11 @@ export class ConversationWorkspaceComponent extends BaseAngularComponent impleme
    * Bubbles up to host application for handling
    */
   onActionableCommand(command: ActionableCommand): void {
+    if (command.type === 'open:resource' && command.resourceType === 'Record') {
+      // chat-area converts Record commands to openEntityRecord; onOpenEntityRecord
+      // re-emits them as actionableCommandExecuted. Skip the raw command to avoid a double open.
+      return;
+    }
     console.log('📤 Bubbling up actionable command:', command);
     this.actionableCommandExecuted.emit(command);
   }


### PR DESCRIPTION
## Summary
- Agents can emit `@{…}` `type: "record"` tokens in Chat `message`. The conversation renderer turns them into clickable pills; the host opens the row via `OpenEntityRecord`.
- Primary keys are sibling fields on the token (composite keys included). `open:resource` Record commands accept the same `keys` map.
- `name` is **optional**. Omit it when surrounding prose already names the record — the pill renders as an icon with an arrow. Include `name` only when the token *is* the mention.
- Loop Agent Type system prompt teaches the grammar and asks for world-class UX: prefer icon-only, one citation per record per section, no heading-plus-body duplicates.

## Test plan
- [ ] Paste a labeled token (`"name": "Acme Corp"`) into a Chat message and confirm a blue name pill opens the record.
- [ ] Paste an icon-only token (no `name`) after prose that already names the row and confirm a compact arrow pill opens the same record.
- [ ] Confirm a composite-PK token (sibling fields, no `resourceId`) opens the correct row.
- [ ] Confirm two nearby tokens for the same record are a prompt/UX issue, not a renderer crash; headings stay text.
- [ ] `pnpm test` in `packages/AI/CorePlus` (record-link cases, including nameless tokens).