### PR TITLE
fix(conversations): stop Unknown error + stuck Running timer on agent fail

### DIFF
--- a/.changeset/skip-unknown-error-stuck-timer.md
+++ b/.changeset/skip-unknown-error-stuck-timer.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/ai-core-plus": patch
+"@memberjunction/ng-conversations": patch
+"@memberjunction/conversations-runtime": patch
+"@memberjunction/graphql-dataprovider": patch
+"@memberjunction/server": patch
+"@memberjunction/ai-agents": patch
+---
+
+Stop Explorer from showing "Unknown error" with a stuck Running timer when a Skip/sub-agent transport path fails. Pass the real error through invokeSubAgent, keep In-Progress when the agent may still be running, and persist Failed/Error on the run and conversation detail if executeAIAgent throws.

--- a/packages/AI/Agents/src/AgentRunner.ts
+++ b/packages/AI/Agents/src/AgentRunner.ts
@@ -201,11 +201,12 @@ export class AgentRunner {
             throw new Error('contextUser is required for RunAgentInConversation');
         }
 
+        let agentResponseDetail: MJConversationDetailEntity | undefined;
+
         try {
             let conversationId: string;
             let userMessageDetailId: string;
             let agentResponseDetailId: string | undefined;
-            let agentResponseDetail: MJConversationDetailEntity | undefined;
 
             // If conversationDetailId is provided, use it (UI-created agent response detail)
             if (options.conversationDetailId) {
@@ -591,6 +592,17 @@ export class AgentRunner {
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
             LogError(`RunAgentInConversation failed: ${errorMessage}`, undefined, error);
+            if (agentResponseDetail && agentResponseDetail.Status === 'In-Progress') {
+                try {
+                    await agentResponseDetail.EnsureSaveComplete();
+                    agentResponseDetail.Status = 'Error';
+                    agentResponseDetail.Message = errorMessage;
+                    agentResponseDetail.Error = errorMessage;
+                    await agentResponseDetail.Save();
+                } catch (persistError) {
+                    LogError(`Failed to persist Error on conversation detail after agent crash: ${persistError}`, undefined, persistError);
+                }
+            }
             throw error;
         }
     }

--- a/packages/AI/CorePlus/src/__tests__/agent-failure-message.test.ts
+++ b/packages/AI/CorePlus/src/__tests__/agent-failure-message.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+    agentFailureDisposition,
     agentFailureMessage,
+    coerceFailedExecuteAgentResult,
     isDisconnectWhileAgentMayStillBeRunning,
 } from '../agent-failure-message';
 
@@ -37,5 +39,61 @@ describe('isDisconnectWhileAgentMayStillBeRunning', () => {
         expect(isDisconnectWhileAgentMayStillBeRunning(
             "Pipeline failed at step 'Execute Sub-Agent: Skip: Data Expert'"
         )).toBe(false);
+    });
+
+    it('does not treat raw Failed to fetch as in-flight (request may never have left the browser)', () => {
+        expect(isDisconnectWhileAgentMayStillBeRunning('Failed to fetch')).toBe(false);
+        expect(isDisconnectWhileAgentMayStillBeRunning('NetworkError when attempting to fetch resource.')).toBe(false);
+    });
+
+    it('is false when the transport knows the request was never acknowledged', () => {
+        expect(isDisconnectWhileAgentMayStillBeRunning(
+            'Lost connection to the server. The agent may still be running. Please refresh to check the latest status.',
+            { requestAcknowledged: false }
+        )).toBe(false);
+    });
+});
+
+describe('agentFailureDisposition', () => {
+    it('keeps In-Progress for a post-ACK disconnect so a later server Complete is not stomped', () => {
+        expect(agentFailureDisposition({
+            errorMessage: 'Lost connection to the server. The agent may still be running. Please refresh to check the latest status.',
+            requestAcknowledged: true,
+        })).toEqual({
+            status: 'In-Progress',
+            message: 'Lost connection to the server. The agent may still be running. Please refresh to check the latest status.',
+        });
+    });
+
+    it('paints Error when the request never left the browser', () => {
+        expect(agentFailureDisposition({
+            errorMessage: 'Failed to fetch',
+            requestAcknowledged: false,
+        }).status).toBe('Error');
+    });
+
+    it('paints Error for a real agent failure', () => {
+        expect(agentFailureDisposition({
+            errorMessage: "Pipeline failed at step 'Execute Sub-Agent: Skip: Data Expert'",
+        })).toEqual({
+            status: 'Error',
+            message: "Pipeline failed at step 'Execute Sub-Agent: Skip: Data Expert'",
+        });
+    });
+});
+
+describe('coerceFailedExecuteAgentResult', () => {
+    it('copies the source and forces success false without mutating the caller', () => {
+        const source = { success: true, errorMessage: 'from result', payload: { a: 1 } };
+        const failed = coerceFailedExecuteAgentResult(source, 'fallback');
+        expect(failed).toEqual({ success: false, errorMessage: 'from result', payload: { a: 1 } });
+        expect(source.success).toBe(true);
+    });
+
+    it('uses the fallback when the result has no error text', () => {
+        const failed = coerceFailedExecuteAgentResult({ success: true, payload: { x: 1 } }, 'envelope failed');
+        expect(failed.success).toBe(false);
+        expect(failed.errorMessage).toBe('envelope failed');
+        expect(failed.payload).toEqual({ x: 1 });
     });
 });

--- a/packages/AI/CorePlus/src/__tests__/agent-failure-message.test.ts
+++ b/packages/AI/CorePlus/src/__tests__/agent-failure-message.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+    agentFailureMessage,
+    isDisconnectWhileAgentMayStillBeRunning,
+} from '../agent-failure-message';
+
+describe('agentFailureMessage', () => {
+    it('prefers agentRun.ErrorMessage over transport errorMessage', () => {
+        expect(agentFailureMessage({
+            errorMessage: 'transport',
+            agentRun: { ErrorMessage: 'run failed' },
+        })).toBe('run failed');
+    });
+
+    it('falls back to transport errorMessage when the run has none', () => {
+        expect(agentFailureMessage({
+            errorMessage: 'Lost connection to the server. The agent may still be running.',
+            agentRun: undefined,
+        })).toBe('Lost connection to the server. The agent may still be running.');
+    });
+
+    it('does not return empty or Unknown error when a real message exists', () => {
+        expect(agentFailureMessage({ errorMessage: 'timeout' })).toBe('timeout');
+        expect(agentFailureMessage(null)).toBe('The agent failed without an error message.');
+        expect(agentFailureMessage({ errorMessage: '  ' })).toBe('The agent failed without an error message.');
+    });
+});
+
+describe('isDisconnectWhileAgentMayStillBeRunning', () => {
+    it('recognizes the GraphQLAIClient lost-connection copy', () => {
+        expect(isDisconnectWhileAgentMayStillBeRunning(
+            'Lost connection to the server. The agent may still be running. Please refresh to check the latest status.'
+        )).toBe(true);
+    });
+
+    it('is false for a genuine pipeline failure', () => {
+        expect(isDisconnectWhileAgentMayStillBeRunning(
+            "Pipeline failed at step 'Execute Sub-Agent: Skip: Data Expert'"
+        )).toBe(false);
+    });
+});

--- a/packages/AI/CorePlus/src/__tests__/agent-failure-message.test.ts
+++ b/packages/AI/CorePlus/src/__tests__/agent-failure-message.test.ts
@@ -37,7 +37,7 @@ describe('isDisconnectWhileAgentMayStillBeRunning', () => {
 
     it('is false for a genuine pipeline failure', () => {
         expect(isDisconnectWhileAgentMayStillBeRunning(
-            "Pipeline failed at step 'Execute Sub-Agent: Skip: Data Expert'"
+            "Pipeline failed at step 'Execute Sub-Agent: Specialist'"
         )).toBe(false);
     });
 
@@ -74,10 +74,10 @@ describe('agentFailureDisposition', () => {
 
     it('paints Error for a real agent failure', () => {
         expect(agentFailureDisposition({
-            errorMessage: "Pipeline failed at step 'Execute Sub-Agent: Skip: Data Expert'",
+            errorMessage: "Pipeline failed at step 'Execute Sub-Agent: Specialist'",
         })).toEqual({
             status: 'Error',
-            message: "Pipeline failed at step 'Execute Sub-Agent: Skip: Data Expert'",
+            message: "Pipeline failed at step 'Execute Sub-Agent: Specialist'",
         });
     });
 });

--- a/packages/AI/CorePlus/src/agent-failure-message.ts
+++ b/packages/AI/CorePlus/src/agent-failure-message.ts
@@ -5,6 +5,12 @@
 export type AgentFailureSource = {
     errorMessage?: string | null;
     agentRun?: { ErrorMessage?: string | null } | null;
+    /**
+     * True when the fire-and-forget mutation returned an ACK before the
+     * transport died. False when the request never left the browser (or the
+     * ACK never arrived). Undefined for callers that do not know.
+     */
+    requestAcknowledged?: boolean;
 } | null | undefined;
 
 /**
@@ -30,14 +36,58 @@ export function agentFailureMessage(
  * True when the failure text means the HTTP/WebSocket path died but the
  * server-side AIAgentRun may still be Running. Painting Status=Error in that
  * case leaves the Explorer timer stuck on In-Progress while the bubble says failed.
+ *
+ * Does **not** match raw `Failed to fetch` / `NetworkError` — those also fire
+ * when the initial mutation never reaches the server (no run exists). The
+ * GraphQL client rewrites a post-ACK disconnect to the "lost connection /
+ * still be running / please refresh" copy; only that copy (or an explicit
+ * `requestAcknowledged: true`) is treated as in-flight.
  */
-export function isDisconnectWhileAgentMayStillBeRunning(message: string): boolean {
+export function isDisconnectWhileAgentMayStillBeRunning(
+    message: string,
+    result?: AgentFailureSource
+): boolean {
+    if (result?.requestAcknowledged === false) {
+        return false;
+    }
     const m = message.toLowerCase();
     return (
         m.includes('still be running') ||
         m.includes('lost connection to the server') ||
-        m.includes('please refresh') ||
-        m.includes('failed to fetch') ||
-        m.includes('networkerror')
+        m.includes('please refresh')
     );
+}
+
+export type AgentFailureDisposition =
+    | { status: 'In-Progress'; message: string }
+    | { status: 'Error'; message: string };
+
+/**
+ * Decide whether a failed `ExecuteAgentResult` should keep the conversation
+ * detail In-Progress (server may still complete) or paint Error.
+ */
+export function agentFailureDisposition(
+    result: AgentFailureSource,
+    fallback?: string
+): AgentFailureDisposition {
+    const message = agentFailureMessage(result, fallback);
+    if (isDisconnectWhileAgentMayStillBeRunning(message, result)) {
+        return { status: 'In-Progress', message };
+    }
+    return { status: 'Error', message };
+}
+
+/**
+ * Copy of a failed agent result. Always `success: false` with a non-empty
+ * `errorMessage`. Does not mutate the caller's object.
+ */
+export function coerceFailedExecuteAgentResult<T extends { success?: boolean; errorMessage?: string | null; agentRun?: { ErrorMessage?: string | null } | null }>(
+    result: T | null | undefined,
+    fallback: string
+): T & { success: false; errorMessage: string } {
+    return {
+        ...(result ?? {}),
+        success: false,
+        errorMessage: agentFailureMessage(result, fallback),
+    } as T & { success: false; errorMessage: string };
 }

--- a/packages/AI/CorePlus/src/agent-failure-message.ts
+++ b/packages/AI/CorePlus/src/agent-failure-message.ts
@@ -1,0 +1,43 @@
+/**
+ * Client/transport failure text when `ExecuteAgentResult.agentRun` is missing
+ * (fire-and-forget timeout, dropped WebSocket, invokeSubAgent used to return null).
+ */
+export type AgentFailureSource = {
+    errorMessage?: string | null;
+    agentRun?: { ErrorMessage?: string | null } | null;
+} | null | undefined;
+
+/**
+ * Prefer the persisted run's ErrorMessage, then a transport-level errorMessage.
+ * Never returns empty string.
+ */
+export function agentFailureMessage(
+    result: AgentFailureSource,
+    fallback = 'The agent failed without an error message.'
+): string {
+    const fromRun = result?.agentRun?.ErrorMessage?.trim();
+    if (fromRun) {
+        return fromRun;
+    }
+    const fromResult = result?.errorMessage?.trim();
+    if (fromResult) {
+        return fromResult;
+    }
+    return fallback;
+}
+
+/**
+ * True when the failure text means the HTTP/WebSocket path died but the
+ * server-side AIAgentRun may still be Running. Painting Status=Error in that
+ * case leaves the Explorer timer stuck on In-Progress while the bubble says failed.
+ */
+export function isDisconnectWhileAgentMayStillBeRunning(message: string): boolean {
+    const m = message.toLowerCase();
+    return (
+        m.includes('still be running') ||
+        m.includes('lost connection to the server') ||
+        m.includes('please refresh') ||
+        m.includes('failed to fetch') ||
+        m.includes('networkerror')
+    );
+}

--- a/packages/AI/CorePlus/src/agent-types.ts
+++ b/packages/AI/CorePlus/src/agent-types.ts
@@ -685,6 +685,12 @@ export type ExecuteAgentResult<P = any> = {
      * fire-and-forget timeout). Prefer `agentRun.ErrorMessage` when the run exists.
      */
     errorMessage?: string;
+    /**
+     * True when the fire-and-forget mutation returned an ACK before the transport
+     * died (server has the run). False when the request never left the browser.
+     * Undefined when the caller does not know.
+     */
+    requestAcknowledged?: boolean;
     /** Optional payload returned by the agent */
     payload?: P;
     /**

--- a/packages/AI/CorePlus/src/agent-types.ts
+++ b/packages/AI/CorePlus/src/agent-types.ts
@@ -680,6 +680,11 @@ export type BaseAgentNextStep<P = any, TContext = any> = {
 export type ExecuteAgentResult<P = any> = {
     /** Whether the agent execution was successful */
     success: boolean;
+    /**
+     * Transport-level failure text when {@link agentRun} is missing (lost WebSocket,
+     * fire-and-forget timeout). Prefer `agentRun.ErrorMessage` when the run exists.
+     */
+    errorMessage?: string;
     /** Optional payload returned by the agent */
     payload?: P;
     /**

--- a/packages/AI/CorePlus/src/index.ts
+++ b/packages/AI/CorePlus/src/index.ts
@@ -1,5 +1,6 @@
 export * from './prompt.types';
 export * from './agent-types';
+export * from './agent-failure-message';
 export * from './agent-payload-change-request';
 export * from './prompt.system-placeholders';
 export * from './agent-spec';

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
@@ -410,8 +410,12 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
   // Bounded poll after a post-ACK disconnect keeps In-Progress. The GraphQLAIClient
   // stall reconciler only runs while invokeSubAgent is waiting; once it returns,
   // this watch is the bound so a dead socket cannot leave the red-pill timer forever.
+  // Must outlast the server: Skip RequestManager defaults to 30 minutes
+  // (REQUEST_MAX_AGE_MS). Giving up earlier unregisters the streaming callback
+  // so a later server Complete never lands and the bubble stays Error.
   private static readonly IN_FLIGHT_WATCH_INTERVAL_MS = 15_000;
-  private static readonly IN_FLIGHT_WATCH_MAX_ATTEMPTS = 6;
+  // 30 min / 15 s. Must stay ≥ Skip RequestManager REQUEST_MAX_AGE_MS (30 min).
+  private static readonly IN_FLIGHT_WATCH_MAX_ATTEMPTS = 120;
   private inFlightWatches = new Map<string, ReturnType<typeof setInterval>>();
 
   // Track pending attachments from the input box
@@ -2240,8 +2244,15 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
       } else {
         await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
       }
-      conversationManagerMessage.Error = catchResult.errorMessage;
-      await this.updateConversationDetail(conversationManagerMessage, `❌ **${agentName}** encountered an error\n\n${catchResult.errorMessage}`, 'Error');
+      const catchDisposition = agentFailureDisposition(catchResult);
+      if (catchDisposition.status === 'Error') {
+        conversationManagerMessage.Error = catchDisposition.message;
+        await this.updateConversationDetail(
+          conversationManagerMessage,
+          `❌ **${agentName}** encountered an error\n\n${catchDisposition.message}`,
+          'Error',
+        );
+      }
     }
   }
 

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
@@ -1762,7 +1762,7 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
         await this.applyAgentFailureToDetail(
           conversationManagerMessage,
           userMessage,
-          'Sage',
+          this.converationManagerAgent?.Name || 'Sage',
           result,
           'failed',
         );

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
@@ -14,7 +14,7 @@ import { ConversationStreamingService, MessageProgressUpdate, MessageProgressMet
 import { GraphQLDataProvider, GraphQLAIClient } from '@memberjunction/graphql-dataprovider';
 import { GenerateAndApplyConversationName } from '../../services/conversation-naming';
 import { AIEngineBase } from '@memberjunction/ai-engine-base';
-import { ExecuteAgentResult, AgentExecutionProgressCallback, AgentResponseForm, ActionableCommand, AutomaticCommand, ConversationUtility } from '@memberjunction/ai-core-plus';
+import { ExecuteAgentResult, AgentExecutionProgressCallback, AgentResponseForm, ActionableCommand, AutomaticCommand, ConversationUtility, agentFailureMessage, isDisconnectWhileAgentMayStillBeRunning } from '@memberjunction/ai-core-plus';
 import { PendingAttachment } from '@memberjunction/ng-composer';
 import { AiComposerComponent } from '../composer/ai-composer.component';
 import { MentionAutocompleteService } from '../../services/mention-autocomplete.service';
@@ -2195,8 +2195,9 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
           await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
         } else {
           // Retry also failed - show error with manual retry option
-          conversationManagerMessage.Error = retryResult?.agentRun?.ErrorMessage || null;
-          await this.updateConversationDetail(conversationManagerMessage, `❌ **${agentName}** failed after retry\n\n${retryResult?.agentRun?.ErrorMessage || 'Unknown error'}`, 'Error');
+          const retryDetail = agentFailureMessage(retryResult);
+          conversationManagerMessage.Error = retryDetail;
+          await this.updateConversationDetail(conversationManagerMessage, `❌ **${agentName}** failed after retry\n\n${retryDetail}`, 'Error');
 
           await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
         }
@@ -2336,11 +2337,7 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
         // Mark user message as complete
         await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
       } else {
-        // Agent failed
-        statusMessage.Error = continuityResult?.agentRun?.ErrorMessage || null;
-        await this.updateConversationDetail(statusMessage, `❌ **${agentName}** failed during refinement\n\n${continuityResult?.agentRun?.ErrorMessage || 'Unknown error'}`, 'Error');
-
-        await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
+        await this.applyAgentFailureToDetail(statusMessage, userMessage, agentName, continuityResult, 'failed during refinement');
       }
     } catch (error) {
       console.error(`❌ Error in agent continuity with ${agentName}:`, error);
@@ -2463,24 +2460,21 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
           await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
         }
       } else {
-        // Agent failed - update the existing message instead of creating a new one
-        agentResponseMessage.Error = result?.agentRun?.ErrorMessage || null;
-        await this.updateConversationDetail(agentResponseMessage, `❌ **@${agentName}** failed\n\n${result?.agentRun?.ErrorMessage || 'Unknown error'}`, 'Error');
-
-        await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
+        await this.applyAgentFailureToDetail(agentResponseMessage, userMessage, agentName, result);
       }
     } catch (error) {
       console.error(`❌ Error invoking mentioned agent ${agentName}:`, error);
 
-      // Task removed in markMessageComplete() - this.activeTasks.remove(taskId);
-
-      // Update the existing agent response message if it was created
       if (agentResponseMessage) {
-        agentResponseMessage.Error = String(error);
-        await this.updateConversationDetail(agentResponseMessage, `❌ **@${agentName}** encountered an error\n\n${String(error)}`, 'Error');
+        await this.applyAgentFailureToDetail(
+          agentResponseMessage,
+          userMessage,
+          agentName,
+          { success: false, errorMessage: error instanceof Error ? error.message : String(error) } as ExecuteAgentResult,
+        );
+      } else {
+        await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
       }
-
-      await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
     }
   }
 
@@ -2670,24 +2664,21 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
         // Mark user message as complete
         await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
       } else {
-        // Agent failed - update the existing message instead of creating a new one
-        agentResponseMessage.Error = result?.agentRun?.ErrorMessage || null;
-        await this.updateConversationDetail(agentResponseMessage, `❌ **${agentName}** failed\n\n${result?.agentRun?.ErrorMessage || 'Unknown error'}`, 'Error');
-
-        await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
+        await this.applyAgentFailureToDetail(agentResponseMessage, userMessage, agentName, result);
       }
     } catch (error) {
       console.error(`❌ Error continuing with agent ${agentName}:`, error);
 
-      // Task removed in markMessageComplete() - this.activeTasks.remove(taskId);
-
-      // Update the existing agent response message if it was created
       if (agentResponseMessage) {
-        agentResponseMessage.Error = String(error);
-        await this.updateConversationDetail(agentResponseMessage, `❌ **${agentName}** encountered an error\n\n${String(error)}`, 'Error');
+        await this.applyAgentFailureToDetail(
+          agentResponseMessage,
+          userMessage,
+          agentName,
+          { success: false, errorMessage: error instanceof Error ? error.message : String(error) } as ExecuteAgentResult,
+        );
+      } else {
+        await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
       }
-
-      await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
     }
   }
 
@@ -2723,6 +2714,39 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
       });
       console.log(`✅ Conversation renamed to: "${result.Name}"`);
     }
+  }
+
+  /**
+   * Persist an agent failure onto the response bubble.
+   *
+   * A dropped HTTP/WebSocket path used to return `null` from invokeSubAgent, so
+   * the bubble said "Unknown error" while the AIAgentRun stayed Running and the
+   * timer kept ticking. If the transport text says the agent may still be
+   * running, keep In-Progress so later progress/completion can land.
+   */
+  private async applyAgentFailureToDetail(
+    agentResponseMessage: MJConversationDetailEntity,
+    userMessage: MJConversationDetailEntity,
+    agentName: string,
+    result: ExecuteAgentResult | null | undefined,
+    failedVerb = 'failed',
+  ): Promise<void> {
+    const detail = agentFailureMessage(result);
+    if (isDisconnectWhileAgentMayStillBeRunning(detail)) {
+      await this.updateConversationDetail(
+        agentResponseMessage,
+        `⏳ **${agentName}** is still running on the server.\n\n${detail}`,
+        'In-Progress',
+      );
+      return;
+    }
+    agentResponseMessage.Error = detail;
+    await this.updateConversationDetail(
+      agentResponseMessage,
+      `❌ **${agentName}** ${failedVerb}\n\n${detail}`,
+      'Error',
+    );
+    await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
   }
 
   /**

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
@@ -407,16 +407,13 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
   private completionTimestamps = new Map<string, number>();
   // Track registered streaming callbacks for cleanup
   private registeredCallbacks = new Map<string, (progress: MessageProgressUpdate) => Promise<void>>();
-  // Bounded poll after a post-ACK disconnect keeps In-Progress. The GraphQLAIClient
-  // stall reconciler only runs while invokeSubAgent is waiting; once it returns,
-  // this watch is the bound so a dead socket cannot leave the red-pill timer forever.
-  // Must outlast the server: Skip RequestManager defaults to 30 minutes
-  // (REQUEST_MAX_AGE_MS). Giving up earlier unregisters the streaming callback
-  // so a later server Complete never lands and the bubble stays Error.
-  private static readonly IN_FLIGHT_WATCH_INTERVAL_MS = 15_000;
-  // 30 min / 15 s. Must stay ≥ Skip RequestManager REQUEST_MAX_AGE_MS (30 min).
-  private static readonly IN_FLIGHT_WATCH_MAX_ATTEMPTS = 120;
-  private inFlightWatches = new Map<string, ReturnType<typeof setInterval>>();
+  // After a post-ACK disconnect, keep observing ConversationDetail.Status until
+  // the *server* writes Complete/Error (MaxTimePerRun terminates the run).
+  // Back off 5s → 15s → 60s so we bound polling cost, not invent a client
+  // verdict. Do not paint Error here — that would unregister the streaming
+  // callback and make a later server Complete sticky-wrong until reload.
+  private static readonly IN_FLIGHT_WATCH_BACKOFF_MS = [5_000, 15_000, 60_000] as const;
+  private inFlightWatches = new Map<string, ReturnType<typeof setTimeout>>();
 
   // Track pending attachments from the input box
   private pendingAttachments: PendingAttachment[] = [];
@@ -1765,7 +1762,7 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
         await this.applyAgentFailureToDetail(
           conversationManagerMessage,
           userMessage,
-          this.converationManagerAgent?.Name || 'Sage',
+          'Sage',
           result,
           'failed',
         );
@@ -2769,9 +2766,11 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
    * A dropped HTTP/WebSocket path used to return `null` from invokeSubAgent, so
    * the bubble said "Unknown error" while the AIAgentRun stayed Running and the
    * timer kept ticking. If the transport ACKed the mutation and then died, keep
-   * In-Progress so a later completion event (or the bounded watch below) can
-   * land. The GraphQLAIClient stall reconciler only covers the wait inside
-   * invokeSubAgent; once that returns, {@link startInFlightDetailWatch} is the bound.
+   * In-Progress so a later completion event (or {@link startInFlightDetailWatch})
+   * can land. ConversationDetail.Status is the server's claim; the client only
+   * renders it. The GraphQLAIClient stall reconciler covers the wait inside
+   * invokeSubAgent; once that returns, the watch observes the detail until the
+   * server writes a terminal status (MaxTimePerRun).
    *
    * Always completes the user message — the user turn finished regardless of
    * what the agent is doing.
@@ -2794,7 +2793,7 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
       // terminal server status (Complete/Error) — starting it would race the
       // just-completed bubble.
       if (agentResponseMessage.Status === 'In-Progress') {
-        this.startInFlightDetailWatch(agentResponseMessage, agentName, disposition.message);
+        this.startInFlightDetailWatch(agentResponseMessage);
       }
       await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
       return;
@@ -2808,28 +2807,27 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
     await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
   }
 
-  private startInFlightDetailWatch(
-    detail: MJConversationDetailEntity,
-    agentName: string,
-    disconnectMessage: string,
-  ): void {
+  private startInFlightDetailWatch(detail: MJConversationDetailEntity): void {
     if (!detail.ID) {
       return;
     }
     this.stopInFlightDetailWatch(detail.ID);
-    let attempts = 0;
-    const handle = setInterval(() => {
-      void this.pollInFlightDetail(detail, agentName, disconnectMessage, ++attempts);
-    }, MessageInputComponent.IN_FLIGHT_WATCH_INTERVAL_MS);
+    this.scheduleInFlightDetailPoll(detail, 0);
+  }
+
+  private scheduleInFlightDetailPoll(detail: MJConversationDetailEntity, step: number): void {
+    const delays = MessageInputComponent.IN_FLIGHT_WATCH_BACKOFF_MS;
+    const delay = delays[Math.min(step, delays.length - 1)];
+    const handle = setTimeout(() => {
+      void this.pollInFlightDetail(detail, step);
+    }, delay);
     this.inFlightWatches.set(detail.ID, handle);
   }
 
-  private async pollInFlightDetail(
-    detail: MJConversationDetailEntity,
-    agentName: string,
-    disconnectMessage: string,
-    attempts: number,
-  ): Promise<void> {
+  private async pollInFlightDetail(detail: MJConversationDetailEntity, step: number): Promise<void> {
+    if (!this.inFlightWatches.has(detail.ID)) {
+      return;
+    }
     try {
       await detail.Load(detail.ID);
       if (detail.Status === 'Complete' || detail.Status === 'Error') {
@@ -2841,28 +2839,23 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
     } catch (e) {
       console.warn(`[InFlightWatch] Failed to reload conversation detail ${detail.ID}:`, e);
     }
-    if (attempts >= MessageInputComponent.IN_FLIGHT_WATCH_MAX_ATTEMPTS) {
-      this.stopInFlightDetailWatch(detail.ID);
-      detail.Error = disconnectMessage;
-      await this.updateConversationDetail(
-        detail,
-        `⏳ **${agentName}** may still be running on the server. Please refresh to check the latest status.\n\n${disconnectMessage}`,
-        'Error',
-      );
+    if (!this.inFlightWatches.has(detail.ID)) {
+      return;
     }
+    this.scheduleInFlightDetailPoll(detail, step + 1);
   }
 
   private stopInFlightDetailWatch(detailId: string): void {
     const handle = this.inFlightWatches.get(detailId);
     if (handle) {
-      clearInterval(handle);
+      clearTimeout(handle);
       this.inFlightWatches.delete(detailId);
     }
   }
 
   private clearInFlightWatches(): void {
     for (const handle of this.inFlightWatches.values()) {
-      clearInterval(handle);
+      clearTimeout(handle);
     }
     this.inFlightWatches.clear();
   }

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
@@ -14,7 +14,7 @@ import { ConversationStreamingService, MessageProgressUpdate, MessageProgressMet
 import { GraphQLDataProvider, GraphQLAIClient } from '@memberjunction/graphql-dataprovider';
 import { GenerateAndApplyConversationName } from '../../services/conversation-naming';
 import { AIEngineBase } from '@memberjunction/ai-engine-base';
-import { ExecuteAgentResult, AgentExecutionProgressCallback, AgentResponseForm, ActionableCommand, AutomaticCommand, ConversationUtility, agentFailureMessage, isDisconnectWhileAgentMayStillBeRunning } from '@memberjunction/ai-core-plus';
+import { ExecuteAgentResult, AgentExecutionProgressCallback, AgentResponseForm, ActionableCommand, AutomaticCommand, ConversationUtility, agentFailureDisposition, agentFailureMessage } from '@memberjunction/ai-core-plus';
 import { PendingAttachment } from '@memberjunction/ng-composer';
 import { AiComposerComponent } from '../composer/ai-composer.component';
 import { MentionAutocompleteService } from '../../services/mention-autocomplete.service';
@@ -407,6 +407,12 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
   private completionTimestamps = new Map<string, number>();
   // Track registered streaming callbacks for cleanup
   private registeredCallbacks = new Map<string, (progress: MessageProgressUpdate) => Promise<void>>();
+  // Bounded poll after a post-ACK disconnect keeps In-Progress. The GraphQLAIClient
+  // stall reconciler only runs while invokeSubAgent is waiting; once it returns,
+  // this watch is the bound so a dead socket cannot leave the red-pill timer forever.
+  private static readonly IN_FLIGHT_WATCH_INTERVAL_MS = 15_000;
+  private static readonly IN_FLIGHT_WATCH_MAX_ATTEMPTS = 6;
+  private inFlightWatches = new Map<string, ReturnType<typeof setInterval>>();
 
   // Track pending attachments from the input box
   private pendingAttachments: PendingAttachment[] = [];
@@ -527,6 +533,7 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
   ngOnDestroy() {
     // Unregister all streaming callbacks
     this.unregisterAllCallbacks();
+    this.clearInFlightWatches();
     this.realtimeActiveSub?.unsubscribe();
     // If the user navigates away mid-call, tear the session down.
     if (this.realtimeSession.IsActive) {
@@ -1751,15 +1758,14 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
       taskId = null; // Clear reference but don't remove from service
 
       if (!result || !result.success) {
-        // Evaluation failed - use updateConversationDetail to ensure task cleanup
-        const errorMsg = result?.agentRun?.ErrorMessage || 'Agent evaluation failed';
-        conversationManagerMessage.Error = errorMsg;
-        await this.updateConversationDetail(conversationManagerMessage, `❌ Evaluation failed`, 'Error');
-
-        await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
-        console.warn('⚠️ Sage failed:', result?.agentRun?.ErrorMessage);
-
-        // Clean up completion timestamp
+        await this.applyAgentFailureToDetail(
+          conversationManagerMessage,
+          userMessage,
+          this.converationManagerAgent?.Name || 'Sage',
+          result,
+          'failed',
+        );
+        console.warn('⚠️ Sage failed:', agentFailureMessage(result, 'Agent evaluation failed'));
         this.cleanupCompletionTimestamp(conversationManagerMessage.ID);
         return;
       }
@@ -1968,15 +1974,15 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
       this.markMessageComplete(convoDetail);
     }
 
-    // Race condition guard: Before writing Error, reload from DB to check if the server
-    // already completed this record. The server and client write to the same conversation
-    // detail record — if the server completed successfully but a client-side timeout or
-    // WebSocket disconnect triggered this error path, we must not overwrite the server's
-    // successful completion with an error status.
-    if (status === 'Error' && convoDetail.ID) {
+    // Race condition guard: Before writing Error *or* In-Progress, reload from DB.
+    // The In-Progress disconnect branch is the path that most needs this: a dropped
+    // socket leaves the in-memory Status stale (still In-Progress from creation), and
+    // without a reload we can overwrite a server Complete with the "still running"
+    // placeholder. If the server already finished, emit that record and stop the timer.
+    if ((status === 'Error' || status === 'In-Progress') && convoDetail.ID) {
       await convoDetail.Load(convoDetail.ID);
-      if (convoDetail.Status === 'Complete') {
-        // Server already completed — emit updated message, don't overwrite with error
+      if (convoDetail.Status === 'Complete' || convoDetail.Status === 'Error') {
+        this.markMessageComplete(convoDetail);
         this.messageSent.emit(convoDetail);
         return;
       }
@@ -2073,12 +2079,13 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
     const reasoning = payload.reasoning || 'Delegating to specialist agent';
 
     // Now create a NEW message for the sub-agent execution
+    let agentResponseMessage: MJConversationDetailEntity | null = null;
     try {
       // Look up the agent to get its ID
       const agent = AIEngineBase.Instance.Agents.find(a => a.Name === agentName);
 
       // Create AI response message BEFORE invoking agent (for duration tracking)
-      const agentResponseMessage = await this.dataCache.createConversationDetail(this.currentUser);
+      agentResponseMessage = await this.dataCache.createConversationDetail(this.currentUser);
 
       agentResponseMessage.ConversationID = conversationId;
       agentResponseMessage.Role = 'AI';
@@ -2154,6 +2161,13 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
         // Mark user message as complete
         await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
       } else {
+        // A post-ACK disconnect means the first run may still be executing on this
+        // detail — do not start a second run on the same conversationDetailId.
+        if (agentFailureDisposition(subResult).status === 'In-Progress') {
+          await this.applyAgentFailureToDetail(agentResponseMessage, userMessage, agentName, subResult);
+          return;
+        }
+
         // Sub-agent failed - attempt auto-retry once
         console.log(`⚠️ ${agentName} failed, attempting auto-retry...`);
 
@@ -2194,21 +2208,40 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
 
           await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
         } else {
-          // Retry also failed - show error with manual retry option
-          const retryDetail = agentFailureMessage(retryResult);
-          conversationManagerMessage.Error = retryDetail;
-          await this.updateConversationDetail(conversationManagerMessage, `❌ **${agentName}** failed after retry\n\n${retryDetail}`, 'Error');
-
-          await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
+          // Retry also failed — terminate the agent bubble (the red-pill timer lives here),
+          // not only the Sage delegation message.
+          await this.applyAgentFailureToDetail(
+            agentResponseMessage,
+            userMessage,
+            agentName,
+            retryResult,
+            'failed after retry',
+          );
+          const retryDisposition = agentFailureDisposition(retryResult);
+          if (retryDisposition.status === 'Error') {
+            conversationManagerMessage.Error = retryDisposition.message;
+            await this.updateConversationDetail(
+              conversationManagerMessage,
+              `❌ **${agentName}** failed after retry\n\n${retryDisposition.message}`,
+              'Error',
+            );
+          }
         }
       }
     } catch (error) {
       console.error(`❌ Error invoking sub-agent ${agentName}:`, error);
 
-      conversationManagerMessage.Error = String(error);
-      await this.updateConversationDetail(conversationManagerMessage, `❌ **${agentName}** encountered an error\n\n${String(error)}`, 'Error');
-
-      await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
+      const catchResult = {
+        success: false,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      } as ExecuteAgentResult;
+      if (agentResponseMessage) {
+        await this.applyAgentFailureToDetail(agentResponseMessage, userMessage, agentName, catchResult);
+      } else {
+        await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
+      }
+      conversationManagerMessage.Error = catchResult.errorMessage;
+      await this.updateConversationDetail(conversationManagerMessage, `❌ **${agentName}** encountered an error\n\n${catchResult.errorMessage}`, 'Error');
     }
   }
 
@@ -2344,10 +2377,13 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
 
       // Task removed in markMessageComplete() - this.activeTasks.remove(taskId);
 
-      statusMessage.Error = String(error);
-      await this.updateConversationDetail(statusMessage, `❌ **${agentName}** encountered an error\n\n${String(error)}`, 'Error');
-
-      await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
+      await this.applyAgentFailureToDetail(
+        statusMessage,
+        userMessage,
+        agentName,
+        { success: false, errorMessage: error instanceof Error ? error.message : String(error) } as ExecuteAgentResult,
+        'encountered an error',
+      );
     }
   }
  
@@ -2721,8 +2757,13 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
    *
    * A dropped HTTP/WebSocket path used to return `null` from invokeSubAgent, so
    * the bubble said "Unknown error" while the AIAgentRun stayed Running and the
-   * timer kept ticking. If the transport text says the agent may still be
-   * running, keep In-Progress so later progress/completion can land.
+   * timer kept ticking. If the transport ACKed the mutation and then died, keep
+   * In-Progress so a later completion event (or the bounded watch below) can
+   * land. The GraphQLAIClient stall reconciler only covers the wait inside
+   * invokeSubAgent; once that returns, {@link startInFlightDetailWatch} is the bound.
+   *
+   * Always completes the user message — the user turn finished regardless of
+   * what the agent is doing.
    */
   private async applyAgentFailureToDetail(
     agentResponseMessage: MJConversationDetailEntity,
@@ -2731,22 +2772,88 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
     result: ExecuteAgentResult | null | undefined,
     failedVerb = 'failed',
   ): Promise<void> {
-    const detail = agentFailureMessage(result);
-    if (isDisconnectWhileAgentMayStillBeRunning(detail)) {
+    const disposition = agentFailureDisposition(result);
+    if (disposition.status === 'In-Progress') {
       await this.updateConversationDetail(
         agentResponseMessage,
-        `⏳ **${agentName}** is still running on the server.\n\n${detail}`,
+        `⏳ **${agentName}** is still running on the server.\n\n${disposition.message}`,
         'In-Progress',
       );
+      // Skip the watch if the reload-before-write guard already found a
+      // terminal server status (Complete/Error) — starting it would race the
+      // just-completed bubble.
+      if (agentResponseMessage.Status === 'In-Progress') {
+        this.startInFlightDetailWatch(agentResponseMessage, agentName, disposition.message);
+      }
+      await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
       return;
     }
-    agentResponseMessage.Error = detail;
+    agentResponseMessage.Error = disposition.message;
     await this.updateConversationDetail(
       agentResponseMessage,
-      `❌ **${agentName}** ${failedVerb}\n\n${detail}`,
+      `❌ **${agentName}** ${failedVerb}\n\n${disposition.message}`,
       'Error',
     );
     await this.updateConversationDetail(userMessage, userMessage.Message, 'Complete');
+  }
+
+  private startInFlightDetailWatch(
+    detail: MJConversationDetailEntity,
+    agentName: string,
+    disconnectMessage: string,
+  ): void {
+    if (!detail.ID) {
+      return;
+    }
+    this.stopInFlightDetailWatch(detail.ID);
+    let attempts = 0;
+    const handle = setInterval(() => {
+      void this.pollInFlightDetail(detail, agentName, disconnectMessage, ++attempts);
+    }, MessageInputComponent.IN_FLIGHT_WATCH_INTERVAL_MS);
+    this.inFlightWatches.set(detail.ID, handle);
+  }
+
+  private async pollInFlightDetail(
+    detail: MJConversationDetailEntity,
+    agentName: string,
+    disconnectMessage: string,
+    attempts: number,
+  ): Promise<void> {
+    try {
+      await detail.Load(detail.ID);
+      if (detail.Status === 'Complete' || detail.Status === 'Error') {
+        this.stopInFlightDetailWatch(detail.ID);
+        this.markMessageComplete(detail);
+        this.messageSent.emit(detail);
+        return;
+      }
+    } catch (e) {
+      console.warn(`[InFlightWatch] Failed to reload conversation detail ${detail.ID}:`, e);
+    }
+    if (attempts >= MessageInputComponent.IN_FLIGHT_WATCH_MAX_ATTEMPTS) {
+      this.stopInFlightDetailWatch(detail.ID);
+      detail.Error = disconnectMessage;
+      await this.updateConversationDetail(
+        detail,
+        `⏳ **${agentName}** may still be running on the server. Please refresh to check the latest status.\n\n${disconnectMessage}`,
+        'Error',
+      );
+    }
+  }
+
+  private stopInFlightDetailWatch(detailId: string): void {
+    const handle = this.inFlightWatches.get(detailId);
+    if (handle) {
+      clearInterval(handle);
+      this.inFlightWatches.delete(detailId);
+    }
+  }
+
+  private clearInFlightWatches(): void {
+    for (const handle of this.inFlightWatches.values()) {
+      clearInterval(handle);
+    }
+    this.inFlightWatches.clear();
   }
 
   /**
@@ -2756,6 +2863,7 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
   private markMessageComplete(conversationDetail: MJConversationDetailEntity): void {
     const now = Date.now();
     this.completionTimestamps.set(conversationDetail.ID, now);
+    this.stopInFlightDetailWatch(conversationDetail.ID);
 
     // Unregister streaming callback for this message (no more updates needed)
     const callback = this.registeredCallbacks.get(conversationDetail.ID);

--- a/packages/Angular/Generic/conversations/src/lib/services/conversation-agent.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/conversation-agent.service.ts
@@ -439,7 +439,7 @@ export class ConversationAgentService {
       const errorMsg = `Error invoking sub-agent "${agentName}": ` + (error instanceof Error ? error.message : String(error));
       console.error(`Error invoking sub-agent "${agentName}":`, error);
       MJNotificationService.Instance?.CreateSimpleNotification(errorMsg, 'error', 5000);
-      return coerceFailedExecuteAgentResult(undefined, errorMsg);
+      return coerceFailedExecuteAgentResult<ExecuteAgentResult>(undefined, errorMsg);
     }
   }
 

--- a/packages/Angular/Generic/conversations/src/lib/services/conversation-agent.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/conversation-agent.service.ts
@@ -425,19 +425,25 @@ export class ConversationAgentService {
 
       if (runResult.Success && runResult.Result) {
         return runResult.Result as ExecuteAgentResult;
-      } else if (!runResult.Success) {
-        const errorMsg = `Sub-agent "${agentName}" failed: ${runResult.ErrorMessage || 'unknown error'}`;
-        console.error(errorMsg);
-        MJNotificationService.Instance?.CreateSimpleNotification(errorMsg, 'error', 5000);
-        return null;
       }
 
-      return null;
+      const failed = (runResult.Result ?? {
+        success: false,
+        errorMessage: runResult.ErrorMessage || `Sub-agent "${agentName}" failed`,
+      }) as ExecuteAgentResult;
+      failed.success = false;
+      if (!failed.errorMessage) {
+        failed.errorMessage = runResult.ErrorMessage || `Sub-agent "${agentName}" failed`;
+      }
+      const errorMsg = `Sub-agent "${agentName}" failed: ${failed.errorMessage}`;
+      console.error(errorMsg);
+      MJNotificationService.Instance?.CreateSimpleNotification(errorMsg, 'error', 5000);
+      return failed;
     } catch (error) {
       const errorMsg = `Error invoking sub-agent "${agentName}": ` + (error instanceof Error ? error.message : String(error));
       console.error(`Error invoking sub-agent "${agentName}":`, error);
       MJNotificationService.Instance?.CreateSimpleNotification(errorMsg, 'error', 5000);
-      return null;
+      return { success: false, errorMessage: errorMsg } as ExecuteAgentResult;
     }
   }
 

--- a/packages/Angular/Generic/conversations/src/lib/services/conversation-agent.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/conversation-agent.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Metadata, IMetadataProvider, RunView } from '@memberjunction/core';
 import { GraphQLDataProvider, GraphQLAIClient } from '@memberjunction/graphql-dataprovider';
-import { ExecuteAgentResult, AgentExecutionProgressCallback } from '@memberjunction/ai-core-plus';
+import { ExecuteAgentResult, AgentExecutionProgressCallback, coerceFailedExecuteAgentResult } from '@memberjunction/ai-core-plus';
 import { AIEngineBase } from '@memberjunction/ai-engine-base';
 import {
   MJConversationDetailEntity,
@@ -427,14 +427,10 @@ export class ConversationAgentService {
         return runResult.Result as ExecuteAgentResult;
       }
 
-      const failed = (runResult.Result ?? {
-        success: false,
-        errorMessage: runResult.ErrorMessage || `Sub-agent "${agentName}" failed`,
-      }) as ExecuteAgentResult;
-      failed.success = false;
-      if (!failed.errorMessage) {
-        failed.errorMessage = runResult.ErrorMessage || `Sub-agent "${agentName}" failed`;
-      }
+      const failed = coerceFailedExecuteAgentResult(
+        runResult.Result as ExecuteAgentResult | null | undefined,
+        runResult.ErrorMessage || `Sub-agent "${agentName}" failed`,
+      );
       const errorMsg = `Sub-agent "${agentName}" failed: ${failed.errorMessage}`;
       console.error(errorMsg);
       MJNotificationService.Instance?.CreateSimpleNotification(errorMsg, 'error', 5000);
@@ -443,7 +439,7 @@ export class ConversationAgentService {
       const errorMsg = `Error invoking sub-agent "${agentName}": ` + (error instanceof Error ? error.message : String(error));
       console.error(`Error invoking sub-agent "${agentName}":`, error);
       MJNotificationService.Instance?.CreateSimpleNotification(errorMsg, 'error', 5000);
-      return { success: false, errorMessage: errorMsg } as ExecuteAgentResult;
+      return coerceFailedExecuteAgentResult(undefined, errorMsg);
     }
   }
 

--- a/packages/ConversationsRuntime/src/__tests__/ConversationAgentRunner.test.ts
+++ b/packages/ConversationsRuntime/src/__tests__/ConversationAgentRunner.test.ts
@@ -3,7 +3,8 @@
  *
  * Covers: default-agent resolution failure surfaces a notification + returns null,
  * successful run returns the underlying ExecuteAgentResult, agent failure surfaces
- * a notification + returns null, isProcessing$ toggles around the call, candidate
+ * a notification + returns a failed ExecuteAgentResult (so the chat bubble can
+ * show the real error instead of "Unknown error"), isProcessing$ toggles around the call, candidate
  * agent filtering excludes the resolved agent / non-Active / Sub-Agent invocation
  * modes / agents with ParentID.
  */
@@ -286,7 +287,7 @@ describe('ConversationAgentRunner', () => {
             withAgents(sageAgent);
         });
 
-        it('surfaces a notification and returns null when the session reports failure', async () => {
+        it('surfaces a notification and returns a failed ExecuteAgentResult when the session reports failure', async () => {
             hoisted.sessionRun.mockResolvedValue({ Success: false, ErrorMessage: 'timeout' });
 
             const result = await runner.processMessage({
@@ -295,13 +296,13 @@ describe('ConversationAgentRunner', () => {
                 conversationDetailId: 'cd1',
             });
 
-            expect(result).toBeNull();
+            expect(result).toEqual({ success: false, errorMessage: 'timeout' });
             expect(notify).toHaveBeenCalledOnce();
             expect(notify.mock.calls[0][0]).toBe('error');
             expect(notify.mock.calls[0][1]).toContain('timeout');
         });
 
-        it('surfaces a notification and returns null when the session throws', async () => {
+        it('surfaces a notification and returns a failed ExecuteAgentResult when the session throws', async () => {
             const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
             try {
                 hoisted.sessionRun.mockRejectedValue(new Error('network'));
@@ -312,7 +313,8 @@ describe('ConversationAgentRunner', () => {
                     conversationDetailId: 'cd1',
                 });
 
-                expect(result).toBeNull();
+                expect(result?.success).toBe(false);
+                expect(result?.errorMessage).toContain('network');
                 expect(notify).toHaveBeenCalledOnce();
                 expect(notify.mock.calls[0][1]).toContain('network');
             } finally {

--- a/packages/ConversationsRuntime/src/__tests__/ConversationAgentRunner.test.ts
+++ b/packages/ConversationsRuntime/src/__tests__/ConversationAgentRunner.test.ts
@@ -78,7 +78,16 @@ vi.mock('@memberjunction/ai-agent-client', () => {
     };
 });
 
-vi.mock('@memberjunction/ai-core-plus', () => ({}));
+vi.mock('@memberjunction/ai-core-plus', () => ({
+    coerceFailedExecuteAgentResult: (result: { errorMessage?: string | null; agentRun?: { ErrorMessage?: string | null } | null } | null | undefined, fallback: string) => ({
+        ...(result ?? {}),
+        success: false as const,
+        errorMessage:
+            result?.agentRun?.ErrorMessage?.trim() ||
+            result?.errorMessage?.trim() ||
+            fallback,
+    }),
+}));
 
 vi.mock('@memberjunction/global', () => ({
     UUIDsEqual: (a: string, b: string): boolean =>
@@ -300,6 +309,26 @@ describe('ConversationAgentRunner', () => {
             expect(notify).toHaveBeenCalledOnce();
             expect(notify.mock.calls[0][0]).toBe('error');
             expect(notify.mock.calls[0][1]).toContain('timeout');
+        });
+
+        it('forces success false when the envelope failed but Result.success is still true', async () => {
+            const source = { success: true, payload: { x: 1 } };
+            hoisted.sessionRun.mockResolvedValue({
+                Success: false,
+                ErrorMessage: 'envelope failed',
+                Result: source,
+            });
+
+            const result = await runner.processMessage({
+                conversationId: 'c1',
+                message: { ID: 'm1' } as never,
+                conversationDetailId: 'cd1',
+            });
+
+            expect(result?.success).toBe(false);
+            expect(result?.errorMessage).toBe('envelope failed');
+            expect(result?.payload).toEqual({ x: 1 });
+            expect(source.success).toBe(true);
         });
 
         it('surfaces a notification and returns a failed ExecuteAgentResult when the session throws', async () => {

--- a/packages/ConversationsRuntime/src/__tests__/ConversationAgentRunner.test.ts
+++ b/packages/ConversationsRuntime/src/__tests__/ConversationAgentRunner.test.ts
@@ -78,16 +78,12 @@ vi.mock('@memberjunction/ai-agent-client', () => {
     };
 });
 
-vi.mock('@memberjunction/ai-core-plus', () => ({
-    coerceFailedExecuteAgentResult: (result: { errorMessage?: string | null; agentRun?: { ErrorMessage?: string | null } | null } | null | undefined, fallback: string) => ({
-        ...(result ?? {}),
-        success: false as const,
-        errorMessage:
-            result?.agentRun?.ErrorMessage?.trim() ||
-            result?.errorMessage?.trim() ||
-            fallback,
-    }),
-}));
+vi.mock('@memberjunction/ai-core-plus', async () => {
+    // Import the helper from source so this test exercises the real function
+    // without loading @memberjunction/ai-core-plus (which pulls BaseEntity).
+    const { coerceFailedExecuteAgentResult } = await import('../../../AI/CorePlus/src/agent-failure-message');
+    return { coerceFailedExecuteAgentResult };
+});
 
 vi.mock('@memberjunction/global', () => ({
     UUIDsEqual: (a: string, b: string): boolean =>

--- a/packages/ConversationsRuntime/src/agent-runner/ConversationAgentRunner.ts
+++ b/packages/ConversationsRuntime/src/agent-runner/ConversationAgentRunner.ts
@@ -244,7 +244,7 @@ export class ConversationAgentRunner {
                 (error instanceof Error ? error.message : String(error));
             console.error('[ConversationAgentRunner] Error processing message:', error);
             this.context.Notification.Notify('error', errorMsg, 5_000);
-            return coerceFailedExecuteAgentResult(undefined, errorMsg);
+            return coerceFailedExecuteAgentResult<ExecuteAgentResult>(undefined, errorMsg);
         } finally {
             this._activeRunCount = Math.max(0, this._activeRunCount - 1);
             this._isProcessing$.next(this._activeRunCount > 0);

--- a/packages/ConversationsRuntime/src/agent-runner/ConversationAgentRunner.ts
+++ b/packages/ConversationsRuntime/src/agent-runner/ConversationAgentRunner.ts
@@ -230,20 +230,21 @@ export class ConversationAgentRunner {
             if (runResult.Success && runResult.Result) {
                 return runResult.Result as ExecuteAgentResult;
             }
-            if (!runResult.Success) {
-                const errorMsg = runResult.ErrorMessage ?? 'Agent execution failed';
-                console.error('[ConversationAgentRunner] Agent execution failed:', errorMsg);
-                this.context.Notification.Notify('error', errorMsg, 5_000);
-                return null;
+            const errorMsg = runResult.ErrorMessage ?? 'Agent execution failed';
+            console.error('[ConversationAgentRunner] Agent execution failed:', errorMsg);
+            this.context.Notification.Notify('error', errorMsg, 5_000);
+            const failed = (runResult.Result ?? { success: false, errorMessage: errorMsg }) as ExecuteAgentResult;
+            if (!failed.errorMessage) {
+                failed.errorMessage = errorMsg;
             }
-            return null;
+            return failed;
         } catch (error) {
             const errorMsg =
                 'Error processing message through agent: ' +
                 (error instanceof Error ? error.message : String(error));
             console.error('[ConversationAgentRunner] Error processing message:', error);
             this.context.Notification.Notify('error', errorMsg, 5_000);
-            return null;
+            return { success: false, errorMessage: errorMsg } as ExecuteAgentResult;
         } finally {
             this._activeRunCount = Math.max(0, this._activeRunCount - 1);
             this._isProcessing$.next(this._activeRunCount > 0);

--- a/packages/ConversationsRuntime/src/agent-runner/ConversationAgentRunner.ts
+++ b/packages/ConversationsRuntime/src/agent-runner/ConversationAgentRunner.ts
@@ -33,6 +33,7 @@ import {
     AgentExecutionProgressCallback,
     ExecuteAgentResult,
     MJAIAgentEntityExtended,
+    coerceFailedExecuteAgentResult,
 } from '@memberjunction/ai-core-plus';
 import { MJConversationDetailEntity } from '@memberjunction/core-entities';
 
@@ -233,18 +234,17 @@ export class ConversationAgentRunner {
             const errorMsg = runResult.ErrorMessage ?? 'Agent execution failed';
             console.error('[ConversationAgentRunner] Agent execution failed:', errorMsg);
             this.context.Notification.Notify('error', errorMsg, 5_000);
-            const failed = (runResult.Result ?? { success: false, errorMessage: errorMsg }) as ExecuteAgentResult;
-            if (!failed.errorMessage) {
-                failed.errorMessage = errorMsg;
-            }
-            return failed;
+            return coerceFailedExecuteAgentResult(
+                runResult.Result as ExecuteAgentResult | null | undefined,
+                errorMsg,
+            );
         } catch (error) {
             const errorMsg =
                 'Error processing message through agent: ' +
                 (error instanceof Error ? error.message : String(error));
             console.error('[ConversationAgentRunner] Error processing message:', error);
             this.context.Notification.Notify('error', errorMsg, 5_000);
-            return { success: false, errorMessage: errorMsg } as ExecuteAgentResult;
+            return coerceFailedExecuteAgentResult(undefined, errorMsg);
         } finally {
             this._activeRunCount = Math.max(0, this._activeRunCount - 1);
             this._isProcessing$.next(this._activeRunCount > 0);

--- a/packages/GraphQLDataProvider/src/graphQLAIClient.ts
+++ b/packages/GraphQLDataProvider/src/graphQLAIClient.ts
@@ -308,6 +308,7 @@ export class GraphQLAIClient {
         sourceArtifactId?: string,
         sourceArtifactVersionId?: string
     ): Promise<ExecuteAgentResult> {
+        let requestAcknowledged = false;
         try {
             const mutation = this.buildRunAIAgentMutation();
             const variables = this.prepareAgentVariables(params, sourceArtifactId, sourceArtifactVersionId);
@@ -321,7 +322,13 @@ export class GraphQLAIClient {
                 variables,
                 mutationFieldName: 'RunAIAgent',
                 operationLabel: 'RunAIAgent',
-                validateAck: (ack) => ack?.success === true,
+                validateAck: (ack) => {
+                    const ok = ack?.success === true;
+                    if (ok) {
+                        requestAcknowledged = true;
+                    }
+                    return ok;
+                },
                 isCompletionEvent: (parsed) => this.isAgentCompletionEvent(parsed),
                 extractResult: (parsed) => this.extractAgentResult(parsed),
                 // Headless clients (no PushStatusUpdates channel) run synchronously; the resolver
@@ -332,10 +339,10 @@ export class GraphQLAIClient {
                     if (params.onProgress) this.forwardAgentProgress(parsed, params.onProgress);
                 },
                 onStall: () => this.reconcileAgentRun(runIdRef.id ? `ID='${runIdRef.id}'` : undefined),
-                createErrorResult: (msg) => this.createAgentErrorResult(msg),
+                createErrorResult: (msg) => this.createAgentErrorResult(msg, requestAcknowledged),
             });
         } catch (e) {
-            return this.handleAgentError(e);
+            return this.handleAgentError(e, requestAcknowledged);
         }
     }
 
@@ -460,19 +467,22 @@ export class GraphQLAIClient {
      * @returns An error result
      * @private
      */
-    private handleAgentError(e: unknown): ExecuteAgentResult {
+    private handleAgentError(e: unknown, requestAcknowledged = false): ExecuteAgentResult {
         const error = e as Error;
         const errorMessage = error?.message || String(e);
         LogError(`Error running AI agent: ${errorMessage}`);
 
-        // Provide a meaningful error message that helps the user understand what happened.
         // CORS/network errors from Azure proxy timeouts appear as "Failed to fetch".
+        // That string also fires when the initial mutation never leaves the browser —
+        // only rewrite it to "may still be running" when the server already ACKed.
         const isFetchError = errorMessage.includes('Failed to fetch') || errorMessage.includes('NetworkError');
         const isTimeoutError = errorMessage.includes('timed out') || errorMessage.includes('timeout');
 
         let userMessage: string;
-        if (isFetchError) {
+        if (isFetchError && requestAcknowledged) {
             userMessage = 'Lost connection to the server. The agent may still be running. Please refresh to check the latest status.';
+        } else if (isFetchError) {
+            userMessage = 'Could not reach the server. The request may not have started. Please try again.';
         } else if (isTimeoutError) {
             userMessage = errorMessage; // Already has a helpful message from the completion timeout
         } else {
@@ -482,7 +492,8 @@ export class GraphQLAIClient {
         return {
             success: false,
             agentRun: undefined,
-            errorMessage: userMessage
+            errorMessage: userMessage,
+            requestAcknowledged,
         } as ExecuteAgentResult;
     }
 
@@ -515,6 +526,7 @@ export class GraphQLAIClient {
     public async RunAIAgentFromConversationDetail(
         params: RunAIAgentFromConversationDetailParams
     ): Promise<ExecuteAgentResult> {
+        let requestAcknowledged = false;
         try {
             const mutation = this.buildConversationDetailMutation();
             const variables = this.prepareConversationDetailVariables(params);
@@ -525,7 +537,13 @@ export class GraphQLAIClient {
                 variables,
                 mutationFieldName: 'RunAIAgentFromConversationDetail',
                 operationLabel: 'RunAIAgentFromConversationDetail',
-                validateAck: (ack) => ack?.success === true,
+                validateAck: (ack) => {
+                    const ok = ack?.success === true;
+                    if (ok) {
+                        requestAcknowledged = true;
+                    }
+                    return ok;
+                },
                 isCompletionEvent: (parsed) =>
                     this.isConversationDetailCompletionEvent(parsed, params.conversationDetailId),
                 extractResult: (parsed) => this.extractAgentResult(parsed),
@@ -539,10 +557,10 @@ export class GraphQLAIClient {
                 // the shared session stream: that key is operation-specific, so concurrent
                 // conversation-detail runs on one session can never cross-resolve to each other.
                 onStall: () => this.reconcileAgentRun(`ConversationDetailID='${params.conversationDetailId}'`),
-                createErrorResult: (msg) => this.createAgentErrorResult(msg),
+                createErrorResult: (msg) => this.createAgentErrorResult(msg, requestAcknowledged),
             });
         } catch (e) {
-            return this.handleAgentError(e);
+            return this.handleAgentError(e, requestAcknowledged);
         }
     }
 
@@ -740,14 +758,17 @@ export class GraphQLAIClient {
                 return parsedResult;
             }
         }
-        // Fallback: construct a minimal result from the event data — always carry
-        // errorMessage so the chat bubble never has to say "Unknown error".
+        // Fallback: construct a minimal result from the event data. Only stamp an
+        // errorMessage when the event is not a success — a successful completion
+        // with no payload is still success, not a failure.
+        const success = Boolean(data.success);
+        const fromEvent = (typeof data.errorMessage === 'string' && data.errorMessage)
+            ? data.errorMessage
+            : undefined;
         return {
-            success: Boolean(data.success),
+            success,
             agentRun: undefined,
-            errorMessage: (typeof data.errorMessage === 'string' && data.errorMessage)
-                ? data.errorMessage
-                : 'Agent execution ended without a result payload',
+            errorMessage: fromEvent ?? (success ? undefined : 'Agent execution ended without a result payload'),
         } as ExecuteAgentResult;
     }
 
@@ -840,11 +861,12 @@ export class GraphQLAIClient {
     /**
      * Create an error ExecuteAgentResult for fire-and-forget failures.
      */
-    private createAgentErrorResult(errorMessage: string): ExecuteAgentResult {
+    private createAgentErrorResult(errorMessage: string, requestAcknowledged = false): ExecuteAgentResult {
         return {
             success: false,
             agentRun: undefined,
             errorMessage,
+            requestAcknowledged,
         } as ExecuteAgentResult;
     }
 

--- a/packages/GraphQLDataProvider/src/graphQLAIClient.ts
+++ b/packages/GraphQLDataProvider/src/graphQLAIClient.ts
@@ -732,12 +732,22 @@ export class GraphQLAIClient {
         const data = parsed.data as Record<string, unknown>;
         const resultJson = data.result as string | undefined;
         if (resultJson) {
-            return SafeJSONParse(resultJson) as ExecuteAgentResult;
+            const parsedResult = SafeJSONParse(resultJson) as ExecuteAgentResult | null;
+            if (parsedResult) {
+                if (!parsedResult.errorMessage && typeof data.errorMessage === 'string') {
+                    parsedResult.errorMessage = data.errorMessage;
+                }
+                return parsedResult;
+            }
         }
-        // Fallback: construct a minimal result from the event data
+        // Fallback: construct a minimal result from the event data — always carry
+        // errorMessage so the chat bubble never has to say "Unknown error".
         return {
-            success: data.success as boolean,
+            success: Boolean(data.success),
             agentRun: undefined,
+            errorMessage: (typeof data.errorMessage === 'string' && data.errorMessage)
+                ? data.errorMessage
+                : 'Agent execution ended without a result payload',
         } as ExecuteAgentResult;
     }
 

--- a/packages/MJServer/src/resolvers/RunAIAgentResolver.ts
+++ b/packages/MJServer/src/resolvers/RunAIAgentResolver.ts
@@ -392,6 +392,11 @@ export class RunAIAgentResolver extends ResolverBase {
         taskGraphDebug?: string
     ): Promise<AIAgentRunResult> {
         const startTime = Date.now();
+        // Best-effort handle for persistInFlightAgentFailure. Populated from a
+        // progress event carrying metadata.agentRun, or from the successful
+        // result. A throw before the first such event leaves this null, so the
+        // run is not marked Failed — the early-failure case we most want to
+        // persist, but we have no run object yet.
         const agentRunRef = runRef ?? { current: null as MJAIAgentRunEntityExtended | null };
 
         try {
@@ -569,11 +574,8 @@ export class RunAIAgentResolver extends ResolverBase {
         errorMessage: string
     ): Promise<void> {
         try {
-            const user = this.GetUserFromPayload(userPayload);
-            if (!user) {
-                return;
-            }
             if (run && run.Status === 'Running') {
+                await run.EnsureSaveComplete();
                 run.Status = 'Failed';
                 run.ErrorMessage = errorMessage;
                 run.CompletedAt = new Date();
@@ -581,12 +583,17 @@ export class RunAIAgentResolver extends ResolverBase {
                     LogError(`Failed to persist Failed status on in-flight AIAgentRun ${run.ID}`);
                 }
             }
+            const user = this.GetUserFromPayload(userPayload);
+            if (!user) {
+                return;
+            }
             if (conversationDetailId) {
                 const detail = await provider.GetEntityObject<MJConversationDetailEntity>(
                     'MJ: Conversation Details',
                     user
                 );
                 if (await detail.Load(conversationDetailId) && detail.Status === 'In-Progress') {
+                    await detail.EnsureSaveComplete();
                     detail.Status = 'Error';
                     detail.Message = errorMessage;
                     detail.Error = errorMessage;

--- a/packages/MJServer/src/resolvers/RunAIAgentResolver.ts
+++ b/packages/MJServer/src/resolvers/RunAIAgentResolver.ts
@@ -392,7 +392,8 @@ export class RunAIAgentResolver extends ResolverBase {
         taskGraphDebug?: string
     ): Promise<AIAgentRunResult> {
         const startTime = Date.now();
-        
+        const agentRunRef = runRef ?? { current: null as MJAIAgentRunEntityExtended | null };
+
         try {
             LogStatus(`=== RUNNING AI AGENT FOR ID: ${agentId} ===`);
 
@@ -422,10 +423,6 @@ export class RunAIAgentResolver extends ResolverBase {
             // (AIAgentRun, AIAgentRunSteps, AIAgentRequests, AIPromptRuns) never share the global
             // singleton's transaction state with concurrent requests (e.g. conversation deletes).
             const agentRunner = new AgentRunner(p);
-
-            // Track agent run for streaming (use ref to update later). Reuse the caller-supplied
-            // ref when provided so the fire-and-forget liveness pulse can observe the run.
-            const agentRunRef = runRef ?? { current: null as any };
 
             console.log(`🚀 Starting agent execution with sessionId: ${sessionId}`);
 
@@ -539,11 +536,15 @@ export class RunAIAgentResolver extends ResolverBase {
         } catch (error) {
             const executionTime = Date.now() - startTime;
             LogError(`AI Agent run failed:`, undefined, error);
-            
-            // Create error payload
+            const errorMessage = (error as Error).message || 'Unknown error occurred';
+
+            // Fire-and-forget clients otherwise leave the run Running and the
+            // conversation detail In-Progress (Explorer red-pill timer).
+            await this.persistInFlightAgentFailure(p, userPayload, agentRunRef.current, conversationDetailId, errorMessage);
+
             const errorResult = {
                 success: false,
-                errorMessage: (error as Error).message || 'Unknown error occurred',
+                errorMessage,
                 executionTimeMs: executionTime
             };
             
@@ -553,6 +554,49 @@ export class RunAIAgentResolver extends ResolverBase {
                 executionTimeMs: executionTime,
                 result: JSON.stringify(errorResult)
             };
+        }
+    }
+
+    /**
+     * When executeAIAgent throws after the run/detail exist, close them so Explorer
+     * does not leave a red-pill timer on Status=Running / ConversationDetail In-Progress.
+     */
+    private async persistInFlightAgentFailure(
+        provider: DatabaseProviderBase,
+        userPayload: UserPayload,
+        run: MJAIAgentRunEntityExtended | null | undefined,
+        conversationDetailId: string | undefined,
+        errorMessage: string
+    ): Promise<void> {
+        try {
+            const user = this.GetUserFromPayload(userPayload);
+            if (!user) {
+                return;
+            }
+            if (run && run.Status === 'Running') {
+                run.Status = 'Failed';
+                run.ErrorMessage = errorMessage;
+                run.CompletedAt = new Date();
+                if (!(await run.Save())) {
+                    LogError(`Failed to persist Failed status on in-flight AIAgentRun ${run.ID}`);
+                }
+            }
+            if (conversationDetailId) {
+                const detail = await provider.GetEntityObject<MJConversationDetailEntity>(
+                    'MJ: Conversation Details',
+                    user
+                );
+                if (await detail.Load(conversationDetailId) && detail.Status === 'In-Progress') {
+                    detail.Status = 'Error';
+                    detail.Message = errorMessage;
+                    detail.Error = errorMessage;
+                    if (!(await detail.Save())) {
+                        LogError(`Failed to persist Error on conversation detail ${conversationDetailId}`);
+                    }
+                }
+            }
+        } catch (persistError) {
+            LogError(`persistInFlightAgentFailure failed: ${persistError}`, undefined, persistError);
         }
     }
 

--- a/packages/Web/RealtimeWidget/package.json
+++ b/packages/Web/RealtimeWidget/package.json
@@ -21,10 +21,11 @@
     "@memberjunction/global": "6.1.0-edge.4",
     "@memberjunction/core": "6.1.0-edge.4",
     "@memberjunction/core-entities": "6.1.0-edge.4",
-    "@memberjunction/conversations-runtime": "6.1.0-edge.4",
-    "@memberjunction/graphql-dataprovider": "6.1.0-edge.4",
     "@memberjunction/ai": "6.1.0-edge.4",
-    "@memberjunction/ai-realtime-client": "6.1.0-edge.4"
+    "@memberjunction/ai-core-plus": "6.1.0-edge.4",
+    "@memberjunction/ai-realtime-client": "6.1.0-edge.4",
+    "@memberjunction/conversations-runtime": "6.1.0-edge.4",
+    "@memberjunction/graphql-dataprovider": "6.1.0-edge.4"
   },
   "devDependencies": {
     "@types/node": "24.10.11",

--- a/packages/Web/RealtimeWidget/src/transport/runtime-widget-transport.ts
+++ b/packages/Web/RealtimeWidget/src/transport/runtime-widget-transport.ts
@@ -18,6 +18,7 @@ import { RunView, type UserInfo, type IMetadataProvider } from '@memberjunction/
 import type { MJConversationEntity, MJConversationDetailEntity } from '@memberjunction/core-entities';
 import { setupGraphQLClient, GraphQLProviderConfigData } from '@memberjunction/graphql-dataprovider';
 import { ConversationsRuntime } from '@memberjunction/conversations-runtime';
+import { agentFailureMessage } from '@memberjunction/ai-core-plus';
 import type { WidgetSession } from '../types.js';
 import type { IWidgetTransport, WidgetProgressCallback, WidgetTurnResult } from './widget-transport.js';
 
@@ -81,7 +82,7 @@ export class RuntimeWidgetTransport implements IWidgetTransport {
                 onProgress: (p) => onProgress?.(p.message ?? 'Working…', p.percentage),
             });
             if (!result || !result.success) {
-                return { reply: '', success: false, error: result?.agentRun?.ErrorMessage ?? 'The agent could not respond.' };
+                return { reply: '', success: false, error: agentFailureMessage(result, 'The agent could not respond.') };
             }
             return { reply: await this.readLatestAgentReply(), success: true };
         } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14853,6 +14853,9 @@ importers:
       '@memberjunction/ai':
         specifier: 6.1.0-edge.4
         version: link:../../AI/Core
+      '@memberjunction/ai-core-plus':
+        specifier: 6.1.0-edge.4
+        version: link:../../AI/CorePlus
       '@memberjunction/ai-realtime-client':
         specifier: 6.1.0-edge.4
         version: link:../../AI/RealtimeClient


### PR DESCRIPTION
## Summary

After approving a Skip dashboard PRD, Explorer showed **Skip failed / Unknown error** while the AIAgentRun stayed **Running** and the conversation detail stayed **In-Progress** — so the red-pill timer never stopped.

Root cause on the MJ side:

- `invokeSubAgent` / `ConversationAgentRunner` discarded the failed `ExecuteAgentResult` and returned `null`. The bubble always fell through to `result?.agentRun?.ErrorMessage || 'Unknown error'`.
- A dropped HTTP/WebSocket (fire-and-forget) often means the **server is still running**. Painting Status=Error on the client while the server keeps writing In-Progress is how you get a failed bubble + a live timer.
- If `executeAIAgent` / `RunAgentInConversation` threw after creating the run, nothing persisted Failed/Error on the in-flight records.

This PR:

- Passes the failed result through (with `errorMessage`) so the bubble can show the real transport text.
- If that text says the agent may still be running (lost connection / please refresh), **keeps In-Progress** so later progress/completion can land.
- On a server throw, persists Failed on the AIAgentRun and Error on the conversation detail.

Skip-side 5-minute abort + missing Skip System person are a separate PR: https://github.com/BlueCypress/Skip-Brain/pull/525

## Test plan

- [x] `@memberjunction/ai-core-plus` vitest: `agent-failure-message.test.ts`
- [x] `@memberjunction/conversations-runtime` vitest: ConversationAgentRunner failure now returns `{ success: false, errorMessage }` instead of null
- [ ] @mention Skip, drop the WebSocket mid-run: bubble should stay In-Progress with “still running on the server”, not Unknown error + a stuck timer
- [ ] Genuine Skip pipeline failure: bubble shows the real ErrorMessage and Status=Error
- [ ] `executeAIAgent` throw after the run exists: AIAgentRun is Failed and the conversation detail is Error