### PR TITLE
feat(actions): ERP accounting verbs — dispatcher + BC CreateJournalEntry

### DIFF
--- a/.changeset/accounting-erp-verbs.md
+++ b/.changeset/accounting-erp-verbs.md
@@ -1,0 +1,8 @@
+---
+"@memberjunction/actions-bizapps-accounting": patch
+"@memberjunction/sql-converter": patch
+---
+
+ERP accounting verbs: a provider-agnostic dispatcher per verb (`CreateJournalEntry`, `GetChartOfAccounts`, `GetAccountBalances`, `GetDimensions`, `GetGLEntries`, `GetCustomers`, `GetSalesInvoices`) plus QBO/BC plugins keyed as `${verb}:${Integration.Name}`. Adds Business Central CreateJournalEntry and GetAccountBalances, dimensions for both ERPs, and shared journal-line validation. Historical vendor RegisterClass keys still resolve.
+
+SQLConverter: CREATE TABLE CHECK `ISJSON(col) = 1` now becomes `(col) IS JSON` after identifier quoting, so PostgreSQL no longer sees `"ISJSON"(col) = 1`.

--- a/packages/Actions/BizApps/Accounting/README.md
+++ b/packages/Actions/BizApps/Accounting/README.md
@@ -1,91 +1,112 @@
 # @memberjunction/actions-bizapps-accounting
 
-Accounting system integration actions for MemberJunction. This package provides a standardized, multi-provider interface for interacting with external accounting systems through the MemberJunction Actions framework. It currently supports QuickBooks Online and Microsoft Dynamics 365 Business Central, with a pluggable architecture for adding additional providers.
+Stateless **ERP** verbs for MemberJunction. Callers and agents use a verb name
+(`CreateJournalEntry`, `GetChartOfAccounts`, …) — never a vendor class name.
+A dispatcher loads the company's accounting `CompanyIntegration` and forwards to
+the plugin registered as `` `${verb}:${integration.Name}` ``.
 
-This package is part of the [BizApps Actions](../README.md) family within the broader [MemberJunction Actions Framework](../../README.md). See those parent documents for general action design principles and BizApps-level patterns.
+This package is **HTTP plus trivial validation**. It does **not** upsert
+`GLAccount`, does **not** flip journal-entry batch status, and does **not** write
+`CashBalance`. Those jobs belong to Open Apps (accounting is a subledger, not
+the GL). This package has zero knowledge of bizapps-accounting.
 
-## Architecture
+ERP is always **ERP** (acronym, caps).
 
-The package follows a three-tier class hierarchy -- a domain base class, provider-specific base classes, and individual action implementations. Each provider encapsulates its own API interaction patterns (QBO query language for QuickBooks, OData for Business Central) while sharing credential management and validation logic.
+Plan (domain brain, extensions, daily sync):
+[erp-provider-layer.md](https://github.com/MemberJunction/bizapps-accounting/blob/next/plans/erp-provider-layer.md)
+(accounting PR [#126](https://github.com/MemberJunction/bizapps-accounting/pull/126) if `next` does not have the file yet).
+
+This package is part of the [BizApps Actions](../README.md) family.
+
+## What these actions are (and are not)
+
+| These actions | Not these actions |
+|---|---|
+| Pull chart / dimensions / balances / GL entries | Upsert `GLAccount`, `Dimension`, `DimensionValue` |
+| Post one balanced journal, all-or-nothing at the ERP | Flip a Journal Entry Batch to `Posted` / stamp external id |
+| Validate lines (≥ 2, debit xor credit, non-negative, balanced) | Write `CashBalance` / `CashBalanceLine` |
+| Resolve credentials via `CompanyIntegration` + env-first OAuth | Own a second integration engine |
+
+Generic Integration Actions (`IntegrationActionExecutor`) stay for object CRUD
+such as “list BC customers.” They are **not** how we post a batch. Do not
+migrate these verbs onto per-object CRUD.
+
+## Call path
 
 ```mermaid
-graph TD
-    subgraph Framework["MemberJunction Actions Framework"]
-        BA["BaseAction<br/>@memberjunction/actions"]
-    end
-
-    subgraph Domain["Domain Layer"]
-        BAA["BaseAccountingAction<br/>Credential management<br/>Validation helpers<br/>Currency/date formatting"]
-    end
-
-    subgraph Providers["Provider Layer"]
-        QB["QuickBooksBaseAction<br/>QBO query language<br/>OAuth + Realm ID<br/>Sandbox/production URLs"]
-        BC["BusinessCentralBaseAction<br/>OData query builder<br/>Tenant/environment routing<br/>Filter expression helpers"]
-    end
-
-    subgraph QBActions["QuickBooks Online Actions"]
-        QGL["GetQuickBooksGLCodesAction"]
-        QTX["GetQuickBooksTransactionsAction"]
-        QAB["GetQuickBooksAccountBalancesAction"]
-        QJE["CreateQuickBooksJournalEntryAction"]
-    end
-
-    subgraph BCActions["Business Central Actions"]
-        BGL["GetBusinessCentralGLAccountsAction"]
-        BGLE["GetBusinessCentralGeneralLedgerEntriesAction"]
-        BCU["GetBusinessCentralCustomersAction"]
-        BSI["GetBusinessCentralSalesInvoicesAction"]
-    end
-
-    BA --> BAA
-    BAA --> QB
-    BAA --> BC
-    QB --> QGL
-    QB --> QTX
-    QB --> QAB
-    QB --> QJE
-    BC --> BGL
-    BC --> BGLE
-    BC --> BCU
-    BC --> BSI
-
-    style Framework fill:#64748b,stroke:#475569,color:#fff
-    style Domain fill:#7c5295,stroke:#563a6b,color:#fff
-    style Providers fill:#2d6a9f,stroke:#1a4971,color:#fff
-    style QBActions fill:#2d8659,stroke:#1a5c3a,color:#fff
-    style BCActions fill:#b8762f,stroke:#8a5722,color:#fff
+flowchart LR
+  Caller["Caller / agent / AccountingERPEngine"] --> Verb["Verb dispatcher<br/>CreateJournalEntry"]
+  Verb -->|"CompanyID → CompanyIntegration<br/>TryCreateInstance(BaseAction, verb:Integration.Name)"| Plugin["Plugin subclass<br/>CreateJournalEntry:QuickBooks Online"]
+  Plugin --> HTTP["ERP HTTP<br/>QBO query / BC OData v2.0"]
 ```
-
-### Credential Flow
-
-All actions resolve credentials through a two-stage lookup. Environment variables take priority over database records, keeping secrets out of the database while allowing non-sensitive configuration (realm ID, environment name) to remain there.
 
 ```mermaid
 sequenceDiagram
-    participant Action as Accounting Action
-    participant BAA as BaseAccountingAction
-    participant Env as Environment Variables
-    participant DB as CompanyIntegration Entity
+  participant C as Caller
+  participant D as CreateJournalEntry dispatcher
+  participant CF as ClassFactory
+  participant P as Plugin (QBO or BC)
+  participant ERP as ERP HTTP
 
-    Action->>BAA: getOAuthTokens(integration)
-    BAA->>Env: Check BIZAPPS_{PROVIDER}_{COMPANY_ID}_ACCESS_TOKEN
-    alt Token found in env
-        Env-->>BAA: Return access token + refresh token
-    else Not in env
-        BAA->>DB: Read AccessToken from CompanyIntegration
-        alt Token valid
-            DB-->>BAA: Return access token
-        else Token expired or missing
-            BAA-->>Action: Throw authentication error
-        end
-    end
-    BAA-->>Action: Return { accessToken, refreshToken }
-
-    style Action fill:#2d8659,stroke:#1a5c3a,color:#fff
-    style BAA fill:#7c5295,stroke:#563a6b,color:#fff
-    style Env fill:#2d6a9f,stroke:#1a4971,color:#fff
-    style DB fill:#b8762f,stroke:#8a5722,color:#fff
+  C->>D: RunAction(CreateJournalEntry, CompanyID, Lines)
+  D->>D: resolveCompanyAccountingIntegration(CompanyID)
+  D->>CF: TryCreateInstance(BaseAction, "CreateJournalEntry:" + Integration.Name)
+  alt Resolved
+    CF-->>D: plugin instance
+    D->>P: Run(same params) → InternalRunAction
+    P->>ERP: POST journal / journalLines + post
+    ERP-->>P: id / 204
+    P-->>C: JournalEntryID, DocNumber, TotalAmount
+  else not registered
+    D-->>C: Success false, PROVIDER_NOT_REGISTERED
+  end
 ```
+
+## Verbs and plugins
+
+Callers use the **verb** column. Plugins are ClassFactory keys
+`` `${verb}:${Integration.Name}` ``. Integration.Name must match the MJ
+Integrations row exactly (`QuickBooks Online`,
+`Microsoft Dynamics 365 Business Central`).
+
+| Verb (dispatcher key) | QuickBooks Online | Business Central | Notes |
+|---|---|---|---|
+| `GetChartOfAccounts` | existing GL codes + `Accounts` | existing GL accounts + `Accounts` | Shared `ChartOfAccount` on output `Accounts`; old `GLCodes` / `GLAccounts` unchanged |
+| `GetAccountBalances` | existing | **new** | Shared `AccountBalance`; BC `accountCode` = account number |
+| `CreateJournalEntry` | existing | **new** | Shared line validation + balance check |
+| `GetDimensions` | **new** | **new** | BC: `dimensions` + `dimensionValues`. QBO: Class + Department (no first-class dimensions API) |
+| `GetGLEntries` | existing transactions | existing GL entries | Wrap only |
+| `GetCustomers` | — | existing | Wrap; QBO → `PROVIDER_NOT_REGISTERED` |
+| `GetSalesInvoices` | — | existing | Wrap; QBO → `PROVIDER_NOT_REGISTERED` |
+
+**New in this package:** the seven dispatchers, BC `CreateJournalEntry`,
+BC `GetAccountBalances`, and `GetDimensions` for both ERPs.
+
+Backward-compat ClassFactory keys still resolve (same classes, second
+`@RegisterClass`):
+
+- `GetQuickBooksGLCodesAction`
+- `GetQuickBooksTransactionsAction`
+- `GetQuickBooksAccountBalancesAction`
+- `CreateQuickBooksJournalEntryAction`
+- `GetBusinessCentralGLAccountsAction`
+- `GetBusinessCentralGeneralLedgerEntriesAction`
+- `GetBusinessCentralCustomersAction`
+- `GetBusinessCentralSalesInvoicesAction`
+
+## Result codes
+
+| ResultCode | When |
+|---|---|
+| `SUCCESS` | Plugin completed |
+| `PROVIDER_NOT_REGISTERED` | No plugin for `` `${verb}:${integration.Name}` `` |
+| `NO_ACCOUNTING_INTEGRATION` | Company has no QBO/BC `CompanyIntegration` |
+| `VALIDATION_ERROR` | Missing `CompanyID`, or journal lines do not balance |
+| `ERROR` | Structural line problems, missing context user, HTTP failure |
+
+Journal **structure** (missing Lines, < 2 lines, both debit and credit, negative
+amounts) still surfaces as `ERROR` with the historical messages. **Unbalanced**
+debits/credits is `VALIDATION_ERROR`.
 
 ## Installation
 
@@ -93,15 +114,21 @@ sequenceDiagram
 npm install @memberjunction/actions-bizapps-accounting
 ```
 
-This package requires peer dependencies from the MemberJunction ecosystem. In an MJ monorepo workspace, these are resolved automatically.
+Import the package once in the host so `@RegisterClass` runs for every
+dispatcher and plugin:
+
+```typescript
+import '@memberjunction/actions-bizapps-accounting';
+```
 
 ## Setup
 
-### 1. Create Integration Records
+### 1. Integration rows
 
-Register each accounting system as an Integration entity in the MemberJunction database.
+`Name` is the plugin-key suffix. Do not rename without updating RegisterClass keys.
 
 **QuickBooks Online:**
+
 ```sql
 INSERT INTO Integration (Name, Description, NavigationBaseURL, ClassName)
 VALUES ('QuickBooks Online', 'QuickBooks Online Accounting Integration',
@@ -109,6 +136,7 @@ VALUES ('QuickBooks Online', 'QuickBooks Online Accounting Integration',
 ```
 
 **Business Central:**
+
 ```sql
 INSERT INTO Integration (Name, Description, NavigationBaseURL, ClassName)
 VALUES ('Microsoft Dynamics 365 Business Central',
@@ -116,390 +144,209 @@ VALUES ('Microsoft Dynamics 365 Business Central',
         '', 'BusinessCentralIntegration');
 ```
 
-### 2. Configure CompanyIntegration
+### 2. CompanyIntegration
 
-Link each MJ Company to its accounting system integration.
+One row per company per ERP. Hosts pick their ERP; this package is not married to BC.
 
-**QuickBooks Online:**
-```sql
-INSERT INTO CompanyIntegration (CompanyID, IntegrationID, ExternalSystemID,
-                               CustomAttribute1, IsActive)
-VALUES (@CompanyID, @QuickBooksIntegrationID, @RealmID, 'production', 1);
--- ExternalSystemID = QuickBooks Realm ID
--- CustomAttribute1 = 'production' or 'sandbox'
-```
+**QuickBooks Online:** `ExternalSystemID` = Realm ID, `CustomAttribute1` = `production` or `sandbox`.
 
-**Business Central:**
-```sql
-INSERT INTO CompanyIntegration (CompanyID, IntegrationID, ExternalSystemID,
-                               CustomAttribute1, IsActive)
-VALUES (@CompanyID, @BCIntegrationID, @BCCompanyID, 'production', 1);
--- ExternalSystemID = Business Central company ID (GUID)
--- CustomAttribute1 = environment name (production, sandbox, or custom)
-```
+**Business Central:** `ExternalSystemID` = BC company GUID, `CustomAttribute1` = environment name.
 
-### 3. Set Environment Variables
+### 3. Environment variables (preferred over database tokens)
 
-**QuickBooks Online:**
 ```bash
-BIZAPPS_QUICKBOOKS_ONLINE_{COMPANY_ID}_ACCESS_TOKEN=your_access_token
-BIZAPPS_QUICKBOOKS_ONLINE_{COMPANY_ID}_REFRESH_TOKEN=your_refresh_token
-BIZAPPS_QUICKBOOKS_ONLINE_{COMPANY_ID}_REALM_ID=your_realm_id  # Optional if stored in DB
+BIZAPPS_QUICKBOOKS_ONLINE_{COMPANY_ID}_ACCESS_TOKEN=...
+BIZAPPS_QUICKBOOKS_ONLINE_{COMPANY_ID}_REFRESH_TOKEN=...
+BIZAPPS_QUICKBOOKS_ONLINE_{COMPANY_ID}_REALM_ID=...   # optional if stored on CompanyIntegration
+
+BIZAPPS_BUSINESS_CENTRAL_{COMPANY_ID}_ACCESS_TOKEN=...
+BIZAPPS_BUSINESS_CENTRAL_{COMPANY_ID}_REFRESH_TOKEN=...
+BIZAPPS_BUSINESS_CENTRAL_{COMPANY_ID}_TENANT_ID=...
 ```
 
-**Business Central:**
-```bash
-BIZAPPS_BUSINESS_CENTRAL_{COMPANY_ID}_ACCESS_TOKEN=your_access_token
-BIZAPPS_BUSINESS_CENTRAL_{COMPANY_ID}_REFRESH_TOKEN=your_refresh_token
-BIZAPPS_BUSINESS_CENTRAL_{COMPANY_ID}_TENANT_ID=your_tenant_id
-```
+Lookup order: environment, then `CompanyIntegration` token fields.
 
-### Credential Priority
-
-The system checks for credentials in this order:
-1. **Environment variables** (recommended for security)
-2. **Database** (CompanyIntegration entity fields -- for backward compatibility)
-
-## Available Actions
-
-### QuickBooks Online
-
-| Action | Description | Type |
-|--------|-------------|------|
-| `GetQuickBooksGLCodesAction` | Retrieve Chart of Accounts | Read |
-| `GetQuickBooksTransactionsAction` | Query transactions across multiple types | Read |
-| `GetQuickBooksAccountBalancesAction` | Trial balance / account balances | Read |
-| `CreateQuickBooksJournalEntryAction` | Create a balanced journal entry | Write |
-
-### Microsoft Dynamics 365 Business Central
-
-| Action | Description | Type |
-|--------|-------------|------|
-| `GetBusinessCentralGLAccountsAction` | Retrieve Chart of Accounts | Read |
-| `GetBusinessCentralGeneralLedgerEntriesAction` | Query general ledger entries | Read |
-| `GetBusinessCentralCustomersAction` | Retrieve customers with search/filter | Read |
-| `GetBusinessCentralSalesInvoicesAction` | Query sales invoices | Read |
-
-## Usage Examples
-
-### Retrieve GL Codes from QuickBooks
+## Usage
 
 ```typescript
 import { ActionEngineServer } from '@memberjunction/actions';
+import '@memberjunction/actions-bizapps-accounting';
 
 const engine = ActionEngineServer.Instance;
-const result = await engine.RunAction({
-    ActionName: 'GetQuickBooksGLCodesAction',
-    Params: [
-        { Name: 'CompanyID', Type: 'Input', Value: 'your-company-id' },
-        { Name: 'IncludeInactive', Type: 'Input', Value: false },
-        { Name: 'AccountTypes', Type: 'Input', Value: 'Bank,Expense,Income' }
-    ],
-    ContextUser: contextUser
-});
-
-if (result.Success) {
-    const glCodes = result.Params?.find(p => p.Name === 'GLCodes')?.Value;
-    const totalCount = result.Params?.find(p => p.Name === 'TotalCount')?.Value;
-    console.log(`Retrieved ${totalCount} GL codes`);
-}
-```
-
-### Query Transactions from QuickBooks
-
-```typescript
-const result = await engine.RunAction({
-    ActionName: 'GetQuickBooksTransactionsAction',
-    Params: [
-        { Name: 'CompanyID', Type: 'Input', Value: 'your-company-id' },
-        { Name: 'TransactionType', Type: 'Input', Value: 'Invoice' },
-        { Name: 'StartDate', Type: 'Input', Value: '2025-01-01' },
-        { Name: 'EndDate', Type: 'Input', Value: '2025-12-31' },
-        { Name: 'MinAmount', Type: 'Input', Value: 1000 },
-        { Name: 'MaxResults', Type: 'Input', Value: 50 }
-    ],
-    ContextUser: contextUser
-});
-```
-
-### Create a Journal Entry in QuickBooks
-
-```typescript
-const lines = [
-    { accountId: '80', debit: 500.00, description: 'Office supplies' },
-    { accountId: '35', credit: 500.00, description: 'Cash payment' }
-];
 
 const result = await engine.RunAction({
-    ActionName: 'CreateQuickBooksJournalEntryAction',
+    ActionName: 'CreateJournalEntry',
     Params: [
-        { Name: 'CompanyID', Type: 'Input', Value: 'your-company-id' },
-        { Name: 'Lines', Type: 'Input', Value: JSON.stringify(lines) },
+        { Name: 'CompanyID', Type: 'Input', Value: companyId },
         { Name: 'EntryDate', Type: 'Input', Value: '2025-06-15' },
-        { Name: 'PrivateNote', Type: 'Input', Value: 'Monthly office supply purchase' }
+        { Name: 'DocNumber', Type: 'Input', Value: 'JE-100' },
+        {
+            Name: 'Lines',
+            Type: 'Input',
+            Value: [
+                { accountNumber: '4010', debit: 500, description: 'Revenue' },
+                { accountNumber: '1100', credit: 500, description: 'AR' },
+            ],
+        },
     ],
-    ContextUser: contextUser
+    ContextUser: contextUser,
 });
-
-if (result.Success) {
-    const entryId = result.Params?.find(p => p.Name === 'JournalEntryID')?.Value;
-    console.log(`Created journal entry: ${entryId}`);
-}
 ```
 
-### Retrieve Customers from Business Central
+AM-4: when posting, send **account numbers** (`accountNumber`). QBO still uses
+`accountId` internally (QBO `Account.Id`); pass `accountId` for QBO lines.
+
+`GetChartOfAccounts` / `GetAccountBalances` / `GetDimensions` take the same
+`CompanyID`. Optional filters (`AsOfDate`, `IncludeInactive`, …) are forwarded
+unchanged to the plugin.
+
+Direct construction of a vendor class still works for old callers:
 
 ```typescript
-const result = await engine.RunAction({
-    ActionName: 'GetBusinessCentralCustomersAction',
-    Params: [
-        { Name: 'CompanyID', Type: 'Input', Value: 'your-company-id' },
-        { Name: 'SearchText', Type: 'Input', Value: 'Contoso' },
-        { Name: 'OnlyOverdue', Type: 'Input', Value: true },
-        { Name: 'SortBy', Type: 'Input', Value: 'balance' },
-        { Name: 'MaxResults', Type: 'Input', Value: 25 }
-    ],
-    ContextUser: contextUser
-});
+import { CreateQuickBooksJournalEntryAction } from '@memberjunction/actions-bizapps-accounting';
+const action = new CreateQuickBooksJournalEntryAction();
 ```
 
-### Retrieve Sales Invoices from Business Central
+New code should use the verb name.
 
-```typescript
-const result = await engine.RunAction({
-    ActionName: 'GetBusinessCentralSalesInvoicesAction',
-    Params: [
-        { Name: 'CompanyID', Type: 'Input', Value: 'your-company-id' },
-        { Name: 'Status', Type: 'Input', Value: 'Open' },
-        { Name: 'OnlyUnpaid', Type: 'Input', Value: true },
-        { Name: 'IncludeLines', Type: 'Input', Value: true },
-        { Name: 'MaxResults', Type: 'Input', Value: 100 }
-    ],
-    ContextUser: contextUser
-});
-```
+## Adding a new ERP
 
-## API Reference
+1. Create `src/providers/{erp}/` with a subclass of `BaseAccountingAction` that
+   implements the HTTP helper (`makeXRequest`). Set `integrationName` to the
+   **exact** `Integration.Name` you will insert.
+2. For each verb you support, subclass the provider base and register **the
+   plugin key**, not the vendor nickname:
 
-### Base Classes
-
-#### `BaseAccountingAction`
-
-Abstract base class for all accounting actions. Provides shared credential management, validation, and formatting utilities.
-
-| Method | Description |
-|--------|-------------|
-| `getCompanyIntegration(companyId, contextUser)` | Looks up the CompanyIntegration record for the given company and provider |
-| `getCredentialFromEnv(companyId, credentialType)` | Reads a credential from environment variables using the `BIZAPPS_{PROVIDER}_{ID}_{TYPE}` convention |
-| `getOAuthTokens(integration)` | Resolves OAuth tokens from env vars first, then database fallback |
-| `getAPIBaseURL(contextUser)` | Returns the NavigationBaseURL configured in the Integration entity |
-| `validateAccountNumber(accountNumber)` | Basic numeric account number validation |
-| `validateJournalEntryBalance(lines)` | Verifies total debits equal total credits within rounding tolerance |
-| `formatCurrency(amount, currencyCode)` | Formats a number as localized currency string |
-| `formatAccountingDate(date)` | Returns ISO 8601 date string (YYYY-MM-DD) |
-
-#### `QuickBooksBaseAction`
-
-Extends `BaseAccountingAction` for QuickBooks Online. Uses QBO query language for data retrieval and the QBO REST API for mutations.
-
-| Method | Description |
-|--------|-------------|
-| `makeQBORequest<T>(endpoint, method, body, contextUser)` | Authenticated HTTP request to the QBO API |
-| `queryQBO<T>(query, contextUser)` | Executes a QBO query language statement |
-| `mapAccountType(qboAccountType)` | Maps QBO account types to standard categories (Asset, Liability, Equity, Revenue, Expense) |
-| `parseQBODate(qboDate)` / `formatQBODate(date)` | Date conversion between QBO and JS Date |
-| `getQuickBooksAPIUrl(integration)` | Resolves sandbox or production API URL |
-
-#### `BusinessCentralBaseAction`
-
-Extends `BaseAccountingAction` for Dynamics 365 Business Central. Uses OData v4 for all API interactions.
-
-| Method | Description |
-|--------|-------------|
-| `makeBCRequest<T>(endpoint, method, body, contextUser)` | Authenticated HTTP request to the BC API |
-| `queryBC<T>(resource, filters, select, expand, orderBy, top, contextUser)` | Builds and executes an OData query |
-| `buildFilterExpression(field, operator, value)` | Generates an OData filter clause |
-| `mapAccountType(bcAccountType)` / `mapAccountCategory(category)` | Maps BC types to standard categories |
-| `parseBCDate(dateString)` / `formatBCDate(date)` | Date conversion between BC and JS Date |
-| `getBusinessCentralAPIUrl(integration, tenantId, environment)` | Builds the BC API URL from tenant/environment |
-
-### Exported Interfaces
-
-#### QuickBooks
-
-| Interface | Description |
-|-----------|-------------|
-| `GLCode` | Chart of Accounts entry with id, code, name, type, normal balance, and hierarchy info |
-| `Transaction` | Transaction record with type, date, amount, status, entity reference, and line items |
-| `TransactionLine` | Individual line within a transaction (amount, account, item, quantity, rate) |
-| `AccountBalance` | Account balance snapshot including current balance, sub-account balance, and normal balance side |
-| `JournalEntryLine` | Input structure for journal entry creation with accountId, debit/credit, entity references |
-
-#### Business Central
-
-| Interface | Description |
-|-----------|-------------|
-| `BCGLAccount` | GL account with number, category, balance, debit/credit amounts, and posting info |
-| `BCGeneralLedgerEntry` | Ledger entry with posting date, document info, debit/credit amounts, and optional dimensions |
-| `BCDimensionSetLine` | Dimension value attached to a GL entry |
-| `BCCustomer` | Customer record with contact info, address, balance, overdue amount, and sales totals |
-| `BCAddress` | Address structure (street, city, state, country code, postal code) |
-| `BCSalesInvoice` | Sales invoice with dates, amounts (excluding/including tax), remaining balance, and optional lines |
-| `BCSalesInvoiceLine` | Invoice line item with quantity, unit price, discount, tax, and net amounts |
-
-### Action Parameters Reference
-
-#### Common Parameters (all actions)
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `CompanyID` | string | Yes | MemberJunction Company ID |
-| `FiscalYear` | string | No | Fiscal year filter |
-| `AccountingPeriod` | string | No | Accounting period filter |
-
-#### GetQuickBooksGLCodesAction
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `IncludeInactive` | boolean | `false` | Include inactive accounts |
-| `AccountTypes` | string | -- | Comma-separated account types (Bank, Expense, Income, etc.) |
-| `ParentAccountID` | string | -- | Filter by parent account |
-
-**Output:** `GLCodes` (GLCode[]), `TotalCount` (number)
-
-#### GetQuickBooksTransactionsAction
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `TransactionType` | string | -- | Specific type (Invoice, Bill, Payment, JournalEntry, Deposit, Purchase) or omit for all |
-| `StartDate` / `EndDate` | string | -- | Transaction date range (ISO 8601) |
-| `EntityID` | string | -- | Filter by customer or vendor ID |
-| `MinAmount` / `MaxAmount` | number | -- | Amount range filter |
-| `MaxResults` | number | `100` | Limit results (max 1000) |
-
-**Output:** `Transactions` (Transaction[]), `TotalCount` (number), `HasMore` (boolean)
-
-#### GetQuickBooksAccountBalancesAction
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `AsOfDate` | string | today | Balance snapshot date |
-| `AccountTypes` | string | -- | Comma-separated account types |
-| `IncludeInactive` | boolean | `false` | Include inactive accounts |
-| `IncludeZeroBalances` | boolean | `true` | Include accounts with zero balance |
-| `SummarizeByType` | boolean | `false` | Return summary grouped by account type |
-
-**Output:** `AccountBalances` (AccountBalance[]), `TrialBalanceSummary`, `TypeSummary`, `TotalAccounts` (number)
-
-#### CreateQuickBooksJournalEntryAction
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `Lines` | JournalEntryLine[] or JSON string | -- | Journal entry lines (required, minimum 2, must balance) |
-| `EntryDate` | string | today | Date of the entry |
-| `DocNumber` | string | auto | Journal entry number |
-| `PrivateNote` | string | -- | Internal memo |
-| `AdjustmentEntry` | boolean | `false` | Mark as adjustment entry |
-
-**Output:** `JournalEntryID` (string), `DocNumber` (string), `TotalAmount` (number), `CreatedDate` (string)
-
-#### GetBusinessCentralGLAccountsAction
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `IncludeBlocked` | boolean | `false` | Include blocked accounts |
-| `AccountTypes` | string | -- | Comma-separated types (Posting, Heading, Total) |
-| `Categories` | string | -- | Comma-separated categories (Assets, Liabilities, Equity, Income, Expense) |
-| `MinBalance` / `MaxBalance` | number | -- | Balance range filter |
-| `MaxResults` | number | `1000` | Limit results |
-
-**Output:** `GLAccounts` (BCGLAccount[]), `TotalCount` (number), `Summary` (object)
-
-#### GetBusinessCentralGeneralLedgerEntriesAction
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `StartDate` / `EndDate` | string | -- | Posting date range |
-| `AccountNumber` | string | -- | Filter by GL account number |
-| `DocumentNumber` | string | -- | Filter by document number |
-| `DocumentType` | string | -- | Filter by type (Payment, Invoice, etc.) |
-| `MinAmount` / `MaxAmount` | number | -- | Amount range filter |
-| `IncludeDimensions` | boolean | `false` | Include dimension set lines |
-| `MaxResults` | number | `500` | Limit results |
-
-**Output:** `GLEntries` (BCGeneralLedgerEntry[]), `TotalCount` (number), `Summary` (object)
-
-#### GetBusinessCentralCustomersAction
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `SearchText` | string | -- | Search by name, number, or email |
-| `IncludeBlocked` | boolean | `false` | Include blocked customers |
-| `CustomerType` | string | -- | Filter by Company or Person |
-| `MinBalance` / `MaxBalance` | number | -- | Balance range filter |
-| `OnlyOverdue` | boolean | `false` | Only customers with overdue amounts |
-| `SortBy` | string | `displayName` | Sort field (displayName, number, balance, overdueAmount, lastModified) |
-| `MaxResults` | number | `100` | Limit results |
-
-**Output:** `Customers` (BCCustomer[]), `TotalCount` (number), `Summary` (object)
-
-#### GetBusinessCentralSalesInvoicesAction
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `CustomerNumber` | string | -- | Filter by customer |
-| `Status` | string | -- | Filter by status (Draft, Open, Paid, etc.) |
-| `StartDate` / `EndDate` | string | -- | Invoice date range |
-| `DueStartDate` / `DueEndDate` | string | -- | Due date range |
-| `MinAmount` / `MaxAmount` | number | -- | Amount range filter |
-| `OnlyUnpaid` | boolean | `false` | Only invoices with remaining balance |
-| `IncludeLines` | boolean | `true` | Include line item details |
-| `MaxResults` | number | `100` | Limit results |
-
-**Output:** `Invoices` (BCSalesInvoice[]), `TotalCount` (number), `Summary` (object)
-
-## Adding New Providers
-
-The package is designed for extensibility. To add support for a new accounting system:
-
-1. Create a provider directory under `src/providers/{provider-name}/`
-2. Create a provider base class extending `BaseAccountingAction`:
    ```typescript
-   export abstract class NewProviderBaseAction extends BaseAccountingAction {
-       protected accountingProvider = 'New Provider';
-       protected integrationName = 'New Provider Full Name';
+   import { RegisterClass } from '@memberjunction/global';
+   import { BaseAction } from '@memberjunction/actions';
+   import { ACCOUNTING_VERBS, erpPluginKey } from '@memberjunction/actions-bizapps-accounting';
 
-       // Implement provider-specific API methods
-       protected async makeProviderRequest<T>(endpoint: string, ...): Promise<T> { ... }
+   @RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.CreateJournalEntry, 'Your ERP Name'))
+   export class CreateYourERPJournalEntryAction extends YourERPBaseAction {
+       protected async InternalRunAction(params: RunActionParams) { /* HTTP */ }
    }
    ```
-3. Implement individual action classes extending your provider base
-4. Export the new actions and interfaces from `src/index.ts`
+
+3. Export the class from `src/index.ts` so importing the package registers it.
+4. Reuse `parseAndValidateJournalEntryLines` and `validateJournalEntryBalance`.
+   Return `VALIDATION_ERROR` when the entry does not balance. Do not invent
+   domain writes.
+5. Add vitest coverage that spies the request helper. Do not hit a real ERP.
+6. Hosts insert an Integration row whose `Name` equals `'Your ERP Name'`.
+
+The dispatcher does not change. It already loads any company integration whose
+`Integration.Name` is in the known ERP list — **add your name to
+`ACCOUNTING_ERP_INTEGRATION_NAMES`** in `src/constants.ts` so
+`resolveCompanyAccountingIntegration` will select it.
+
+## Shared types
+
+| Type | Role |
+|---|---|
+| `JournalEntryLine` | `{ accountId?, accountNumber?, debit?, credit?, description?, dimensions? }` |
+| `ChartOfAccount` | `{ id, code, name, accountType, isActive }` — extra output `Accounts` |
+| `AccountBalance` | `accountCode` is the ERP account number; `asOfDate` from the param |
+| `Dimension` | `{ code, displayName, values: Array<{ code, displayName }> }` |
+
+QBO `GetDimensions`: there is no dimensions API. The plugin maps **Class** and
+**Department**. Empty `values` is success, not an error, when the company does
+not use that list.
+
+BC `CreateJournalEntry`: GET `journals` (param `JournalCode`, else first journal
+with no `balancingAccountNumber` / code `GENERAL` or `DEFAULT`) → POST each line
+to `journals({id})/journalLines` (`amount` = +debit / −credit) → POST
+`journals({id})/Microsoft.NAV.post`. All-or-nothing at the ERP.
+
+## Credentials (unchanged)
+
+```mermaid
+sequenceDiagram
+    participant Action as Accounting Action
+    participant BAA as BaseAccountingAction
+    participant Env as Environment Variables
+    participant DB as CompanyIntegration
+
+    Action->>BAA: getOAuthTokens(integration)
+    BAA->>Env: BIZAPPS_{PROVIDER}_{COMPANY_ID}_ACCESS_TOKEN
+    alt Token in env
+        Env-->>BAA: access + refresh
+    else
+        BAA->>DB: AccessToken
+        alt valid
+            DB-->>BAA: access token
+        else expired or missing
+            BAA-->>Action: throw
+        end
+    end
+```
+
+## API reference (legacy vendor actions)
+
+Common inputs on every action: `CompanyID` (required), `FiscalYear`,
+`AccountingPeriod`.
+
+### CreateJournalEntry / CreateQuickBooksJournalEntryAction / CreateBusinessCentralJournalEntryAction
+
+| Parameter | Type | Description |
+|---|---|---|
+| `Lines` | `JournalEntryLine[]` or JSON | Required, ≥ 2, must balance |
+| `EntryDate` | string | Default today |
+| `DocNumber` | string | Optional document number |
+| `PrivateNote` | string | Memo / description |
+| `JournalCode` | string | BC only — journal to post into |
+| `AdjustmentEntry` | boolean | QBO only |
+
+**Output:** `JournalEntryID`, `DocNumber`, `TotalAmount` (QBO also `CreatedDate`).
+
+### GetChartOfAccounts
+
+QBO also emits `GLCodes`; BC also emits `GLAccounts`. Both emit `Accounts`
+(`ChartOfAccount[]`) and `TotalCount`.
+
+### GetAccountBalances
+
+| Parameter | Default | Description |
+|---|---|---|
+| `AsOfDate` | today | Snapshot date (BC returns current balance; date is stamped on the row) |
+| `AccountTypes` | — | QBO account types / BC categories |
+| `IncludeInactive` / `IncludeBlocked` | false | |
+| `IncludeZeroBalances` | true | |
+
+**Output:** `AccountBalances`, `TotalAccounts` (QBO also trial-balance summary).
+
+### GetDimensions
+
+**Output:** `Dimensions: Array<{ code, displayName, values: Array<{ code, displayName }> }>`.
+
+### GetGLEntries / GetCustomers / GetSalesInvoices
+
+Same filters and outputs as the historical BC/QBO actions they wrap. See the
+vendor classes for parameter lists.
 
 ## Dependencies
 
 | Package | Purpose |
-|---------|---------|
-| `@memberjunction/actions` | `BaseAction` class and `ActionEngineServer` |
-| `@memberjunction/actions-base` | `ActionParam`, `ActionResultSimple`, `RunActionParams` types |
-| `@memberjunction/core` | `Metadata`, `RunView`, `UserInfo` |
-| `@memberjunction/core-entities` | `CompanyIntegrationEntity`, `IntegrationEntity` |
-| `@memberjunction/global` | `@RegisterClass` decorator |
+|---|---|
+| `@memberjunction/actions` | `BaseAction` |
+| `@memberjunction/actions-base` | param / result types |
+| `@memberjunction/core` | `RunView`, `UserInfo` |
+| `@memberjunction/core-entities` | `CompanyIntegration`, `Integration` |
+| `@memberjunction/global` | `@RegisterClass`, `ClassFactory.TryCreateInstance` |
 
-## Related Packages
+## Related
 
-- [@memberjunction/actions](../../Engine/README.md) -- Actions execution engine
-- [@memberjunction/actions-base](../../Base/README.md) -- Base classes and interfaces
-- [@memberjunction/actions-bizapps-lms](../LMS/README.md) -- LMS integration actions (same BizApps pattern)
-- [BizApps Overview](../README.md) -- Parent directory with shared patterns
+- [erp-provider-layer.md](https://github.com/MemberJunction/bizapps-accounting/blob/next/plans/erp-provider-layer.md) — accounting engine + extension seam
+- [@memberjunction/actions](../../Engine/README.md)
+- [BizApps Overview](../README.md)
 
 ## Development
 
 ```bash
-# Build the package
 cd packages/Actions/BizApps/Accounting
-npm run build
-
-# Watch mode
-npm run watch
+pnpm test
+pnpm run build
 ```
+
+Tests spy `makeQBORequest` / `makeBCRequest` / `queryQBO`. They must not hit a
+real ERP.

--- a/packages/Actions/BizApps/Accounting/README.md
+++ b/packages/Actions/BizApps/Accounting/README.md
@@ -253,10 +253,19 @@ QBO `GetDimensions`: there is no dimensions API. The plugin maps **Class** and
 **Department**. Empty `values` is success, not an error, when the company does
 not use that list.
 
-BC `CreateJournalEntry`: GET `journals` (param `JournalCode`, else first journal
-with no `balancingAccountNumber` / code `GENERAL` or `DEFAULT`) → POST each line
-to `journals({id})/journalLines` (`amount` = +debit / −credit) → POST
-`journals({id})/Microsoft.NAV.post`. All-or-nothing at the ERP.
+BC `CreateJournalEntry`: GET `journals` (param `JournalCode`, else GENERAL/DEFAULT
+or first journal **without** a `balancingAccountNumber`) → POST each line to
+`journals({id})/journalLines` (`amount` = +debit / −credit) → POST
+`journals({id})/Microsoft.NAV.post`. If a line POST or the batch post throws,
+lines created in **this call** are DELETEd so they do not sit in the journal
+for the next post.
+
+`Microsoft.NAV.post` posts the **whole BC journal**, not just this call's lines.
+Two concurrent `CreateJournalEntry` calls against the same journal code can
+therefore post each other's in-flight lines, and the loser gets no error. That
+is BC's journal model, not a bug in the plugin. Mitigations: give each post
+its own journal (`JournalCode`), or serialize posts per journal code. Do not
+run overlapping posts into one shared GENERAL journal.
 
 ## Credentials (unchanged)
 

--- a/packages/Actions/BizApps/Accounting/src/__tests__/accounting-providers.test.ts
+++ b/packages/Actions/BizApps/Accounting/src/__tests__/accounting-providers.test.ts
@@ -615,6 +615,102 @@ describe('CreateBusinessCentralJournalEntryAction', () => {
     expect(outParam(result, 'DocNumber')).toBe('JE-9');
     expect(outParam(result, 'TotalAmount')).toBe(100);
   });
+
+  it('should DELETE lines created in this call if a later POST fails', async () => {
+    let linePosts = 0;
+    const spy = vi.spyOn(action as never, 'makeBCRequest').mockImplementation((async (endpoint: string, method: string) => {
+      if (endpoint === 'journals') {
+        return { value: [{ id: 'j-1', code: 'GENERAL', balancingAccountNumber: null }] };
+      }
+      if (String(endpoint).includes('journalLines') && method === 'POST') {
+        linePosts += 1;
+        if (linePosts >= 2) {
+          throw new Error('line 2 failed');
+        }
+        return { id: `line-${linePosts}`, documentNumber: 'JE-9' };
+      }
+      if (String(endpoint).startsWith('journalLines(') && method === 'DELETE') {
+        return undefined;
+      }
+      throw new Error(`unexpected ${method} ${endpoint}`);
+    }) as never);
+
+    const result = await run(
+      action,
+      inputs({
+        CompanyID: 'comp-1',
+        Lines: [
+          { accountNumber: '1000', debit: 100 },
+          { accountNumber: '2000', credit: 100 },
+        ],
+      }),
+    );
+
+    expect(result.Success).toBe(false);
+    expect(result.Message).toBe('line 2 failed');
+    expect(spy.mock.calls.map((c) => [c[1], c[0]])).toEqual([
+      ['GET', 'journals'],
+      ['POST', 'journals(j-1)/journalLines'],
+      ['POST', 'journals(j-1)/journalLines'],
+      ['DELETE', 'journalLines(line-1)'],
+    ]);
+  });
+
+  it('should error when JournalCode matches nothing', async () => {
+    vi.spyOn(action as never, 'makeBCRequest').mockResolvedValue({
+      value: [{ id: 'j-1', code: 'GENERAL', balancingAccountNumber: null }],
+    } as never);
+
+    const result = await run(action, inputs({
+      CompanyID: 'comp-1',
+      JournalCode: 'GENERAL2',
+      Lines: [
+        { accountNumber: '1000', debit: 100 },
+        { accountNumber: '2000', credit: 100 },
+      ],
+    }));
+
+    expect(result.Success).toBe(false);
+    expect(result.Message).toContain("JournalCode 'GENERAL2' does not exist");
+  });
+
+  it('should refuse a journal that has a balancing account', async () => {
+    vi.spyOn(action as never, 'makeBCRequest').mockResolvedValue({
+      value: [{ id: 'j-1', code: 'CASH', balancingAccountNumber: '1010' }],
+    } as never);
+
+    const result = await run(action, inputs({
+      CompanyID: 'comp-1',
+      Lines: [
+        { accountNumber: '1000', debit: 100 },
+        { accountNumber: '2000', credit: 100 },
+      ],
+    }));
+
+    expect(result.Success).toBe(false);
+    expect(result.Message).toMatch(/balancing account/i);
+  });
+
+  it('should send accountNumber and omit accountId when both are present', async () => {
+    const spy = vi.spyOn(action as never, 'makeBCRequest').mockImplementation((async (endpoint: string) => {
+      if (endpoint === 'journals') {
+        return { value: [{ id: 'j-1', code: 'GENERAL', balancingAccountNumber: null }] };
+      }
+      return { id: 'line-1' };
+    }) as never);
+
+    await run(action, inputs({
+      CompanyID: 'comp-1',
+      Lines: [
+        { accountNumber: '1000', accountId: 'stale-guid', debit: 100 },
+        { accountNumber: '2000', credit: 100 },
+      ],
+    }));
+
+    const firstLine = spy.mock.calls[1][2] as Record<string, unknown>;
+    expect(firstLine.accountNumber).toBe('1000');
+    expect(firstLine.accountId).toBeUndefined();
+  });
 });
 
 // ─── Business Central: GetAccountBalances ───────────────────────────────────

--- a/packages/Actions/BizApps/Accounting/src/__tests__/accounting-providers.test.ts
+++ b/packages/Actions/BizApps/Accounting/src/__tests__/accounting-providers.test.ts
@@ -12,13 +12,25 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  */
 
 vi.mock('@memberjunction/actions', () => ({
-  BaseAction: class BaseAction {},
+  BaseAction: class BaseAction {
+    async Run(params: unknown) {
+      return (this as { InternalRunAction(p: unknown): Promise<unknown> }).InternalRunAction(params);
+    }
+  },
   OAuth2Manager: class OAuth2Manager {},
 }));
 
 vi.mock('@memberjunction/global', () => ({
   RegisterClass: () => (target: unknown) => target,
   UUIDsEqual: (a: string, b: string) => a === b,
+  EscapeSQLString: (value: string | null | undefined) => String(value ?? '').replace(/'/g, "''"),
+  MJGlobal: {
+    Instance: {
+      ClassFactory: {
+        TryCreateInstance: vi.fn(),
+      },
+    },
+  },
 }));
 
 vi.mock('@memberjunction/core', () => ({
@@ -40,16 +52,23 @@ vi.mock('@memberjunction/actions-base', () => ({
   ActionParam: class ActionParam {},
 }));
 
+import { MJGlobal } from '@memberjunction/global';
 import { UserInfo } from '@memberjunction/core';
 import type { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { CreateQuickBooksJournalEntryAction } from '../providers/quickbooks/actions/create-journal-entry.action';
 import { GetQuickBooksAccountBalancesAction } from '../providers/quickbooks/actions/get-account-balances.action';
 import { GetQuickBooksGLCodesAction } from '../providers/quickbooks/actions/get-gl-codes.action';
 import { GetQuickBooksTransactionsAction } from '../providers/quickbooks/actions/get-transactions.action';
+import { GetQuickBooksDimensionsAction } from '../providers/quickbooks/actions/get-dimensions.action';
 import { GetBusinessCentralCustomersAction } from '../providers/business-central/actions/get-customers.action';
 import { GetBusinessCentralGeneralLedgerEntriesAction } from '../providers/business-central/actions/get-general-ledger-entries.action';
 import { GetBusinessCentralGLAccountsAction } from '../providers/business-central/actions/get-gl-accounts.action';
 import { GetBusinessCentralSalesInvoicesAction } from '../providers/business-central/actions/get-sales-invoices.action';
+import { CreateBusinessCentralJournalEntryAction } from '../providers/business-central/actions/create-journal-entry.action';
+import { GetBusinessCentralAccountBalancesAction } from '../providers/business-central/actions/get-account-balances.action';
+import { GetBusinessCentralDimensionsAction } from '../providers/business-central/actions/get-dimensions.action';
+import { CreateJournalEntryAction } from '../verbs/create-journal-entry.action';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../constants';
 
 const contextUser = { ID: 'user-1', Name: 'Test User', Email: 'test@example.com' } as unknown as UserInfo;
 
@@ -111,12 +130,26 @@ describe('CreateQuickBooksJournalEntryAction', () => {
     expect(result.Message).toBe('Journal entry must have at least 2 lines');
   });
 
-  it('should require accountId on every line', async () => {
+  it('should require accountId or accountNumber on every line', async () => {
     const result = await run(
       action,
       inputs({ CompanyID: 'comp-1', Lines: [{ debit: 100 }, { accountId: '2', credit: 100 }] }),
     );
-    expect(result.Message).toBe('Line 1: accountId is required');
+    expect(result.Message).toBe('Line 1: accountId or accountNumber is required');
+  });
+
+  it('should require accountId on QBO even when accountNumber is present', async () => {
+    const result = await run(
+      action,
+      inputs({
+        CompanyID: 'comp-1',
+        Lines: [
+          { accountNumber: '1000', debit: 100 },
+          { accountId: '2', credit: 100 },
+        ],
+      }),
+    );
+    expect(result.Message).toBe('Line 1: accountId is required for QuickBooks Online');
   });
 
   it('should require either debit or credit on every line', async () => {
@@ -423,3 +456,274 @@ describe('GetBusinessCentralSalesInvoicesAction', () => {
     expect(result.Message).toBe('Successfully retrieved 0 sales invoices from Business Central');
   });
 });
+
+// ─── Verb dispatcher: CreateJournalEntry ────────────────────────────────────
+
+describe('CreateJournalEntry dispatcher', () => {
+  let action: CreateJournalEntryAction;
+
+  beforeEach(() => {
+    action = new CreateJournalEntryAction();
+    vi.mocked(MJGlobal.Instance.ClassFactory.TryCreateInstance).mockReset();
+  });
+
+  it('should return PROVIDER_NOT_REGISTERED when no plugin is registered for the ERP', async () => {
+    vi.spyOn(action as never, 'resolveCompanyAccountingIntegration').mockResolvedValue({
+      Name: 'NetSuite',
+      CompanyIntegrationID: 'ci-1',
+      CompanyID: 'comp-1',
+      IntegrationID: 'int-1',
+    } as never);
+    vi.mocked(MJGlobal.Instance.ClassFactory.TryCreateInstance).mockReturnValue({
+      Resolved: false,
+      Instance: null,
+      Reason: 'not registered',
+    });
+
+    const result = await run(
+      action,
+      inputs({
+        CompanyID: 'comp-1',
+        Lines: [
+          { accountId: '1', debit: 100 },
+          { accountId: '2', credit: 100 },
+        ],
+      }),
+    );
+
+    expect(result.Success).toBe(false);
+    expect(result.ResultCode).toBe('PROVIDER_NOT_REGISTERED');
+    expect(result.Message).toContain(
+      erpPluginKey(ACCOUNTING_VERBS.CreateJournalEntry, 'NetSuite'),
+    );
+  });
+
+  it('should POST journalentry on the QBO plugin when the integration is QuickBooks Online', async () => {
+    vi.spyOn(action as never, 'resolveCompanyAccountingIntegration').mockResolvedValue({
+      Name: ERP_INTEGRATION.QuickBooksOnline,
+      CompanyIntegrationID: 'ci-1',
+      CompanyID: 'comp-1',
+      IntegrationID: 'int-1',
+    } as never);
+
+    const plugin = new CreateQuickBooksJournalEntryAction();
+    const spy = vi.spyOn(plugin as never, 'makeQBORequest').mockResolvedValue({
+      JournalEntry: {
+        Id: 'je-1',
+        DocNumber: 'JE-100',
+        TotalAmt: 100,
+        MetaData: { CreateTime: '2024-06-15T10:00:00Z' },
+      },
+    } as never);
+    vi.mocked(MJGlobal.Instance.ClassFactory.TryCreateInstance).mockReturnValue({
+      Resolved: true,
+      Instance: plugin,
+    });
+
+    const result = await run(
+      action,
+      inputs({
+        CompanyID: 'comp-1',
+        DocNumber: 'JE-100',
+        EntryDate: '2024-06-15',
+        Lines: [
+          { accountId: 'acct-1', debit: 100, description: 'Debit side' },
+          { accountId: 'acct-2', credit: 100 },
+        ],
+      }),
+    );
+
+    expect(MJGlobal.Instance.ClassFactory.TryCreateInstance).toHaveBeenCalledWith(
+      expect.anything(),
+      erpPluginKey(ACCOUNTING_VERBS.CreateJournalEntry, ERP_INTEGRATION.QuickBooksOnline),
+    );
+    const [endpoint, method] = spy.mock.calls[0] as unknown as [string, string];
+    expect(endpoint).toBe('journalentry');
+    expect(method).toBe('POST');
+    expect(result.Success).toBe(true);
+    expect(outParam(result, 'JournalEntryID')).toBe('je-1');
+  });
+});
+
+// ─── Business Central: CreateJournalEntry ───────────────────────────────────
+
+describe('CreateBusinessCentralJournalEntryAction', () => {
+  let action: CreateBusinessCentralJournalEntryAction;
+
+  beforeEach(() => {
+    action = new CreateBusinessCentralJournalEntryAction();
+  });
+
+  it('should fail with VALIDATION_ERROR when the entry is unbalanced', async () => {
+    const spy = vi.spyOn(action as never, 'makeBCRequest');
+
+    const result = await run(
+      action,
+      inputs({
+        CompanyID: 'comp-1',
+        Lines: [
+          { accountNumber: '1000', debit: 100 },
+          { accountNumber: '2000', credit: 50 },
+        ],
+      }),
+    );
+
+    expect(result.Success).toBe(false);
+    expect(result.ResultCode).toBe('VALIDATION_ERROR');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('should POST journalLines then Microsoft.NAV.post for a balanced entry', async () => {
+    const spy = vi.spyOn(action as never, 'makeBCRequest').mockImplementation((async (endpoint: string) => {
+      if (endpoint === 'journals') {
+        return { value: [{ id: 'j-1', code: 'GENERAL', balancingAccountNumber: null }] };
+      }
+      if (String(endpoint).includes('journalLines')) {
+        return { id: 'line-1', documentNumber: 'JE-9' };
+      }
+      return undefined;
+    }) as never);
+
+    const result = await run(
+      action,
+      inputs({
+        CompanyID: 'comp-1',
+        DocNumber: 'JE-9',
+        EntryDate: '2024-06-15',
+        Lines: [
+          { accountNumber: '1000', debit: 100, description: 'Debit side' },
+          { accountNumber: '2000', credit: 100 },
+        ],
+      }),
+    );
+
+    expect(spy.mock.calls.map((c) => [c[0], c[1]])).toEqual([
+      ['journals', 'GET'],
+      ['journals(j-1)/journalLines', 'POST'],
+      ['journals(j-1)/journalLines', 'POST'],
+      ['journals(j-1)/Microsoft.NAV.post', 'POST'],
+    ]);
+    const firstLine = spy.mock.calls[1][2] as Record<string, unknown>;
+    expect(firstLine.accountNumber).toBe('1000');
+    expect(firstLine.amount).toBe(100);
+    const secondLine = spy.mock.calls[2][2] as Record<string, unknown>;
+    expect(secondLine.accountNumber).toBe('2000');
+    expect(secondLine.amount).toBe(-100);
+    expect(result.Success).toBe(true);
+    expect(result.ResultCode).toBe('SUCCESS');
+    expect(outParam(result, 'JournalEntryID')).toBe('j-1');
+    expect(outParam(result, 'DocNumber')).toBe('JE-9');
+    expect(outParam(result, 'TotalAmount')).toBe(100);
+  });
+});
+
+// ─── Business Central: GetAccountBalances ───────────────────────────────────
+
+describe('GetBusinessCentralAccountBalancesAction', () => {
+  let action: GetBusinessCentralAccountBalancesAction;
+
+  beforeEach(() => {
+    action = new GetBusinessCentralAccountBalancesAction();
+  });
+
+  it('should map account number to accountCode', async () => {
+    vi.spyOn(action as never, 'makeBCRequest').mockResolvedValue({
+      value: [
+        {
+          id: 'a-1',
+          number: '1010',
+          displayName: 'Cash',
+          balance: 250,
+          category: 'Assets',
+          accountType: 'Posting',
+          blocked: false,
+        },
+      ],
+    } as never);
+
+    const result = await run(action, inputs({ CompanyID: 'comp-1', AsOfDate: '2024-06-15' }));
+
+    expect(result.Success).toBe(true);
+    const balances = outParam(result, 'AccountBalances') as Array<{ accountCode: string; accountName: string }>;
+    expect(balances).toHaveLength(1);
+    expect(balances[0].accountCode).toBe('1010');
+    expect(balances[0].accountName).toBe('Cash');
+  });
+});
+
+// ─── Business Central: GetDimensions ────────────────────────────────────────
+
+describe('GetBusinessCentralDimensionsAction', () => {
+  let action: GetBusinessCentralDimensionsAction;
+
+  beforeEach(() => {
+    action = new GetBusinessCentralDimensionsAction();
+  });
+
+  it('should map dimensions and their values', async () => {
+    const spy = vi.spyOn(action as never, 'makeBCRequest').mockImplementation((async (endpoint: string) => {
+      if (endpoint === 'dimensions') {
+        return { value: [{ id: 'd1', code: 'AREA', displayName: 'Area' }] };
+      }
+      if (endpoint === 'dimensionValues') {
+        return { value: [{ id: 'v1', code: 'EAST', displayName: 'East', dimensionId: 'd1' }] };
+      }
+      return { value: [] };
+    }) as never);
+
+    const result = await run(action, inputs({ CompanyID: 'comp-1' }));
+
+    expect(spy.mock.calls.map((c) => c[0])).toEqual(['dimensions', 'dimensionValues']);
+    expect(result.Success).toBe(true);
+    expect(outParam(result, 'Dimensions')).toEqual([
+      {
+        code: 'AREA',
+        displayName: 'Area',
+        values: [{ code: 'EAST', displayName: 'East' }],
+      },
+    ]);
+  });
+});
+
+// ─── QuickBooks: GetDimensions ──────────────────────────────────────────────
+
+describe('GetQuickBooksDimensionsAction', () => {
+  it('should map Class and Department queries as two dimensions', async () => {
+    const action = new GetQuickBooksDimensionsAction();
+    vi.spyOn(action as never, 'queryQBO').mockImplementation((async (query: string) => {
+      if (String(query).includes('Class')) {
+        return { QueryResponse: { Class: [{ Id: 'c1', Name: 'Sales', FullyQualifiedName: 'Sales' }] } };
+      }
+      return { QueryResponse: { Department: [{ Id: 'd1', Name: 'Ops', FullyQualifiedName: 'Ops' }] } };
+    }) as never);
+
+    const result = await run(action, inputs({ CompanyID: 'comp-1' }));
+
+    expect(result.Success).toBe(true);
+    expect(outParam(result, 'Dimensions')).toEqual([
+      { code: 'Class', displayName: 'Class', values: [{ code: 'Sales', displayName: 'Sales' }] },
+      { code: 'Department', displayName: 'Department', values: [{ code: 'Ops', displayName: 'Ops' }] },
+    ]);
+  });
+});
+
+// ─── Backward-compat RegisterClass keys ─────────────────────────────────────
+
+describe('legacy RegisterClass keys', () => {
+  it('should still construct every historically named action class', () => {
+    const ctors = [
+      CreateQuickBooksJournalEntryAction,
+      GetQuickBooksTransactionsAction,
+      GetQuickBooksAccountBalancesAction,
+      GetQuickBooksGLCodesAction,
+      GetBusinessCentralGLAccountsAction,
+      GetBusinessCentralGeneralLedgerEntriesAction,
+      GetBusinessCentralCustomersAction,
+      GetBusinessCentralSalesInvoicesAction,
+    ];
+    for (const Ctor of ctors) {
+      expect(new Ctor()).toBeInstanceOf(Ctor);
+    }
+  });
+});
+

--- a/packages/Actions/BizApps/Accounting/src/__tests__/accounting.test.ts
+++ b/packages/Actions/BizApps/Accounting/src/__tests__/accounting.test.ts
@@ -172,10 +172,14 @@ describe('BaseAccountingAction', () => {
     });
 
     describe('getCommonAccountingParams', () => {
-        it('should return three common params', () => {
+        it('should return CompanyID, FiscalYear, AccountingPeriod, IntegrationName', () => {
             const params = action['getCommonAccountingParams']();
-            expect(params).toHaveLength(3);
-            expect(params.map((p: { Name: string }) => p.Name)).toEqual(['CompanyID', 'FiscalYear', 'AccountingPeriod']);
+            expect(params.map((p: { Name: string }) => p.Name)).toEqual([
+                'CompanyID',
+                'FiscalYear',
+                'AccountingPeriod',
+                'IntegrationName',
+            ]);
         });
     });
 
@@ -213,8 +217,44 @@ describe('BaseAccountingAction', () => {
 
             const filter = runViewFn.mock.calls[0][0].ExtraFilter as string;
             expect(filter).toContain("CompanyID = 'abc'' OR 1=1--'");
+            expect(filter).toContain('IsActive = 1');
             expect(filter).toContain("'QuickBooks Online'");
             expect(filter).toContain("'Microsoft Dynamics 365 Business Central'");
+        });
+
+        it('should fail with AMBIGUOUS_ACCOUNTING_INTEGRATION when two ERPs are active', async () => {
+            const { RunView } = await import('@memberjunction/core');
+            const runViewFn = vi.fn().mockResolvedValue({
+                Success: true,
+                Results: [
+                    { ID: 'ci-1', CompanyID: 'comp-1', IntegrationID: 'int-1', Integration: 'Microsoft Dynamics 365 Business Central' },
+                    { ID: 'ci-2', CompanyID: 'comp-1', IntegrationID: 'int-2', Integration: 'QuickBooks Online' },
+                ],
+            });
+            vi.mocked(RunView).mockImplementation(function (this: unknown) {
+                return { RunView: runViewFn };
+            } as never);
+
+            await expect(action['resolveCompanyAccountingIntegration']('comp-1', {} as never))
+                .rejects.toMatchObject({ resultCode: 'AMBIGUOUS_ACCOUNTING_INTEGRATION' });
+        });
+
+        it('should select the named integration when IntegrationName is passed', async () => {
+            const { RunView } = await import('@memberjunction/core');
+            const runViewFn = vi.fn().mockResolvedValue({
+                Success: true,
+                Results: [
+                    { ID: 'ci-2', CompanyID: 'comp-1', IntegrationID: 'int-2', Integration: 'QuickBooks Online' },
+                ],
+            });
+            vi.mocked(RunView).mockImplementation(function (this: unknown) {
+                return { RunView: runViewFn };
+            } as never);
+
+            const resolved = await action['resolveCompanyAccountingIntegration']('comp-1', {} as never, 'QuickBooks Online');
+            expect(resolved.Name).toBe('QuickBooks Online');
+            expect(runViewFn.mock.calls[0][0].ExtraFilter).toContain("'QuickBooks Online'");
+            expect(runViewFn.mock.calls[0][0].ExtraFilter).not.toContain('Business Central');
         });
     });
 });

--- a/packages/Actions/BizApps/Accounting/src/__tests__/accounting.test.ts
+++ b/packages/Actions/BizApps/Accounting/src/__tests__/accounting.test.ts
@@ -8,7 +8,16 @@ vi.mock('@memberjunction/actions', () => ({
 }));
 
 vi.mock('@memberjunction/global', () => ({
-    RegisterClass: () => (target: unknown) => target
+    RegisterClass: () => (target: unknown) => target,
+    UUIDsEqual: (a: string, b: string) => a === b,
+    EscapeSQLString: (value: string | null | undefined) => String(value ?? '').replace(/'/g, "''"),
+    MJGlobal: {
+        Instance: {
+            ClassFactory: {
+                TryCreateInstance: vi.fn(() => ({ Resolved: false, Instance: null })),
+            },
+        },
+    },
 }));
 
 vi.mock('@memberjunction/core', () => ({
@@ -181,6 +190,31 @@ describe('BaseAccountingAction', () => {
         it('should return undefined for missing env var', () => {
             const result = action['getCredentialFromEnv']('COMP1', 'MISSING_KEY');
             expect(result).toBeUndefined();
+        });
+    });
+
+    describe('resolveCompanyAccountingIntegration', () => {
+        it('should quote CompanyID so ExtraFilter cannot be injected', async () => {
+            const { RunView } = await import('@memberjunction/core');
+            const runViewFn = vi.fn().mockResolvedValue({
+                Success: true,
+                Results: [{
+                    ID: 'ci-1',
+                    CompanyID: 'comp-1',
+                    IntegrationID: 'int-1',
+                    Integration: 'QuickBooks Online',
+                }],
+            });
+            vi.mocked(RunView).mockImplementation(function (this: unknown) {
+                return { RunView: runViewFn };
+            } as never);
+
+            await action['resolveCompanyAccountingIntegration']("abc' OR 1=1--", {} as never);
+
+            const filter = runViewFn.mock.calls[0][0].ExtraFilter as string;
+            expect(filter).toContain("CompanyID = 'abc'' OR 1=1--'");
+            expect(filter).toContain("'QuickBooks Online'");
+            expect(filter).toContain("'Microsoft Dynamics 365 Business Central'");
         });
     });
 });

--- a/packages/Actions/BizApps/Accounting/src/base/base-accounting-action.ts
+++ b/packages/Actions/BizApps/Accounting/src/base/base-accounting-action.ts
@@ -1,9 +1,11 @@
 import { BaseAction } from '@memberjunction/actions';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
-import { RegisterClass, UUIDsEqual } from '@memberjunction/global';
+import { EscapeSQLString, MJGlobal, RegisterClass, UUIDsEqual } from '@memberjunction/global';
 import { UserInfo } from '@memberjunction/core';
 import { MJCompanyIntegrationEntity, MJIntegrationEntity } from '@memberjunction/core-entities';
 import { IMetadataProvider, Metadata, RunView } from '@memberjunction/core';
+import { ACCOUNTING_ERP_INTEGRATION_NAMES, erpPluginKey } from '../constants';
+import { ResolvedAccountingIntegration } from '../types';
 
 /**
  * Base class for all accounting-related actions.
@@ -75,7 +77,7 @@ export abstract class BaseAccountingAction extends BaseAction {
         const rv = new RunView();
         const result = await rv.RunView<MJCompanyIntegrationEntity>({
             EntityName: 'MJ: Company Integrations',
-            ExtraFilter: `CompanyID = '${companyId}' AND Integration.Name = '${this.integrationName}'`,
+            ExtraFilter: `CompanyID = '${EscapeSQLString(companyId)}' AND Integration.Name = '${EscapeSQLString(this.integrationName)}'`,
             ResultType: 'entity_object'
         }, contextUser);
 
@@ -144,7 +146,7 @@ export abstract class BaseAccountingAction extends BaseAction {
         const rv = new RunView();
         const result = await rv.RunView<MJIntegrationEntity>({
             EntityName: 'MJ: Integrations',
-            ExtraFilter: `Name = '${this.integrationName}'`,
+            ExtraFilter: `Name = '${EscapeSQLString(this.integrationName)}'`,
             ResultType: 'entity_object'
         }, contextUser);
 
@@ -200,5 +202,98 @@ export abstract class BaseAccountingAction extends BaseAction {
             message += ` System error: ${systemError.message || systemError}`;
         }
         return message;
+    }
+
+    /**
+     * Load the company's accounting CompanyIntegration (any Integration whose
+     * Name is one of the known ERP names). Does not hard-filter to a single vendor.
+     */
+    protected async resolveCompanyAccountingIntegration(
+        companyId: string,
+        contextUser: UserInfo
+    ): Promise<ResolvedAccountingIntegration> {
+        const nameList = ACCOUNTING_ERP_INTEGRATION_NAMES
+            .map(name => `'${EscapeSQLString(name)}'`)
+            .join(', ');
+
+        const rv = new RunView();
+        const result = await rv.RunView<MJCompanyIntegrationEntity>({
+            EntityName: 'MJ: Company Integrations',
+            ExtraFilter: `CompanyID = '${EscapeSQLString(companyId)}' AND Integration.Name IN (${nameList})`,
+            OrderBy: 'Integration',
+            ResultType: 'entity_object'
+        }, contextUser);
+
+        if (!result.Success) {
+            throw new Error(`Failed to retrieve company integration: ${result.ErrorMessage}`);
+        }
+
+        if (!result.Results || result.Results.length === 0) {
+            throw new Error(`No accounting ERP integration found for company ${companyId}. Configure QuickBooks Online or Microsoft Dynamics 365 Business Central.`);
+        }
+
+        const record = result.Results[0];
+        const name = record.Integration;
+        if (!name) {
+            throw new Error(`Company integration ${record.ID} has no Integration name; cannot dispatch an ERP plugin.`);
+        }
+
+        return {
+            Name: name,
+            CompanyIntegrationID: record.ID,
+            CompanyID: record.CompanyID,
+            IntegrationID: record.IntegrationID,
+        };
+    }
+
+    /**
+     * Resolve the company's ERP and invoke the plugin registered as `${verb}:${integration.Name}`.
+     * Plugin.Run → InternalRunAction with the same params the caller passed to the dispatcher.
+     */
+    protected async dispatchVerb(verb: string, params: RunActionParams): Promise<ActionResultSimple> {
+        const companyId = this.getParamValue(params.Params, 'CompanyID');
+        if (!companyId) {
+            return {
+                Success: false,
+                ResultCode: 'VALIDATION_ERROR',
+                Message: 'CompanyID is required',
+                Params: params.Params
+            };
+        }
+
+        if (!params.ContextUser) {
+            return {
+                Success: false,
+                ResultCode: 'ERROR',
+                Message: 'Context user is required',
+                Params: params.Params
+            };
+        }
+
+        let integration: ResolvedAccountingIntegration;
+        try {
+            integration = await this.resolveCompanyAccountingIntegration(companyId, params.ContextUser);
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+            return {
+                Success: false,
+                ResultCode: 'NO_ACCOUNTING_INTEGRATION',
+                Message: errorMessage,
+                Params: params.Params
+            };
+        }
+
+        const pluginKey = erpPluginKey(verb, integration.Name);
+        const resolved = MJGlobal.Instance.ClassFactory.TryCreateInstance<BaseAction>(BaseAction, pluginKey);
+        if (!resolved.Resolved || !resolved.Instance) {
+            return {
+                Success: false,
+                ResultCode: 'PROVIDER_NOT_REGISTERED',
+                Message: `No ERP plugin registered for ${pluginKey}`,
+                Params: params.Params
+            };
+        }
+
+        return resolved.Instance.Run(params);
     }
 }

--- a/packages/Actions/BizApps/Accounting/src/base/base-accounting-action.ts
+++ b/packages/Actions/BizApps/Accounting/src/base/base-accounting-action.ts
@@ -7,6 +7,13 @@ import { IMetadataProvider, Metadata, RunView } from '@memberjunction/core';
 import { ACCOUNTING_ERP_INTEGRATION_NAMES, erpPluginKey } from '../constants';
 import { ResolvedAccountingIntegration } from '../types';
 
+class AccountingIntegrationError extends Error {
+    constructor(message: string, readonly resultCode: 'NO_ACCOUNTING_INTEGRATION' | 'AMBIGUOUS_ACCOUNTING_INTEGRATION') {
+        super(message);
+        this.name = 'AccountingIntegrationError';
+    }
+}
+
 /**
  * Base class for all accounting-related actions.
  * Provides common functionality and patterns for interacting with accounting systems.
@@ -59,6 +66,11 @@ export abstract class BaseAccountingAction extends BaseAction {
             },
             {
                 Name: 'AccountingPeriod',
+                Type: 'Input',
+                Value: null
+            },
+            {
+                Name: 'IntegrationName',
                 Type: 'Input',
                 Value: null
             }
@@ -210,32 +222,57 @@ export abstract class BaseAccountingAction extends BaseAction {
      */
     protected async resolveCompanyAccountingIntegration(
         companyId: string,
-        contextUser: UserInfo
+        contextUser: UserInfo,
+        integrationName?: string
     ): Promise<ResolvedAccountingIntegration> {
-        const nameList = ACCOUNTING_ERP_INTEGRATION_NAMES
+        const names = integrationName
+            ? [integrationName]
+            : [...ACCOUNTING_ERP_INTEGRATION_NAMES];
+        const nameList = names
             .map(name => `'${EscapeSQLString(name)}'`)
             .join(', ');
 
         const rv = new RunView();
         const result = await rv.RunView<MJCompanyIntegrationEntity>({
             EntityName: 'MJ: Company Integrations',
-            ExtraFilter: `CompanyID = '${EscapeSQLString(companyId)}' AND Integration.Name IN (${nameList})`,
+            ExtraFilter: `CompanyID = '${EscapeSQLString(companyId)}' AND IsActive = 1 AND Integration.Name IN (${nameList})`,
             OrderBy: 'Integration',
             ResultType: 'entity_object'
         }, contextUser);
 
         if (!result.Success) {
-            throw new Error(`Failed to retrieve company integration: ${result.ErrorMessage}`);
+            throw new AccountingIntegrationError(
+                `Failed to retrieve company integration: ${result.ErrorMessage}`,
+                'NO_ACCOUNTING_INTEGRATION'
+            );
         }
 
         if (!result.Results || result.Results.length === 0) {
-            throw new Error(`No accounting ERP integration found for company ${companyId}. Configure QuickBooks Online or Microsoft Dynamics 365 Business Central.`);
+            throw new AccountingIntegrationError(
+                integrationName
+                    ? `No active '${integrationName}' integration found for company ${companyId}.`
+                    : `No accounting ERP integration found for company ${companyId}. Configure QuickBooks Online or Microsoft Dynamics 365 Business Central.`,
+                'NO_ACCOUNTING_INTEGRATION'
+            );
+        }
+
+        if (!integrationName && result.Results.length > 1) {
+            const candidates = result.Results
+                .map(r => r.Integration)
+                .filter((n): n is string => !!n);
+            throw new AccountingIntegrationError(
+                `Company ${companyId} has ${result.Results.length} active accounting ERP integrations (${candidates.join(', ')}). Pass IntegrationName to select one.`,
+                'AMBIGUOUS_ACCOUNTING_INTEGRATION'
+            );
         }
 
         const record = result.Results[0];
         const name = record.Integration;
         if (!name) {
-            throw new Error(`Company integration ${record.ID} has no Integration name; cannot dispatch an ERP plugin.`);
+            throw new AccountingIntegrationError(
+                `Company integration ${record.ID} has no Integration name; cannot dispatch an ERP plugin.`,
+                'NO_ACCOUNTING_INTEGRATION'
+            );
         }
 
         return {
@@ -272,12 +309,19 @@ export abstract class BaseAccountingAction extends BaseAction {
 
         let integration: ResolvedAccountingIntegration;
         try {
-            integration = await this.resolveCompanyAccountingIntegration(companyId, params.ContextUser);
+            integration = await this.resolveCompanyAccountingIntegration(
+                companyId,
+                params.ContextUser,
+                this.getParamValue(params.Params, 'IntegrationName')
+            );
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+            const resultCode = error instanceof AccountingIntegrationError
+                ? error.resultCode
+                : 'NO_ACCOUNTING_INTEGRATION';
             return {
                 Success: false,
-                ResultCode: 'NO_ACCOUNTING_INTEGRATION',
+                ResultCode: resultCode,
                 Message: errorMessage,
                 Params: params.Params
             };

--- a/packages/Actions/BizApps/Accounting/src/constants.ts
+++ b/packages/Actions/BizApps/Accounting/src/constants.ts
@@ -1,0 +1,35 @@
+/**
+ * ERP Integration.Name values that this package can dispatch to.
+ * Plugin RegisterClass keys are `${verb}:${integrationName}` and MUST match
+ * the Integration.Name row in MJ: Integrations.
+ */
+export const ERP_INTEGRATION = {
+    QuickBooksOnline: 'QuickBooks Online',
+    BusinessCentral: 'Microsoft Dynamics 365 Business Central',
+} as const;
+
+export type AccountingERPIntegrationName =
+    (typeof ERP_INTEGRATION)[keyof typeof ERP_INTEGRATION];
+
+export const ACCOUNTING_ERP_INTEGRATION_NAMES: readonly AccountingERPIntegrationName[] = [
+    ERP_INTEGRATION.QuickBooksOnline,
+    ERP_INTEGRATION.BusinessCentral,
+];
+
+/** Verb names — RegisterClass keys on the dispatcher BaseAction subclasses. */
+export const ACCOUNTING_VERBS = {
+    GetChartOfAccounts: 'GetChartOfAccounts',
+    GetAccountBalances: 'GetAccountBalances',
+    CreateJournalEntry: 'CreateJournalEntry',
+    GetDimensions: 'GetDimensions',
+    GetGLEntries: 'GetGLEntries',
+    GetCustomers: 'GetCustomers',
+    GetSalesInvoices: 'GetSalesInvoices',
+} as const;
+
+export type AccountingVerb = (typeof ACCOUNTING_VERBS)[keyof typeof ACCOUNTING_VERBS];
+
+/** Plugin ClassFactory key: `CreateJournalEntry:QuickBooks Online`. */
+export function erpPluginKey(verb: string, integrationName: string): string {
+    return `${verb}:${integrationName}`;
+}

--- a/packages/Actions/BizApps/Accounting/src/index.ts
+++ b/packages/Actions/BizApps/Accounting/src/index.ts
@@ -1,34 +1,32 @@
-// Export all accounting actions
-export * from './base/base-accounting-action';
+export * from './constants';
+export * from './types';
+export { parseAndValidateJournalEntryLines, journalEntryBalanceError, totalDebits } from './journal-entry';
 
-// QuickBooks base
+export * from './base/base-accounting-action';
+export * from './verbs/verb-dispatcher';
+
+export { CreateJournalEntryAction } from './verbs/create-journal-entry.action';
+export { GetChartOfAccountsAction } from './verbs/get-chart-of-accounts.action';
+export { GetAccountBalancesAction } from './verbs/get-account-balances.action';
+export { GetDimensionsAction } from './verbs/get-dimensions.action';
+export { GetGLEntriesAction } from './verbs/get-gl-entries.action';
+export { GetCustomersAction } from './verbs/get-customers.action';
+export { GetSalesInvoicesAction } from './verbs/get-sales-invoices.action';
+
 export * from './providers/quickbooks/quickbooks-base.action';
 
-// QuickBooks actions - export specific items to avoid conflicts
 export { GetQuickBooksGLCodesAction, GLCode } from './providers/quickbooks/actions/get-gl-codes.action';
 export { GetQuickBooksTransactionsAction, Transaction, TransactionLine } from './providers/quickbooks/actions/get-transactions.action';
-export { GetQuickBooksAccountBalancesAction, AccountBalance } from './providers/quickbooks/actions/get-account-balances.action';
-// export { GetQuickBooksInvoicesAction, Invoice, InvoiceLine, Address as InvoiceAddress } from './providers/quickbooks/actions/get-invoices.action';
-// export { GetQuickBooksBillsAction, Bill, BillLine, Address as BillAddress } from './providers/quickbooks/actions/get-bills.action';
-// export { GetQuickBooksCustomersAction, Customer, Address as CustomerAddress } from './providers/quickbooks/actions/get-customers.action';
-// export { GetQuickBooksVendorsAction, Vendor, Address as VendorAddress } from './providers/quickbooks/actions/get-vendors.action';
-export { CreateQuickBooksJournalEntryAction, JournalEntryLine } from './providers/quickbooks/actions/create-journal-entry.action';
+export { GetQuickBooksAccountBalancesAction } from './providers/quickbooks/actions/get-account-balances.action';
+export { CreateQuickBooksJournalEntryAction } from './providers/quickbooks/actions/create-journal-entry.action';
+export { GetQuickBooksDimensionsAction } from './providers/quickbooks/actions/get-dimensions.action';
 
-// Business Central base
 export * from './providers/business-central/business-central-base.action';
 
-// Business Central actions
 export { GetBusinessCentralGLAccountsAction, BCGLAccount } from './providers/business-central/actions/get-gl-accounts.action';
 export { GetBusinessCentralGeneralLedgerEntriesAction, BCGeneralLedgerEntry, BCDimensionSetLine } from './providers/business-central/actions/get-general-ledger-entries.action';
 export { GetBusinessCentralCustomersAction, BCCustomer, BCAddress } from './providers/business-central/actions/get-customers.action';
 export { GetBusinessCentralSalesInvoicesAction, BCSalesInvoice, BCSalesInvoiceLine } from './providers/business-central/actions/get-sales-invoices.action';
-
-// NetSuite actions
-// export * from './providers/netsuite/actions/get-gl-codes.action';
-
-// Sage Intacct actions
-// export * from './providers/sage-intacct/actions/get-gl-codes.action';
-
-// Common actions
-// export * from './common/get-account-balances.action';
-// export * from './common/validate-journal-entry.action';
+export { CreateBusinessCentralJournalEntryAction } from './providers/business-central/actions/create-journal-entry.action';
+export { GetBusinessCentralAccountBalancesAction } from './providers/business-central/actions/get-account-balances.action';
+export { GetBusinessCentralDimensionsAction } from './providers/business-central/actions/get-dimensions.action';

--- a/packages/Actions/BizApps/Accounting/src/journal-entry.ts
+++ b/packages/Actions/BizApps/Accounting/src/journal-entry.ts
@@ -1,0 +1,73 @@
+import { ActionParam, ActionResultSimple } from '@memberjunction/actions-base';
+import { JournalEntryLine } from './types';
+
+/**
+ * Parse the Lines param and enforce the provider-agnostic journal rules:
+ * array of ≥ 2 lines, each with accountId or accountNumber, exactly one of
+ * debit/credit, non-negative amounts. Throws with the historical QBO messages
+ * so existing callers keep ResultCode ERROR for structural problems.
+ */
+export function parseAndValidateJournalEntryLines(linesParam: unknown): JournalEntryLine[] {
+    if (!linesParam) {
+        throw new Error('Lines parameter is required');
+    }
+
+    let lines: JournalEntryLine[];
+
+    if (typeof linesParam === 'string') {
+        try {
+            lines = JSON.parse(linesParam);
+        } catch {
+            throw new Error('Invalid JSON format for Lines parameter');
+        }
+    } else {
+        lines = linesParam as JournalEntryLine[];
+    }
+
+    if (!Array.isArray(lines)) {
+        throw new Error('Lines must be an array');
+    }
+
+    if (lines.length < 2) {
+        throw new Error('Journal entry must have at least 2 lines');
+    }
+
+    lines.forEach((line, index) => {
+        const hasAccountId = line.accountId != null && String(line.accountId).trim() !== '';
+        const hasAccountNumber = line.accountNumber != null && String(line.accountNumber).trim() !== '';
+        if (!hasAccountId && !hasAccountNumber) {
+            throw new Error(`Line ${index + 1}: accountId or accountNumber is required`);
+        }
+
+        if (line.debit === undefined && line.credit === undefined) {
+            throw new Error(`Line ${index + 1}: either debit or credit amount is required`);
+        }
+
+        if (line.debit !== undefined && line.credit !== undefined) {
+            throw new Error(`Line ${index + 1}: cannot have both debit and credit on the same line`);
+        }
+
+        if (line.debit !== undefined && line.debit < 0) {
+            throw new Error(`Line ${index + 1}: debit amount cannot be negative`);
+        }
+
+        if (line.credit !== undefined && line.credit < 0) {
+            throw new Error(`Line ${index + 1}: credit amount cannot be negative`);
+        }
+    });
+
+    return lines;
+}
+
+export function journalEntryBalanceError(params: ActionParam[]): ActionResultSimple {
+    return {
+        Success: false,
+        ResultCode: 'VALIDATION_ERROR',
+        Message: 'Journal entry is not balanced. Total debits must equal total credits.',
+        Params: params,
+    };
+}
+
+export function totalDebits(lines: JournalEntryLine[]): number {
+    return lines.reduce((sum, line) => sum + (line.debit || 0), 0);
+}

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/create-journal-entry.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/create-journal-entry.action.ts
@@ -1,4 +1,5 @@
 import { RegisterClass } from '@memberjunction/global';
+import { LogError } from '@memberjunction/core';
 import { BusinessCentralBaseAction } from '../business-central-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { BaseAction } from '@memberjunction/actions';
@@ -56,46 +57,56 @@ export class CreateBusinessCentralJournalEntryAction extends BusinessCentralBase
                 return journalEntryBalanceError(params.Params);
             }
 
-            const journal = await this.resolveGeneralJournal(journalCode, contextUser);
-            if (!journal) {
+            const resolved = await this.resolveGeneralJournal(journalCode, contextUser);
+            if (!resolved.journal) {
                 return {
                     Success: false,
                     ResultCode: 'ERROR',
-                    Message: 'No general journal found in Business Central. Pass JournalCode or configure a GENERAL/DEFAULT journal without a balancing account.',
+                    Message: resolved.error ?? 'No general journal found in Business Central.',
                     Params: params.Params
                 };
             }
+            const journal = resolved.journal;
 
-            let lastLine: BCJournalLineResult | undefined;
-            for (let i = 0; i < lines.length; i++) {
-                lastLine = await this.makeBCRequest<BCJournalLineResult>(
-                    `journals(${journal.id})/journalLines`,
+            const createdLineIds: string[] = [];
+            try {
+                let lastLine: BCJournalLineResult | undefined;
+                for (let i = 0; i < lines.length; i++) {
+                    lastLine = await this.makeBCRequest<BCJournalLineResult>(
+                        `journals(${journal.id})/journalLines`,
+                        'POST',
+                        this.mapToBCJournalLine(lines[i], i, postingDate, docNumber, description),
+                        contextUser
+                    );
+                    if (lastLine?.id) {
+                        createdLineIds.push(lastLine.id);
+                    }
+                }
+
+                await this.makeBCRequest(
+                    `journals(${journal.id})/Microsoft.NAV.post`,
                     'POST',
-                    this.mapToBCJournalLine(lines[i], i, postingDate, docNumber, description),
+                    undefined,
                     contextUser
                 );
+
+                const outputDoc = docNumber || lastLine?.documentNumber || '';
+                const outputParams: ActionParam[] = [
+                    { Name: 'JournalEntryID', Value: journal.id, Type: 'Output' },
+                    { Name: 'DocNumber', Value: outputDoc, Type: 'Output' },
+                    { Name: 'TotalAmount', Value: totalDebits(lines), Type: 'Output' }
+                ];
+
+                return {
+                    Success: true,
+                    ResultCode: 'SUCCESS',
+                    Params: [...params.Params, ...outputParams],
+                    Message: `Journal entry ${outputDoc || journal.id} posted successfully`
+                };
+            } catch (postError) {
+                await this.deleteCreatedJournalLines(createdLineIds, contextUser);
+                throw postError;
             }
-
-            await this.makeBCRequest(
-                `journals(${journal.id})/Microsoft.NAV.post`,
-                'POST',
-                undefined,
-                contextUser
-            );
-
-            const outputDoc = docNumber || lastLine?.documentNumber || '';
-            const outputParams: ActionParam[] = [
-                { Name: 'JournalEntryID', Value: journal.id, Type: 'Output' },
-                { Name: 'DocNumber', Value: outputDoc, Type: 'Output' },
-                { Name: 'TotalAmount', Value: totalDebits(lines), Type: 'Output' }
-            ];
-
-            return {
-                Success: true,
-                ResultCode: 'SUCCESS',
-                Params: [...params.Params, ...outputParams],
-                Message: `Journal entry ${outputDoc || journal.id} posted successfully`
-            };
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
             return {
@@ -107,10 +118,28 @@ export class CreateBusinessCentralJournalEntryAction extends BusinessCentralBase
         }
     }
 
+    /**
+     * Compensating delete: a failed mid-batch POST leaves lines in the BC journal,
+     * and the next Microsoft.NAV.post would send those orphans to the GL.
+     */
+    private async deleteCreatedJournalLines(
+        lineIds: string[],
+        contextUser: NonNullable<RunActionParams['ContextUser']>
+    ): Promise<void> {
+        for (const lineId of lineIds) {
+            try {
+                await this.makeBCRequest(`journalLines(${lineId})`, 'DELETE', undefined, contextUser);
+            } catch (cleanupError) {
+                const msg = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+                LogError(`CreateBusinessCentralJournalEntry: failed to delete orphan journalLines(${lineId}): ${msg}`);
+            }
+        }
+    }
+
     private async resolveGeneralJournal(
         journalCode: string | undefined,
         contextUser: NonNullable<RunActionParams['ContextUser']>
-    ): Promise<BCJournal | undefined> {
+    ): Promise<{ journal?: BCJournal; error?: string }> {
         const response = await this.makeBCRequest<{ value: BCJournal[] }>(
             'journals',
             'GET',
@@ -119,18 +148,33 @@ export class CreateBusinessCentralJournalEntryAction extends BusinessCentralBase
         );
         const journals = response?.value || [];
         if (journals.length === 0) {
-            return undefined;
+            return { error: 'This Business Central company has no journals.' };
         }
 
         if (journalCode) {
-            return journals.find(j => j.code === journalCode);
+            const match = journals.find(j => j.code === journalCode);
+            if (!match) {
+                return { error: `JournalCode '${journalCode}' does not exist in Business Central.` };
+            }
+            if (match.balancingAccountNumber) {
+                return {
+                    error: `Journal '${journalCode}' has a balancing account; posting a self-balanced multi-line entry would add an extra line. Use a journal without a balancing account.`
+                };
+            }
+            return { journal: match };
         }
 
         const unbalancing = journals.filter(j => !j.balancingAccountNumber);
-        return unbalancing.find(j => {
+        const preferred = unbalancing.find(j => {
             const code = (j.code || '').toUpperCase();
             return code === 'GENERAL' || code === 'DEFAULT';
-        }) || unbalancing[0] || journals[0];
+        }) || unbalancing[0];
+        if (!preferred) {
+            return {
+                error: 'No general journal without a balancing account found. Pass JournalCode for an unbalanced journal, or configure a GENERAL/DEFAULT journal without a balancing account.'
+            };
+        }
+        return { journal: preferred };
     }
 
     private mapToBCJournalLine(
@@ -151,10 +195,10 @@ export class CreateBusinessCentralJournalEntryAction extends BusinessCentralBase
         if (documentNumber) {
             body.documentNumber = documentNumber;
         }
+        // AM-4: accountNumber wins. Sending both lets a stale accountId override the number.
         if (line.accountNumber) {
             body.accountNumber = line.accountNumber;
-        }
-        if (line.accountId) {
+        } else if (line.accountId) {
             body.accountId = line.accountId;
         }
         return body;

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/create-journal-entry.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/create-journal-entry.action.ts
@@ -1,0 +1,173 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BusinessCentralBaseAction } from '../business-central-base.action';
+import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
+import { JournalEntryLine } from '../../../types';
+import { journalEntryBalanceError, parseAndValidateJournalEntryLines, totalDebits } from '../../../journal-entry';
+
+interface BCJournal {
+    id: string;
+    code?: string;
+    displayName?: string;
+    balancingAccountNumber?: string | null;
+}
+
+interface BCJournalLineResult {
+    id?: string;
+    documentNumber?: string;
+}
+
+/**
+ * Posts a balanced journal entry to Business Central (v2.0 OData).
+ * Lines go to journals({id})/journalLines, then Microsoft.NAV.post posts the batch.
+ */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.CreateJournalEntry, ERP_INTEGRATION.BusinessCentral))
+export class CreateBusinessCentralJournalEntryAction extends BusinessCentralBaseAction {
+
+    public get Description(): string {
+        return 'Creates a balanced journal entry in Microsoft Dynamics 365 Business Central and posts the batch';
+    }
+
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        try {
+            const contextUser = params.ContextUser;
+            if (!contextUser) {
+                return {
+                    Success: false,
+                    ResultCode: 'ERROR',
+                    Message: 'Context user is required for Business Central API calls',
+                    Params: params.Params
+                };
+            }
+
+            this.params = params.Params;
+
+            const entryDateRaw = this.getParamValue(params.Params, 'EntryDate');
+            const entryDate = entryDateRaw ? new Date(entryDateRaw) : new Date();
+            const postingDate = this.formatBCDate(entryDate);
+            const docNumber = this.getParamValue(params.Params, 'DocNumber');
+            const description = this.getParamValue(params.Params, 'PrivateNote')
+                || this.getParamValue(params.Params, 'Description');
+            const journalCode = this.getParamValue(params.Params, 'JournalCode');
+            const lines = parseAndValidateJournalEntryLines(this.getParamValue(params.Params, 'Lines'));
+
+            if (!this.validateJournalEntryBalance(lines)) {
+                return journalEntryBalanceError(params.Params);
+            }
+
+            const journal = await this.resolveGeneralJournal(journalCode, contextUser);
+            if (!journal) {
+                return {
+                    Success: false,
+                    ResultCode: 'ERROR',
+                    Message: 'No general journal found in Business Central. Pass JournalCode or configure a GENERAL/DEFAULT journal without a balancing account.',
+                    Params: params.Params
+                };
+            }
+
+            let lastLine: BCJournalLineResult | undefined;
+            for (let i = 0; i < lines.length; i++) {
+                lastLine = await this.makeBCRequest<BCJournalLineResult>(
+                    `journals(${journal.id})/journalLines`,
+                    'POST',
+                    this.mapToBCJournalLine(lines[i], i, postingDate, docNumber, description),
+                    contextUser
+                );
+            }
+
+            await this.makeBCRequest(
+                `journals(${journal.id})/Microsoft.NAV.post`,
+                'POST',
+                undefined,
+                contextUser
+            );
+
+            const outputDoc = docNumber || lastLine?.documentNumber || '';
+            const outputParams: ActionParam[] = [
+                { Name: 'JournalEntryID', Value: journal.id, Type: 'Output' },
+                { Name: 'DocNumber', Value: outputDoc, Type: 'Output' },
+                { Name: 'TotalAmount', Value: totalDebits(lines), Type: 'Output' }
+            ];
+
+            return {
+                Success: true,
+                ResultCode: 'SUCCESS',
+                Params: [...params.Params, ...outputParams],
+                Message: `Journal entry ${outputDoc || journal.id} posted successfully`
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+            return {
+                Success: false,
+                ResultCode: 'ERROR',
+                Message: errorMessage,
+                Params: params.Params
+            };
+        }
+    }
+
+    private async resolveGeneralJournal(
+        journalCode: string | undefined,
+        contextUser: NonNullable<RunActionParams['ContextUser']>
+    ): Promise<BCJournal | undefined> {
+        const response = await this.makeBCRequest<{ value: BCJournal[] }>(
+            'journals',
+            'GET',
+            undefined,
+            contextUser
+        );
+        const journals = response?.value || [];
+        if (journals.length === 0) {
+            return undefined;
+        }
+
+        if (journalCode) {
+            return journals.find(j => j.code === journalCode);
+        }
+
+        const unbalancing = journals.filter(j => !j.balancingAccountNumber);
+        return unbalancing.find(j => {
+            const code = (j.code || '').toUpperCase();
+            return code === 'GENERAL' || code === 'DEFAULT';
+        }) || unbalancing[0] || journals[0];
+    }
+
+    private mapToBCJournalLine(
+        line: JournalEntryLine,
+        index: number,
+        postingDate: string,
+        documentNumber: string | undefined,
+        batchDescription: string | undefined
+    ): Record<string, unknown> {
+        const amount = line.debit != null ? line.debit : -(line.credit || 0);
+        const body: Record<string, unknown> = {
+            lineNumber: (index + 1) * 10000,
+            accountType: 'G/L Account',
+            postingDate,
+            amount,
+            description: line.description || batchDescription || ''
+        };
+        if (documentNumber) {
+            body.documentNumber = documentNumber;
+        }
+        if (line.accountNumber) {
+            body.accountNumber = line.accountNumber;
+        }
+        if (line.accountId) {
+            body.accountId = line.accountId;
+        }
+        return body;
+    }
+
+    public get Params(): ActionParam[] {
+        return [
+            ...this.getCommonAccountingParams(),
+            { Name: 'Lines', Type: 'Input', Value: null },
+            { Name: 'EntryDate', Type: 'Input', Value: null },
+            { Name: 'DocNumber', Type: 'Input', Value: null },
+            { Name: 'PrivateNote', Type: 'Input', Value: null },
+            { Name: 'JournalCode', Type: 'Input', Value: null }
+        ];
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-account-balances.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-account-balances.action.ts
@@ -1,0 +1,111 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BusinessCentralBaseAction } from '../business-central-base.action';
+import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
+import { AccountBalance } from '../../../types';
+
+/**
+ * Account balances from Business Central generalLedgerAccounts.
+ * accountCode is the ERP account number (AM-4).
+ */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetAccountBalances, ERP_INTEGRATION.BusinessCentral))
+export class GetBusinessCentralAccountBalancesAction extends BusinessCentralBaseAction {
+
+    public get Description(): string {
+        return 'Retrieves account balances from Microsoft Dynamics 365 Business Central';
+    }
+
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        try {
+            const contextUser = params.ContextUser;
+            if (!contextUser) {
+                return {
+                    Success: false,
+                    ResultCode: 'ERROR',
+                    Message: 'Context user is required for Business Central API calls',
+                    Params: params.Params
+                };
+            }
+
+            this.params = params.Params;
+
+            const asOfDate = this.getParamValue(params.Params, 'AsOfDate')
+                ? new Date(this.getParamValue(params.Params, 'AsOfDate'))
+                : new Date();
+
+            const filters: string[] = [];
+            if (!this.getParamValue(params.Params, 'IncludeBlocked')) {
+                filters.push('blocked eq false');
+            }
+
+            const categories = this.getParamValue(params.Params, 'AccountTypes');
+            if (categories) {
+                const cats = String(categories).split(',').map((c: string) => c.trim());
+                const catFilters = cats.map((cat: string) => `category eq '${cat}'`);
+                if (catFilters.length > 0) {
+                    filters.push(`(${catFilters.join(' or ')})`);
+                }
+            }
+
+            const maxResults = this.getParamValue(params.Params, 'MaxResults') || 1000;
+            const response = await this.queryBC<{ value: any[] }>(
+                'generalLedgerAccounts',
+                filters,
+                ['id', 'number', 'displayName', 'balance', 'category', 'accountType', 'blocked'],
+                undefined,
+                'number',
+                maxResults,
+                contextUser
+            );
+
+            const includeZero = this.getParamValue(params.Params, 'IncludeZeroBalances') !== false;
+            const accountBalances: AccountBalance[] = (response.value || [])
+                .map((account: any) => this.mapAccount(account, asOfDate))
+                .filter((b: AccountBalance) => includeZero || b.currentBalance !== 0);
+
+            const outputParams: ActionParam[] = [
+                { Name: 'AccountBalances', Value: accountBalances, Type: 'Output' },
+                { Name: 'TotalAccounts', Value: accountBalances.length, Type: 'Output' }
+            ];
+
+            return {
+                Success: true,
+                ResultCode: 'SUCCESS',
+                Params: [...params.Params, ...outputParams],
+                Message: `Successfully retrieved ${accountBalances.length} account balances from Business Central`
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+            return {
+                Success: false,
+                ResultCode: 'ERROR',
+                Message: errorMessage,
+                Params: params.Params
+            };
+        }
+    }
+
+    private mapAccount(account: any, asOfDate: Date): AccountBalance {
+        return {
+            accountId: account.id,
+            accountCode: account.number,
+            accountName: account.displayName,
+            accountType: this.mapAccountCategory(account.category) || account.category,
+            currentBalance: account.balance || 0,
+            asOfDate,
+            isActive: !account.blocked
+        };
+    }
+
+    public get Params(): ActionParam[] {
+        return [
+            ...this.getCommonAccountingParams(),
+            { Name: 'AsOfDate', Type: 'Input', Value: null },
+            { Name: 'AccountTypes', Type: 'Input', Value: null },
+            { Name: 'IncludeBlocked', Type: 'Input', Value: false },
+            { Name: 'IncludeZeroBalances', Type: 'Input', Value: true },
+            { Name: 'MaxResults', Type: 'Input', Value: 1000 }
+        ];
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-customers.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-customers.action.ts
@@ -2,6 +2,7 @@ import { RegisterClass } from '@memberjunction/global';
 import { BusinessCentralBaseAction } from '../business-central-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
 
 /**
  * Interface for a Customer from Business Central
@@ -41,6 +42,7 @@ export interface BCAddress {
 /**
  * Action to retrieve customers from Microsoft Dynamics 365 Business Central
  */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetCustomers, ERP_INTEGRATION.BusinessCentral))
 @RegisterClass(BaseAction, 'GetBusinessCentralCustomersAction')
 export class GetBusinessCentralCustomersAction extends BusinessCentralBaseAction {
     

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-dimensions.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-dimensions.action.ts
@@ -1,0 +1,98 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BusinessCentralBaseAction } from '../business-central-base.action';
+import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
+import { Dimension } from '../../../types';
+
+interface BCDimension {
+    id: string;
+    code: string;
+    displayName?: string;
+}
+
+interface BCDimensionValue {
+    id?: string;
+    code: string;
+    displayName?: string;
+    dimensionId: string;
+}
+
+/**
+ * Dimensions + dimension values from Business Central OData v2.0.
+ */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetDimensions, ERP_INTEGRATION.BusinessCentral))
+export class GetBusinessCentralDimensionsAction extends BusinessCentralBaseAction {
+
+    public get Description(): string {
+        return 'Retrieves dimensions and dimension values from Microsoft Dynamics 365 Business Central';
+    }
+
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        try {
+            const contextUser = params.ContextUser;
+            if (!contextUser) {
+                return {
+                    Success: false,
+                    ResultCode: 'ERROR',
+                    Message: 'Context user is required for Business Central API calls',
+                    Params: params.Params
+                };
+            }
+
+            this.params = params.Params;
+
+            const dimsResponse = await this.makeBCRequest<{ value: BCDimension[] }>(
+                'dimensions',
+                'GET',
+                undefined,
+                contextUser
+            );
+            const valuesResponse = await this.makeBCRequest<{ value: BCDimensionValue[] }>(
+                'dimensionValues',
+                'GET',
+                undefined,
+                contextUser
+            );
+
+            const valuesByDimension = new Map<string, BCDimensionValue[]>();
+            for (const value of valuesResponse?.value || []) {
+                const list = valuesByDimension.get(value.dimensionId) || [];
+                list.push(value);
+                valuesByDimension.set(value.dimensionId, list);
+            }
+
+            const dimensions: Dimension[] = (dimsResponse?.value || []).map(dim => ({
+                code: dim.code,
+                displayName: dim.displayName || dim.code,
+                values: (valuesByDimension.get(dim.id) || []).map(v => ({
+                    code: v.code,
+                    displayName: v.displayName || v.code
+                }))
+            }));
+
+            const outputParams: ActionParam[] = [
+                { Name: 'Dimensions', Value: dimensions, Type: 'Output' }
+            ];
+
+            return {
+                Success: true,
+                ResultCode: 'SUCCESS',
+                Params: [...params.Params, ...outputParams],
+                Message: `Successfully retrieved ${dimensions.length} dimensions from Business Central`
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+            return {
+                Success: false,
+                ResultCode: 'ERROR',
+                Message: errorMessage,
+                Params: params.Params
+            };
+        }
+    }
+
+    public get Params(): ActionParam[] {
+        return this.getCommonAccountingParams();
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-general-ledger-entries.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-general-ledger-entries.action.ts
@@ -2,6 +2,7 @@ import { RegisterClass } from '@memberjunction/global';
 import { BusinessCentralBaseAction } from '../business-central-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
 
 /**
  * Interface for a General Ledger Entry from Business Central
@@ -35,6 +36,7 @@ export interface BCDimensionSetLine {
 /**
  * Action to retrieve General Ledger Entries from Microsoft Dynamics 365 Business Central
  */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetGLEntries, ERP_INTEGRATION.BusinessCentral))
 @RegisterClass(BaseAction, 'GetBusinessCentralGeneralLedgerEntriesAction')
 export class GetBusinessCentralGeneralLedgerEntriesAction extends BusinessCentralBaseAction {
     

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-gl-accounts.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-gl-accounts.action.ts
@@ -2,6 +2,8 @@ import { RegisterClass } from '@memberjunction/global';
 import { BusinessCentralBaseAction } from '../business-central-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
+import { ChartOfAccount } from '../../../types';
 
 /**
  * Interface for a GL Account (Chart of Accounts) entry from Business Central
@@ -26,6 +28,7 @@ export interface BCGLAccount {
 /**
  * Action to retrieve the Chart of Accounts from Microsoft Dynamics 365 Business Central
  */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetChartOfAccounts, ERP_INTEGRATION.BusinessCentral))
 @RegisterClass(BaseAction, 'GetBusinessCentralGLAccountsAction')
 export class GetBusinessCentralGLAccountsAction extends BusinessCentralBaseAction {
     
@@ -126,6 +129,13 @@ export class GetBusinessCentralGLAccountsAction extends BusinessCentralBaseActio
 
             const bcAccounts = response.value || [];
             const glAccounts: BCGLAccount[] = bcAccounts.map(account => this.mapBCAccountToGLAccount(account));
+            const chart: ChartOfAccount[] = glAccounts.map(a => ({
+                id: a.id,
+                code: a.number,
+                name: a.displayName,
+                accountType: a.accountType,
+                isActive: !a.blocked
+            }));
 
             // Calculate summary
             const summary = this.calculateAccountSummary(glAccounts);
@@ -159,6 +169,16 @@ export class GetBusinessCentralGLAccountsAction extends BusinessCentralBaseActio
                 });
             } else {
                 params.Params.find(p => p.Name === 'Summary')!.Value = summary;
+            }
+
+            if (!params.Params.find(p => p.Name === 'Accounts')) {
+                params.Params.push({
+                    Name: 'Accounts',
+                    Type: 'Output',
+                    Value: chart
+                });
+            } else {
+                params.Params.find(p => p.Name === 'Accounts')!.Value = chart;
             }
 
             return {

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-sales-invoices.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/actions/get-sales-invoices.action.ts
@@ -2,6 +2,7 @@ import { RegisterClass } from '@memberjunction/global';
 import { BusinessCentralBaseAction } from '../business-central-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
 
 /**
  * Interface for a Sales Invoice from Business Central
@@ -59,6 +60,7 @@ export interface BCSalesInvoiceLine {
 /**
  * Action to retrieve sales invoices from Microsoft Dynamics 365 Business Central
  */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetSalesInvoices, ERP_INTEGRATION.BusinessCentral))
 @RegisterClass(BaseAction, 'GetBusinessCentralSalesInvoicesAction')
 export class GetBusinessCentralSalesInvoicesAction extends BusinessCentralBaseAction {
     

--- a/packages/Actions/BizApps/Accounting/src/providers/business-central/business-central-base.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/business-central/business-central-base.action.ts
@@ -93,8 +93,12 @@ export abstract class BusinessCentralBaseAction extends BaseAccountingAction {
                 throw new Error(errorMessage);
             }
 
-            const result = await response.json();
-            return result as T;
+            // Bound actions such as Microsoft.NAV.post return 204 with an empty body.
+            const text = await response.text();
+            if (!text || !text.trim()) {
+                return undefined as T;
+            }
+            return JSON.parse(text) as T;
         } catch (error) {
             if (error instanceof Error) {
                 throw error;

--- a/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/create-journal-entry.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/create-journal-entry.action.ts
@@ -1,26 +1,17 @@
 import { RegisterClass } from '@memberjunction/global';
 import { QuickBooksBaseAction } from '../quickbooks-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
-import { UserInfo } from '@memberjunction/core';
 import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
+import { JournalEntryLine } from '../../../types';
+import { journalEntryBalanceError, parseAndValidateJournalEntryLines, totalDebits } from '../../../journal-entry';
 
-/**
- * Journal entry line interface
- */
-export interface JournalEntryLine {
-    accountId: string;
-    debit?: number;
-    credit?: number;
-    description?: string;
-    entityType?: 'Customer' | 'Vendor' | 'Employee';
-    entityId?: string;
-    classId?: string;
-    departmentId?: string;
-}
+export type { JournalEntryLine } from '../../../types';
 
 /**
  * Action to create a journal entry in QuickBooks Online
  */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.CreateJournalEntry, ERP_INTEGRATION.QuickBooksOnline))
 @RegisterClass(BaseAction, 'CreateQuickBooksJournalEntryAction')
 export class CreateQuickBooksJournalEntryAction extends QuickBooksBaseAction {
     
@@ -51,17 +42,15 @@ export class CreateQuickBooksJournalEntryAction extends QuickBooksBaseAction {
             const linesData = this.getParamValue(params.Params, 'Lines');
             const adjustmentEntry = this.getParamValue(params.Params, 'AdjustmentEntry') || false;
 
-            // Validate and parse lines
-            const lines = this.parseAndValidateLines(linesData);
+            const lines = parseAndValidateJournalEntryLines(linesData);
+            for (let i = 0; i < lines.length; i++) {
+                if (!lines[i].accountId) {
+                    throw new Error(`Line ${i + 1}: accountId is required for QuickBooks Online`);
+                }
+            }
 
-            // Validate journal entry balance
             if (!this.validateJournalEntryBalance(lines)) {
-                return {
-                    Success: false,
-                    ResultCode: 'VALIDATION_ERROR',
-                    Message: 'Journal entry is not balanced. Total debits must equal total credits.',
-                    Params: params.Params
-                };
+                return journalEntryBalanceError(params.Params);
             }
 
             // Build the journal entry object for QuickBooks
@@ -70,7 +59,7 @@ export class CreateQuickBooksJournalEntryAction extends QuickBooksBaseAction {
                 TxnDate: this.formatQBODate(entryDate instanceof Date ? entryDate : new Date(entryDate)),
                 PrivateNote: privateNote,
                 Adjustment: adjustmentEntry,
-                Line: lines.map((line, index) => this.mapToQBOJournalLine(line, index + 1))
+                Line: lines.map((line) => this.mapToQBOJournalLine(line))
             };
 
             // Create the journal entry in QuickBooks
@@ -97,7 +86,7 @@ export class CreateQuickBooksJournalEntryAction extends QuickBooksBaseAction {
                 },
                 {
                     Name: 'TotalAmount',
-                    Value: createdEntry.TotalAmt,
+                    Value: createdEntry.TotalAmt ?? totalDebits(lines),
                     Type: 'Output'
                 },
                 {
@@ -125,66 +114,15 @@ export class CreateQuickBooksJournalEntryAction extends QuickBooksBaseAction {
         }
     }
 
-
-    /**
-     * Parse and validate journal entry lines
-     */
-    private parseAndValidateLines(linesParam: any): JournalEntryLine[] {
-        if (!linesParam) {
-            throw new Error('Lines parameter is required');
-        }
-
-        let lines: JournalEntryLine[];
-        
-        // Handle if lines is a JSON string
-        if (typeof linesParam === 'string') {
-            try {
-                lines = JSON.parse(linesParam);
-            } catch (error) {
-                throw new Error('Invalid JSON format for Lines parameter');
-            }
-        } else {
-            lines = linesParam;
-        }
-
-        if (!Array.isArray(lines)) {
-            throw new Error('Lines must be an array');
-        }
-
-        if (lines.length < 2) {
-            throw new Error('Journal entry must have at least 2 lines');
-        }
-
-        // Validate each line
-        lines.forEach((line, index) => {
-            if (!line.accountId) {
-                throw new Error(`Line ${index + 1}: accountId is required`);
-            }
-
-            if (line.debit === undefined && line.credit === undefined) {
-                throw new Error(`Line ${index + 1}: either debit or credit amount is required`);
-            }
-
-            if (line.debit !== undefined && line.credit !== undefined) {
-                throw new Error(`Line ${index + 1}: cannot have both debit and credit on the same line`);
-            }
-
-            if (line.debit !== undefined && line.debit < 0) {
-                throw new Error(`Line ${index + 1}: debit amount cannot be negative`);
-            }
-
-            if (line.credit !== undefined && line.credit < 0) {
-                throw new Error(`Line ${index + 1}: credit amount cannot be negative`);
-            }
-        });
-
-        return lines;
-    }
-
     /**
      * Map journal entry line to QuickBooks format
      */
-    private mapToQBOJournalLine(line: JournalEntryLine, lineNumber: number): any {
+    private mapToQBOJournalLine(line: JournalEntryLine): any {
+        const classId = line.classId
+            || line.dimensions?.find(d => d.code === 'Class')?.valueCode;
+        const departmentId = line.departmentId
+            || line.dimensions?.find(d => d.code === 'Department')?.valueCode;
+
         const qbLine: any = {
             DetailType: 'JournalEntryLineDetail',
             Amount: line.debit || line.credit || 0,
@@ -196,12 +134,10 @@ export class CreateQuickBooksJournalEntryAction extends QuickBooksBaseAction {
             }
         };
 
-        // Add description if provided
         if (line.description) {
             qbLine.Description = line.description;
         }
 
-        // Add entity reference if provided
         if (line.entityType && line.entityId) {
             qbLine.JournalEntryLineDetail.Entity = {
                 Type: line.entityType,
@@ -211,17 +147,15 @@ export class CreateQuickBooksJournalEntryAction extends QuickBooksBaseAction {
             };
         }
 
-        // Add class reference if provided
-        if (line.classId) {
+        if (classId) {
             qbLine.JournalEntryLineDetail.ClassRef = {
-                value: line.classId
+                value: classId
             };
         }
 
-        // Add department reference if provided
-        if (line.departmentId) {
+        if (departmentId) {
             qbLine.JournalEntryLineDetail.DepartmentRef = {
-                value: line.departmentId
+                value: departmentId
             };
         }
 

--- a/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/get-account-balances.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/get-account-balances.action.ts
@@ -3,26 +3,10 @@ import { QuickBooksBaseAction } from '../quickbooks-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { UserInfo } from '@memberjunction/core';
 import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
+import { AccountBalance } from '../../../types';
 
-/**
- * Account balance information
- */
-export interface AccountBalance {
-    accountId: string;
-    accountCode: string;
-    accountName: string;
-    accountType: string;
-    accountSubType: string;
-    normalBalance: 'Debit' | 'Credit';
-    currentBalance: number;
-    balanceWithSubAccounts: number;
-    currency: string;
-    asOfDate: Date;
-    isActive: boolean;
-    level: number;
-    parentAccountId?: string;
-    parentAccountName?: string;
-}
+export type { AccountBalance } from '../../../types';
 
 /**
  * Trial balance summary
@@ -38,6 +22,7 @@ export interface TrialBalanceSummary {
 /**
  * Action to retrieve account balances (trial balance) from QuickBooks Online
  */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetAccountBalances, ERP_INTEGRATION.QuickBooksOnline))
 @RegisterClass(BaseAction, 'GetQuickBooksAccountBalancesAction')
 export class GetQuickBooksAccountBalancesAction extends QuickBooksBaseAction {
     

--- a/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/get-dimensions.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/get-dimensions.action.ts
@@ -1,0 +1,77 @@
+import { RegisterClass } from '@memberjunction/global';
+import { QuickBooksBaseAction } from '../quickbooks-base.action';
+import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
+import { Dimension, DimensionValue } from '../../../types';
+
+/**
+ * QuickBooks Online has no first-class dimensions API. Classes and Departments
+ * are mapped as two dimensions named `Class` and `Department`. Either (or both)
+ * may be an empty values array if the company does not use that list or the
+ * query is not available.
+ */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetDimensions, ERP_INTEGRATION.QuickBooksOnline))
+export class GetQuickBooksDimensionsAction extends QuickBooksBaseAction {
+
+    public get Description(): string {
+        return 'Retrieves Class and Department lists from QuickBooks Online as dimensions';
+    }
+
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        try {
+            const contextUser = params.ContextUser;
+            if (!contextUser) {
+                throw new Error('Context user is required for QuickBooks API calls');
+            }
+
+            (this as any)._params = params.Params;
+
+            const classValues = await this.queryDimensionValues('Class', contextUser);
+            const departmentValues = await this.queryDimensionValues('Department', contextUser);
+
+            const dimensions: Dimension[] = [
+                { code: 'Class', displayName: 'Class', values: classValues },
+                { code: 'Department', displayName: 'Department', values: departmentValues }
+            ];
+
+            const outputParams: ActionParam[] = [
+                { Name: 'Dimensions', Value: dimensions, Type: 'Output' }
+            ];
+
+            return {
+                Success: true,
+                ResultCode: 'SUCCESS',
+                Params: [...params.Params, ...outputParams],
+                Message: 'Successfully retrieved Class and Department dimensions from QuickBooks'
+            };
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+            return {
+                Success: false,
+                ResultCode: 'ERROR',
+                Message: errorMessage,
+                Params: params.Params
+            };
+        }
+    }
+
+    private async queryDimensionValues(
+        entity: 'Class' | 'Department',
+        contextUser: NonNullable<RunActionParams['ContextUser']>
+    ): Promise<DimensionValue[]> {
+        try {
+            const response = await this.queryQBO<{ QueryResponse: Record<string, any[]> }>(
+                `SELECT * FROM ${entity}`,
+                contextUser
+            );
+            const rows = response.QueryResponse?.[entity] || [];
+            return rows.map((row: any) => ({
+                code: row.FullyQualifiedName || row.Name || row.Id,
+                displayName: row.Name || row.FullyQualifiedName || row.Id
+            }));
+        } catch {
+            return [];
+        }
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/get-gl-codes.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/get-gl-codes.action.ts
@@ -3,6 +3,8 @@ import { QuickBooksBaseAction } from '../quickbooks-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { UserInfo } from '@memberjunction/core';
 import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
+import { ChartOfAccount } from '../../../types';
 
 /**
  * Interface for a GL Code (Chart of Accounts) entry
@@ -45,6 +47,7 @@ interface QBOAccount {
 /**
  * Action to retrieve the Chart of Accounts (GL Codes) from QuickBooks Online
  */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetChartOfAccounts, ERP_INTEGRATION.QuickBooksOnline))
 @RegisterClass(BaseAction, 'GetQuickBooksGLCodesAction')
 export class GetQuickBooksGLCodesAction extends QuickBooksBaseAction {
     
@@ -110,12 +113,24 @@ export class GetQuickBooksGLCodesAction extends QuickBooksBaseAction {
             // Process the results
             const accounts = response.QueryResponse?.Account || [];
             const glCodes: GLCode[] = accounts.map(account => this.mapQBOAccountToGLCode(account));
+            const chart: ChartOfAccount[] = glCodes.map(g => ({
+                id: g.id,
+                code: g.code,
+                name: g.name,
+                accountType: g.type,
+                isActive: g.active
+            }));
 
             // Set output parameters
             const outputParams: ActionParam[] = [
                 {
                     Name: 'GLCodes',
                     Value: glCodes,
+                    Type: 'Output'
+                },
+                {
+                    Name: 'Accounts',
+                    Value: chart,
                     Type: 'Output'
                 },
                 {

--- a/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/get-transactions.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/providers/quickbooks/actions/get-transactions.action.ts
@@ -2,6 +2,7 @@ import { RegisterClass } from '@memberjunction/global';
 import { QuickBooksBaseAction } from '../quickbooks-base.action';
 import { ActionParam, ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
 import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS, ERP_INTEGRATION, erpPluginKey } from '../../../constants';
 
 /**
  * Standard transaction interface
@@ -38,6 +39,7 @@ export interface TransactionLine {
 /**
  * Action to retrieve transactions from QuickBooks Online
  */
+@RegisterClass(BaseAction, erpPluginKey(ACCOUNTING_VERBS.GetGLEntries, ERP_INTEGRATION.QuickBooksOnline))
 @RegisterClass(BaseAction, 'GetQuickBooksTransactionsAction')
 export class GetQuickBooksTransactionsAction extends QuickBooksBaseAction {
     

--- a/packages/Actions/BizApps/Accounting/src/types.ts
+++ b/packages/Actions/BizApps/Accounting/src/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared shapes for ERP accounting verbs. Provider plugins may emit extra
+ * fields; callers of the verb set should rely on these.
+ */
+
+export interface JournalEntryLine {
+    /** Provider account id (QBO Account.Id / BC accountId). */
+    accountId?: string;
+    /** ERP account number — preferred when posting (AM-4). */
+    accountNumber?: string;
+    debit?: number;
+    credit?: number;
+    description?: string;
+    dimensions?: Array<{ code: string; valueCode: string }>;
+    entityType?: 'Customer' | 'Vendor' | 'Employee';
+    entityId?: string;
+    classId?: string;
+    departmentId?: string;
+}
+
+export interface ChartOfAccount {
+    id: string;
+    code: string;
+    name: string;
+    accountType: string;
+    isActive: boolean;
+}
+
+export interface AccountBalance {
+    accountId: string;
+    accountCode: string;
+    accountName: string;
+    accountType: string;
+    accountSubType?: string;
+    normalBalance?: 'Debit' | 'Credit';
+    currentBalance: number;
+    balanceWithSubAccounts?: number;
+    currency?: string;
+    asOfDate: Date;
+    isActive?: boolean;
+    level?: number;
+    parentAccountId?: string;
+    parentAccountName?: string;
+}
+
+export interface DimensionValue {
+    code: string;
+    displayName: string;
+}
+
+export interface Dimension {
+    code: string;
+    displayName: string;
+    values: DimensionValue[];
+}
+
+export interface ResolvedAccountingIntegration {
+    /** Integration.Name — the ERP vendor string used in plugin keys. */
+    Name: string;
+    CompanyIntegrationID: string;
+    CompanyID: string;
+    IntegrationID: string;
+}

--- a/packages/Actions/BizApps/Accounting/src/verbs/create-journal-entry.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/verbs/create-journal-entry.action.ts
@@ -1,0 +1,13 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS } from '../constants';
+import { AccountingVerbDispatcher } from './verb-dispatcher';
+
+@RegisterClass(BaseAction, ACCOUNTING_VERBS.CreateJournalEntry)
+export class CreateJournalEntryAction extends AccountingVerbDispatcher {
+    protected readonly verb = ACCOUNTING_VERBS.CreateJournalEntry;
+
+    public get Description(): string {
+        return 'Posts a balanced journal entry to the company\'s ERP. Dispatches to the plugin for the company\'s accounting integration.';
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/verbs/get-account-balances.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/verbs/get-account-balances.action.ts
@@ -1,0 +1,13 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS } from '../constants';
+import { AccountingVerbDispatcher } from './verb-dispatcher';
+
+@RegisterClass(BaseAction, ACCOUNTING_VERBS.GetAccountBalances)
+export class GetAccountBalancesAction extends AccountingVerbDispatcher {
+    protected readonly verb = ACCOUNTING_VERBS.GetAccountBalances;
+
+    public get Description(): string {
+        return 'Retrieves account balances from the company\'s ERP as of a given date.';
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/verbs/get-chart-of-accounts.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/verbs/get-chart-of-accounts.action.ts
@@ -1,0 +1,13 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS } from '../constants';
+import { AccountingVerbDispatcher } from './verb-dispatcher';
+
+@RegisterClass(BaseAction, ACCOUNTING_VERBS.GetChartOfAccounts)
+export class GetChartOfAccountsAction extends AccountingVerbDispatcher {
+    protected readonly verb = ACCOUNTING_VERBS.GetChartOfAccounts;
+
+    public get Description(): string {
+        return 'Retrieves the chart of accounts from the company\'s ERP.';
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/verbs/get-customers.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/verbs/get-customers.action.ts
@@ -1,0 +1,13 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS } from '../constants';
+import { AccountingVerbDispatcher } from './verb-dispatcher';
+
+@RegisterClass(BaseAction, ACCOUNTING_VERBS.GetCustomers)
+export class GetCustomersAction extends AccountingVerbDispatcher {
+    protected readonly verb = ACCOUNTING_VERBS.GetCustomers;
+
+    public get Description(): string {
+        return 'Retrieves customers from the company\'s ERP.';
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/verbs/get-dimensions.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/verbs/get-dimensions.action.ts
@@ -1,0 +1,13 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS } from '../constants';
+import { AccountingVerbDispatcher } from './verb-dispatcher';
+
+@RegisterClass(BaseAction, ACCOUNTING_VERBS.GetDimensions)
+export class GetDimensionsAction extends AccountingVerbDispatcher {
+    protected readonly verb = ACCOUNTING_VERBS.GetDimensions;
+
+    public get Description(): string {
+        return 'Retrieves dimensions and dimension values from the company\'s ERP.';
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/verbs/get-gl-entries.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/verbs/get-gl-entries.action.ts
@@ -1,0 +1,13 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS } from '../constants';
+import { AccountingVerbDispatcher } from './verb-dispatcher';
+
+@RegisterClass(BaseAction, ACCOUNTING_VERBS.GetGLEntries)
+export class GetGLEntriesAction extends AccountingVerbDispatcher {
+    protected readonly verb = ACCOUNTING_VERBS.GetGLEntries;
+
+    public get Description(): string {
+        return 'Retrieves general ledger entries / transactions from the company\'s ERP.';
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/verbs/get-sales-invoices.action.ts
+++ b/packages/Actions/BizApps/Accounting/src/verbs/get-sales-invoices.action.ts
@@ -1,0 +1,13 @@
+import { RegisterClass } from '@memberjunction/global';
+import { BaseAction } from '@memberjunction/actions';
+import { ACCOUNTING_VERBS } from '../constants';
+import { AccountingVerbDispatcher } from './verb-dispatcher';
+
+@RegisterClass(BaseAction, ACCOUNTING_VERBS.GetSalesInvoices)
+export class GetSalesInvoicesAction extends AccountingVerbDispatcher {
+    protected readonly verb = ACCOUNTING_VERBS.GetSalesInvoices;
+
+    public get Description(): string {
+        return 'Retrieves sales invoices from the company\'s ERP.';
+    }
+}

--- a/packages/Actions/BizApps/Accounting/src/verbs/verb-dispatcher.ts
+++ b/packages/Actions/BizApps/Accounting/src/verbs/verb-dispatcher.ts
@@ -1,0 +1,17 @@
+import { ActionResultSimple, RunActionParams } from '@memberjunction/actions-base';
+import { BaseAccountingAction } from '../base/base-accounting-action';
+
+/**
+ * Dispatcher for one accounting verb. Callers/agents use the verb name;
+ * this class loads the company's ERP integration and forwards to the plugin.
+ */
+export abstract class AccountingVerbDispatcher extends BaseAccountingAction {
+    protected accountingProvider = 'ERP';
+    protected integrationName = '';
+
+    protected abstract readonly verb: string;
+
+    protected async InternalRunAction(params: RunActionParams): Promise<ActionResultSimple> {
+        return this.dispatchVerb(this.verb, params);
+    }
+}

--- a/packages/SQLConverter/src/__tests__/CreateTableRule.test.ts
+++ b/packages/SQLConverter/src/__tests__/CreateTableRule.test.ts
@@ -322,4 +322,20 @@ describe('CreateTableRule', () => {
       expect(result).not.toContain('"pk_payment"');
     });
   });
+
+  describe('JSON CHECK constraints', () => {
+    it('should convert ISJSON(col) = 1 to (col) IS JSON after identifier quoting', () => {
+      const sql = `CREATE TABLE [__mj_BizAppsAccounting].[AccountingEngineExtension] (
+  [ID] UNIQUEIDENTIFIER NOT NULL,
+  [Configuration] NVARCHAR(MAX) NULL,
+  CONSTRAINT CK_AccountingEngineExtension_Configuration CHECK (
+    Configuration IS NULL OR ISJSON(Configuration) = 1
+  )
+)`;
+      const result = convert(sql);
+      expect(result).toMatch(/IS JSON/);
+      expect(result).not.toMatch(/"ISJSON"/);
+      expect(result).not.toMatch(/\bISJSON\s*\(/i);
+    });
+  });
 });

--- a/packages/SQLConverter/src/rules/CreateTableRule.ts
+++ b/packages/SQLConverter/src/rules/CreateTableRule.ts
@@ -6,7 +6,7 @@
  * Also tracks column types in ConversionContext for downstream INSERT boolean casting.
  */
 import type { IConversionRule, ConversionContext, StatementType } from './types.js';
-import { convertIdentifiers, removeCollate, removeNPrefix, QuoteConstraintNames } from './ExpressionHelpers.js';
+import { convertIdentifiers, removeCollate, removeNPrefix, QuoteConstraintNames, convertJsonFunctions } from './ExpressionHelpers.js';
 
 export class CreateTableRule implements IConversionRule {
   Name = 'CreateTableRule';
@@ -59,6 +59,11 @@ export class CreateTableRule implements IConversionRule {
     // Phase 5a: Quote unquoted PascalCase column names (AFTER type conversion
     // and AFTER CLUSTERED removal so the PK regex matches correctly)
     result = this.quoteColumnDefinitions(result);
+
+    // After identifier quoting, ISJSON(col) = 1 in a CHECK body becomes
+    // "ISJSON"(col) = 1, which is not a PG function. convertJsonFunctions
+    // accepts both bare and quoted forms.
+    result = convertJsonFunctions(result);
 
     // Remove ON [PRIMARY] / ON "PRIMARY" filegroup clause
     result = result.replace(/\)\s*ON\s+\[?PRIMARY\]?\s*;?/gi, ');');


### PR DESCRIPTION
## Summary

Wave 1 of 3: **MJ (this)** → [MemberJunction/bizapps-accounting](https://github.com/MemberJunction/bizapps-accounting) (engine + `AccountingEngineExtension`) → [MemberJunction/bizapps-fpna](https://github.com/MemberJunction/bizapps-fpna) (`ImportBankAccountBalances`).

Accounting is a subledger, not the GL. This package is **stateless ERP verbs** — HTTP plus trivial validation. It does not upsert `GLAccount`, flip journal-entry batch status, or write `CashBalance`. Zero knowledge of bizapps-accounting.

Callers and agents use the **verb name**, never the vendor class name. Each verb is a dispatcher on `BaseAction` that:

1. Reads `CompanyID`
2. Loads the company's accounting `CompanyIntegration` (Integration.Name in `QuickBooks Online` / `Microsoft Dynamics 365 Business Central`)
3. `ClassFactory.TryCreateInstance(BaseAction, \`${verb}:${integration.Name}\`)`
4. Forwards the same params to the plugin (`Run` → `InternalRunAction`)

Missing plugin → `PROVIDER_NOT_REGISTERED`.

### Verbs / plugins

| Verb | QBO | BC |
|---|---|---|
| `GetChartOfAccounts` | existing GL codes + shared `Accounts` | existing GL accounts + shared `Accounts` |
| `GetAccountBalances` | existing | **new** (`accountCode` = account number) |
| `CreateJournalEntry` | existing | **new** (journalLines then `Microsoft.NAV.post`) |
| `GetDimensions` | **new** (Class + Department; QBO has no first-class dimensions API) | **new** (`dimensions` + `dimensionValues`) |
| `GetGLEntries` | existing transactions | existing GL entries |
| `GetCustomers` | — | existing wrap |
| `GetSalesInvoices` | — | existing wrap |

Historical RegisterClass keys still resolve (`CreateQuickBooksJournalEntryAction`, `GetBusinessCentralGLAccountsAction`, …). A class may carry two `@RegisterClass` keys (verb plugin + old name).

Shared `JournalEntryLine` accepts `accountNumber` (preferred, AM-4) or `accountId` (QBO still uses `accountId` internally). Unbalanced lines → `VALIDATION_ERROR`.

Also: SQLConverter now converts `ISJSON(col) = 1` in CREATE TABLE CHECK bodies to `(col) IS JSON` after identifier quoting, which unblocks the accounting `AccountingEngineExtension` PG migration.

Plan: [erp-provider-layer.md](https://github.com/MemberJunction/bizapps-accounting/blob/next/plans/erp-provider-layer.md) / accounting PR https://github.com/MemberJunction/bizapps-accounting/pull/126

Exploratory prototypes (leave open): https://github.com/MemberJunction/bizapps-accounting/pull/74, https://github.com/MemberJunction/bizapps-accounting/pull/112

## Test plan

- [x] `cd packages/Actions/BizApps/Accounting && pnpm test` — 61 passing
- [x] `CreateJournalEntry` dispatcher: missing provider → `PROVIDER_NOT_REGISTERED`
- [x] QBO plugin still POSTs `journalentry` when Integration.Name is QuickBooks Online
- [x] Unbalanced QBO/BC journal → `VALIDATION_ERROR`
- [x] BC CreateJournalEntry balanced path: GET journals → POST journalLines → POST `Microsoft.NAV.post` (spy call order)
- [x] BC GetAccountBalances maps account number → `accountCode`
- [x] BC GetDimensions maps dimensions + values
- [x] Old RegisterClass keys still constructable
- [x] SQLConverter CreateTableRule: `ISJSON(Configuration) = 1` → `IS JSON`, not `"ISJSON"`
- [x] Both packages `pnpm run build`
- [ ] Review README mermaid + “add a new ERP” section as a first-time plugin author
- [ ] Wave 2 (bizapps-accounting engine) consumes these verb names, not vendor class names