### PR TITLE
fix(codegen,tests): make two silent failures loud — manifest generator + UR13 race

### DIFF
--- a/.changeset/manifest-guard-and-ur13-race.md
+++ b/.changeset/manifest-guard-and-ur13-race.md
@@ -1,0 +1,26 @@
+---
+"@memberjunction/codegen-lib": patch
+"@memberjunction/integration-test-suite": patch
+---
+
+Two silent failures made loud: the manifest generator's unbuilt-package fallback, and UR13's race with the live routine dispatcher.
+
+**The manifest generator no longer guesses when a lazy package hasn't been built.** `resolveSubpathExportsDetailed()` resolves a package's lazy-loading subpaths by reading the `.d.ts` each `exports` entry's `types` field names, and skips any it cannot find. On an unbuilt workspace it finds none, returns an empty map, and the package falls through to the whole-package branch of `groupClassesIntoChunks()` — which replaces its per-subpath lazy chunks with one eager chunk. The result is valid TypeScript that compiles and passes review with its code splitting quietly removed. Running `mj codegen manifest` against an unbuilt tree collapsed `ng-dashboards`' twelve per-dashboard chunks into a single import and deleted 254 lines from `lazy-feature-config.ts` without a single warning.
+
+`resolveLazySubpathExports()` now throws instead, naming the package and the directory it searched.
+
+The guard is deliberately narrow, because "declares subpaths that didn't resolve" is a much weaker signal than it first appears — two innocent cases produce it:
+
+- Every ng-packagr output publishes `"./package.json": { "default": "./package.json" }`, an entry with no `types` field that resolution skips by design. Only entries carrying `types` are counted.
+- A subpath whose `.d.ts` declares no classes is skipped exactly like a missing one. `BootstrapLite`'s `./mj-class-registrations` is a real example — a generated manifest of const arrays, built and present, with nothing to reach.
+
+So the check fires only for a package that actually **contributes lazy classes**, since that is the only case where an empty map mis-groups anything. A package contributing no classes has nothing to lose to the fallback.
+
+**UR13 no longer races the product it is testing.** The check asserted an exact global run-row count for a routine that the shipped `User Routine Dispatcher` scheduled job — `Status=Active`, per-minute cron — is equally entitled to claim. `ConcurrencyMode=Skip` cannot prevent the overlap: it serialises *scheduled* runs against each other, while the check constructs a driver in-process against a fabricated `MJScheduledJobEntity` that is never saved, so the engine cannot see it. The scheduler polls on a timer anchored to MJAPI's boot rather than to the wall clock, so whether a sweep lands inside the bundle's ~3-second window varies run to run — which is why this failed on `next` after a slow boot with no relevant code change.
+
+It now snapshots the run rows before the pass and asserts on the delta, which is strictly stronger than what it replaced:
+
+- `Details.RoutinesRun === 1` states the no-double-run property directly against *our* sweep, where it is deterministic, rather than inferring it from a row count anyone may write to.
+- Every new run row must satisfy the OnChange contract, not just the one at index 1 — all of them replay the same expression, so the property has to hold for each regardless of which dispatcher produced it.
+
+`UR11` and `UR14` share the same exposure and are left alone here; they are not currently failing, and the durable fix for them is a fixture-level decision (pausing the live dispatcher for the bundle) that belongs to the suite's owner.

--- a/packages/CodeGenLib/src/Manifest/GenerateClassRegistrationsManifest.ts
+++ b/packages/CodeGenLib/src/Manifest/GenerateClassRegistrationsManifest.ts
@@ -1385,6 +1385,78 @@ export function resolveSubpathExports(packageDir: string): Map<string, Set<strin
 }
 
 /**
+ * Count the subpath exports that resolution is actually *expected* to satisfy: non-`.` entries
+ * carrying a `types` field.
+ *
+ * This is deliberately narrower than {@link hasSubpathExports}, which answers "is there any key
+ * besides `.`" and therefore counts entries that were never code subpaths at all. A built Angular
+ * package publishes `"./package.json": { "default": "./package.json" }`, which has no `types` and
+ * which `resolveSubpathExportsDetailed()` skips by design. Treating that as a declared-but-missing
+ * subpath would flag every ng-packagr output as unbuilt.
+ */
+function countTypedSubpathExports(packageDir: string): number {
+    const pkgPath = path.join(packageDir, 'package.json');
+    if (!fs.existsSync(pkgPath)) return 0;
+
+    let pkg: Record<string, unknown>;
+    try {
+        pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    } catch {
+        return 0;
+    }
+
+    const exports = pkg.exports as Record<string, Record<string, string> | string> | undefined;
+    if (!exports || typeof exports !== 'object') return 0;
+
+    let count = 0;
+    for (const [subpath, entry] of Object.entries(exports)) {
+        if (subpath === '.') continue;
+        const typesField = typeof entry === 'object' && entry !== null ? entry.types : undefined;
+        if (typesField) count++;
+    }
+    return count;
+}
+
+/**
+ * Resolve a lazy package's subpath exports, refusing to answer "none" when the package
+ * declares typed subpaths it simply hasn't built yet.
+ *
+ * **Call this only for a package that contributes lazy classes.** `resolveSubpathExportsDetailed()`
+ * reads the `.d.ts` each `exports` entry's `types` field names and records the subpath only if
+ * classes are reachable from it, so an empty result is perfectly ordinary in two innocent cases:
+ * a subpath whose `.d.ts` declares no classes, and a package with no code subpaths at all. Neither
+ * is a problem when there are no classes to group.
+ *
+ * With classes present it is a different matter. An empty map sends every one of them down the
+ * whole-package branch of `groupClassesIntoChunks()`, replacing the package's per-subpath lazy
+ * chunks with a SINGLE eager chunk. The emitted config is still valid TypeScript, still compiles,
+ * still passes review — it has just had its code splitting deleted, and nothing downstream can
+ * tell the difference.
+ *
+ * So refuse. A missing build is recoverable in one command; a silently de-optimised bundle
+ * shipped to production is not.
+ *
+ * @throws when `packageDir` declares typed subpath exports but none of them resolve.
+ */
+export function resolveLazySubpathExports(packageName: string, packageDir: string): Map<string, SubpathExportInfo> {
+    const subpaths = resolveSubpathExportsDetailed(packageDir);
+    if (subpaths.size === 0) {
+        const declared = countTypedSubpathExports(packageDir);
+        if (declared > 0) {
+            throw new Error(
+                `Cannot resolve the subpath exports of '${packageName}'. Its package.json declares ${declared} ` +
+                `subpath export(s) with a "types" target, but none of those targets exist under ${packageDir} — ` +
+                `the package has not been built.\n\n` +
+                `Build the workspace before generating the manifest. Emitting a manifest from here would ` +
+                `silently collapse this package's per-subpath lazy chunks into one eager import, removing ` +
+                `its code splitting without failing anything.`
+            );
+        }
+    }
+    return subpaths;
+}
+
+/**
  * Detailed version that also returns the .d.ts file path where each class was found.
  * Used by the lazy config generator to disambiguate classes with the same name
  * that appear in different subpath modules.
@@ -1619,10 +1691,21 @@ function groupClassesIntoChunks(
     lazyPackages: Map<string, string>,
     log: (msg: string) => void
 ): LazyChunk[] {
-    // Build detailed subpath export maps (including .d.ts file paths for disambiguation)
+    // Build detailed subpath export maps (including .d.ts file paths for disambiguation).
+    //
+    // Only packages that actually CONTRIBUTE lazy classes are guarded. An unresolved subpath map
+    // is harmful precisely when there are classes to mis-group: those classes fall through to the
+    // whole-package branch below and the package's per-subpath lazy chunks silently become one
+    // eager chunk. For a package contributing no classes the same fallback groups nothing, so an
+    // empty map is not evidence of anything — and it is a completely ordinary state, since a
+    // subpath whose .d.ts declares no classes (a generated manifest of const arrays, say) is
+    // skipped by resolution exactly like a missing one.
+    const packagesWithLazyClasses = new Set(lazyClasses.map(c => c.packageName));
     const packageSubpaths = new Map<string, Map<string, SubpathExportInfo>>();
     for (const [depName, depDir] of lazyPackages.entries()) {
-        const subpaths = resolveSubpathExportsDetailed(depDir);
+        const subpaths = packagesWithLazyClasses.has(depName)
+            ? resolveLazySubpathExports(depName, depDir)
+            : resolveSubpathExportsDetailed(depDir);
         if (subpaths.size > 0) {
             packageSubpaths.set(depName, subpaths);
         }

--- a/packages/CodeGenLib/src/__tests__/manifest.test.ts
+++ b/packages/CodeGenLib/src/__tests__/manifest.test.ts
@@ -3,7 +3,7 @@ import ts from 'typescript';
 import * as fs from 'fs';
 import * as path from 'path';
 import { glob } from 'glob';
-import { generateClassRegistrationsManifest, resolveSubpathExports } from '../Manifest/GenerateClassRegistrationsManifest';
+import { generateClassRegistrationsManifest, resolveSubpathExports, resolveLazySubpathExports } from '../Manifest/GenerateClassRegistrationsManifest';
 
 // We test the pure functions from the manifest generator by importing via a module-level mock setup.
 // Many functions in the manifest generator are module-private, but we can test the exported types
@@ -1564,5 +1564,118 @@ describe('generateClassRegistrationsManifest - RegisterClassEx decorator', () =>
         expect(result.classes.map(c => c.className).sort()).toEqual(['DistOptionsBagPanel', 'DistPositionalPanel']);
         expect(result.classes.find(c => c.className === 'DistOptionsBagPanel')!.key).toBe('dist-options-bag');
         expect(result.classes.find(c => c.className === 'DistOptionsBagPanel')!.baseClassName).toBe('BaseFormPanel');
+    });
+});
+
+// ---------------------------------------------------------------------------------------
+// A package that DECLARES subpath exports but has not been built used to resolve to "no
+// subpaths", which is indistinguishable from a package that genuinely has none — and sends it
+// down the whole-package branch, collapsing its per-subpath lazy chunks into one eager import.
+// The emitted config still compiles, so nothing downstream catches it. These pin the refusal.
+// ---------------------------------------------------------------------------------------
+describe('Manifest Generator - lazy subpath resolution refuses to guess', () => {
+    const PKG_DIR = '/repo/packages/Angular/Explorer/dashboards';
+
+    /** Route existsSync/readFileSync by path: package.json present, every .d.ts absent unless listed. */
+    function mockPackage(packageJson: Record<string, unknown>, presentDtsFiles: string[] = []): void {
+        const present = new Set(presentDtsFiles);
+        vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+            const s = String(p);
+            if (s.endsWith('package.json')) return true;
+            return present.has(s);
+        });
+        vi.mocked(fs.readFileSync).mockImplementation(((p: fs.PathOrFileDescriptor) => {
+            const s = String(p);
+            if (s.endsWith('package.json')) return JSON.stringify(packageJson);
+            return 'export declare class Whatever {}';
+        }) as unknown as typeof fs.readFileSync);
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('throws when subpath exports are declared but none of their .d.ts targets exist', () => {
+        mockPackage({
+            name: '@memberjunction/ng-dashboards',
+            exports: {
+                '.': { types: './dist/index.d.ts', default: './dist/index.js' },
+                './core-dashboards.module': { types: './dist/core-dashboards.module.d.ts', default: './dist/core-dashboards.module.js' },
+                './ai-dashboards.module': { types: './dist/ai-dashboards.module.d.ts', default: './dist/ai-dashboards.module.js' }
+            }
+        });
+
+        expect(() => resolveLazySubpathExports('@memberjunction/ng-dashboards', PKG_DIR)).toThrow(/has not been built/);
+    });
+
+    it('names the package and the directory it looked in, so the message is actionable', () => {
+        mockPackage({
+            exports: {
+                '.': { types: './dist/index.d.ts' },
+                './core-dashboards.module': { types: './dist/core-dashboards.module.d.ts' }
+            }
+        });
+
+        expect(() => resolveLazySubpathExports('@memberjunction/ng-dashboards', PKG_DIR))
+            .toThrow(/@memberjunction\/ng-dashboards/);
+        expect(() => resolveLazySubpathExports('@memberjunction/ng-dashboards', PKG_DIR))
+            .toThrow(new RegExp(PKG_DIR.replace(/\//g, '\\/')));
+    });
+
+    it('does NOT throw for a package that legitimately declares no subpath exports', () => {
+        mockPackage({ name: '@memberjunction/ng-shared', exports: { '.': { types: './dist/index.d.ts' } } });
+
+        expect(() => resolveLazySubpathExports('@memberjunction/ng-shared', PKG_DIR)).not.toThrow();
+        expect(resolveLazySubpathExports('@memberjunction/ng-shared', PKG_DIR).size).toBe(0);
+    });
+
+    it('does NOT throw for a package with no exports field at all', () => {
+        mockPackage({ name: '@memberjunction/legacy', main: './dist/index.js' });
+
+        expect(() => resolveLazySubpathExports('@memberjunction/legacy', PKG_DIR)).not.toThrow();
+    });
+
+    // Regression: the first cut of this guard asked "is there any key besides '.'", which is true
+    // for every ng-packagr output — they all publish `"./package.json"`, an entry with no `types`
+    // field that resolution skips by design. That flagged built Angular packages as unbuilt and
+    // broke lazy-config generation outright. The guard must count only entries carrying `types`.
+    it('does NOT throw for a built ng-packagr output whose only extra export is ./package.json', () => {
+        mockPackage({
+            name: '@memberjunction/ng-bootstrap',
+            exports: {
+                './package.json': { default: './package.json' },
+                '.': { types: './types/memberjunction-ng-bootstrap.d.ts', default: './fesm2022/memberjunction-ng-bootstrap.mjs' }
+            }
+        });
+
+        expect(() => resolveLazySubpathExports('@memberjunction/ng-bootstrap', PKG_DIR)).not.toThrow();
+    });
+
+    it('does NOT throw when the only extra exports are untyped, however many there are', () => {
+        mockPackage({
+            name: '@memberjunction/whatever',
+            exports: {
+                '.': { types: './dist/index.d.ts' },
+                './package.json': { default: './package.json' },
+                './styles.css': { default: './dist/styles.css' }
+            }
+        });
+
+        expect(() => resolveLazySubpathExports('@memberjunction/whatever', PKG_DIR)).not.toThrow();
+    });
+
+    it('does NOT throw once the package is built — the subpaths resolve', () => {
+        mockPackage(
+            {
+                name: '@memberjunction/ng-dashboards',
+                exports: {
+                    '.': { types: './dist/index.d.ts' },
+                    './core-dashboards.module': { types: './dist/core-dashboards.module.d.ts' }
+                }
+            },
+            [path.resolve(PKG_DIR, './dist/core-dashboards.module.d.ts')]
+        );
+
+        expect(() => resolveLazySubpathExports('@memberjunction/ng-dashboards', PKG_DIR)).not.toThrow();
     });
 });

--- a/packages/TestingFramework/integration-test-suite/src/checks/user-routines.checks.ts
+++ b/packages/TestingFramework/integration-test-suite/src/checks/user-routines.checks.ts
@@ -388,24 +388,46 @@ export const UserRoutinesChecks: NamedCheck[] = [
             f.RoutineDue!.NotifyCondition = 'OnChange';
             Assert(await f.RoutineDue!.Save(), `re-arming the routine failed: ${f.RoutineDue!.LatestResult?.CompleteMessage}`);
 
+            // Snapshot the run rows that exist BEFORE this pass, and assert on the DELTA.
+            //
+            // The shipped "User Routine Dispatcher" scheduled job is Active with a per-minute cron,
+            // so from the moment the Save above makes this routine due, the live sweep inside MJAPI
+            // is entitled to claim it too. ConcurrencyMode=Skip does not prevent that: it serialises
+            // SCHEDULED runs against each other, and the driver below is constructed in-process
+            // against a fabricated MJScheduledJobEntity that is never saved, so the engine cannot
+            // see it. A global count assertion here is therefore a race against the product, and it
+            // resolves differently depending on where MJAPI's poll tick — anchored to boot time,
+            // not to the wall clock — happens to land inside this bundle's ~3 second window.
+            const before = new Set((await fetchRuns(f.RoutineDue!.ID, user)).map(r => String(r.ID)));
+
             const driver = new UserRoutineDispatcherDriver();
             const result = await driver.Execute(await makeDispatcherContext(ctx));
             Assert(result.Success, `second dispatcher sweep failed: ${result.ErrorMessage}`);
+            // The property the old exact-count assertion was really protecting — that a sweep does
+            // not double-run a routine it claimed — stated directly against OUR sweep, where it is
+            // deterministic, instead of inferred from a row count anyone else may also write to.
+            AssertEqual(Number(result.Details?.RoutinesRun), 1, 'this sweep must claim and run the routine exactly once');
 
             const runs = await fetchRuns(f.RoutineDue!.ID, user);
-            AssertEqual(runs.length, 2, 'a second run row exists after the second pass');
-            const secondRun = runs[1];
-            AssertEqual(String(secondRun.Status), 'Success', `second run status (error: ${secondRun.ErrorMessage ?? 'none'})`);
-            AssertEqual(String(secondRun.ResultHash), String(runs[0].ResultHash), 'identical expression must produce an identical hash');
-            AssertEqual(secondRun.NotificationSent, false, 'OnChange with an unchanged hash must NOT notify');
+            const newRuns = runs.filter(r => !before.has(String(r.ID)));
+            Assert(newRuns.length >= 1, `the second pass must produce at least one run row (got ${newRuns.length})`);
 
-            const notifications = await new RunView().RunView({
-                EntityName: 'MJ: User Notifications',
-                ExtraFilter: `UserID='${user.ID}' AND ResourceConfiguration LIKE '%${String(secondRun.ID)}%'`,
-                ResultType: 'simple',
-                BypassCache: true,
-            }, user);
-            AssertEqual(notifications.Results.length, 0, 'no notification row for the unchanged second run');
+            // Every run in this window replays the same expression against the same data, so the
+            // OnChange contract has to hold for ALL of them regardless of which dispatcher produced
+            // each one. Checking every new row is strictly stronger than checking the one at index 1.
+            for (const run of newRuns) {
+                AssertEqual(String(run.Status), 'Success', `second run status (error: ${run.ErrorMessage ?? 'none'})`);
+                AssertEqual(String(run.ResultHash), String(runs[0].ResultHash), 'identical expression must produce an identical hash');
+                AssertEqual(run.NotificationSent, false, 'OnChange with an unchanged hash must NOT notify');
+
+                const notifications = await new RunView().RunView({
+                    EntityName: 'MJ: User Notifications',
+                    ExtraFilter: `UserID='${user.ID}' AND ResourceConfiguration LIKE '%${String(run.ID)}%'`,
+                    ResultType: 'simple',
+                    BypassCache: true,
+                }, user);
+                AssertEqual(notifications.Results.length, 0, 'no notification row for the unchanged second run');
+            }
         }
     },
     {


### PR DESCRIPTION
Two failures that were invisible by construction. Both were found while preparing #4105, and both cost real time there before being understood.

Independent of #4105 — that PR is regenerated output, this one is generator logic and a test fix. #4105 should land first since it unblocks `Build`.

## 1. The manifest generator guessed when a lazy package wasn't built

`resolveSubpathExportsDetailed()` resolves a package's lazy-loading subpaths by reading the `.d.ts` that each `exports` entry's `types` field names, and `continue`s past any it cannot find. Against an unbuilt workspace it finds none, returns an empty map, and the package falls through to the whole-package branch of `groupClassesIntoChunks()` — which replaces its per-subpath lazy chunks with a **single eager chunk**.

The output is valid TypeScript. It compiles. It passes review. It has simply had its code splitting removed. Running `mj codegen manifest` against an unbuilt tree collapsed `ng-dashboards`' twelve per-dashboard chunks into one import and deleted 254 lines from `lazy-feature-config.ts` — with no warning, no error, and a plausible-looking diff.

`resolveLazySubpathExports()` now throws, naming the package and the directory it searched.

**The guard is narrow on purpose.** My first two attempts at it were wrong, and each false positive taught something worth keeping in the code:

- **Every ng-packagr output publishes `"./package.json": { "default": "./package.json" }`** — an entry with no `types` field that resolution skips by design. A guard asking "is there any key besides `.`" flags every built Angular package as unbuilt. Only entries carrying `types` are counted.
- **A subpath whose `.d.ts` declares no classes is skipped exactly like a missing one.** `BootstrapLite`'s `./mj-class-registrations` is a real, built, present example — a generated manifest of const arrays with no classes to reach.

So the check fires only for a package that actually **contributes lazy classes**, because that is the only case where an empty map mis-groups anything. A package contributing nothing has nothing to lose to the fallback.

Verified against the real workspace in all three states:

| scenario | result |
|---|---|
| fully built | generation succeeds, `Lazy config unchanged` |
| `ng-dashboards/dist` removed | **fails loudly**, names `ng-dashboards` and the path |
| restored | succeeds again |

The middle row is the exact scenario that silently deleted 254 lines.

## 2. UR13 raced the product it was testing

The check asserted an exact global run-row count for a routine that the shipped `User Routine Dispatcher` scheduled job — `Status=Active`, cron `0 * * * * *` — is equally entitled to claim.

`ConcurrencyMode=Skip` cannot prevent the overlap. It serialises *scheduled* runs against each other, while the check builds a `UserRoutineDispatcherDriver` in-process and hands it a fabricated `MJScheduledJobEntity` that is never saved — so the engine has no idea a sweep is in flight. The engine polls via `setTimeout(poll, ActivePollingInterval ?? 60_000)`, a phase anchored to MJAPI's boot rather than to the wall clock, so whether a sweep lands inside the bundle's ~3-second window varies run to run.

That is why this failed on `next` at `919bb9064a` — a merge containing nothing but an Angular connectivity-banner fix — while passing at `b4c4c7b15e` an hour earlier. MJAPI booted abnormally slowly on that run (it tripped the `failed to boot within 3 minutes` branch), which shifted the poll phase into the test window.

The check now snapshots run rows before the pass and asserts on the delta. This is **stronger** than what it replaced, not weaker:

- `Details.RoutinesRun === 1` states the no-double-run property directly against *our own* sweep, where it is deterministic — rather than inferring it from a global row count that anything may write to.
- Every new run row must satisfy the OnChange contract, not just the one at index 1. All of them replay the same expression against the same data, so the property has to hold for each, whichever dispatcher produced it.

`UR11` and `UR14` share the exposure and are deliberately untouched: they are not currently failing, and the durable fix for them is a fixture-level decision — pausing the live dispatcher for the bundle's duration — that belongs to the suite's owner rather than to this PR.

## Not included: the shard matrix "bug"

I flagged `Unit tests (shard ${{ matrix.shard.index }}/${{ matrix.shard.total }})` skipping with an unexpanded expression on `next` as a third defect. **It isn't one**, and there is nothing to fix.

That job's matrix comes from `needs.build.outputs.shards`. When `Build` fails, the output is empty, the matrix job is skipped, and GitHub renders the name without a matrix context to expand it against. On the most recent run where `Build` succeeded, all six shards ran with fully expanded names (`Unit tests (shard 1/6)` … `6/6`). No configuration change would alter that rendering.

## Verification

| check | result |
|---|---|
| Build (`codegen-lib`, `integration-test-suite`) | `153 successful, 153 total` |
| `@memberjunction/codegen-lib` tests | **1255 passed**, 66 skipped |
| `@memberjunction/integration-test-suite` tests | **200 passed** |
| Manifest generator, built workspace | generation succeeds, no output churn |
| Manifest generator, unbuilt lazy package | fails loudly and names it |

7 new unit tests cover the throw, the message naming the package and directory, and the four cases that must **not** throw — no subpath exports, no `exports` field, an ng-packagr `./package.json` entry, and untyped extra entries.

The deterministic integration tier was not run here (it needs SQL Server and a booted MJAPI), so UR13's fix is verified by construction and by the suite's own unit tests rather than by an observed green run. It is worth watching across a few merges, since the failure it addresses is intermittent by nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
