### PR TITLE
fix(ng-explorer-core): regenerate the lazy-feature manifest for archiving dashboards

### DIFF
--- a/.changeset/lazy-manifest-archiving.md
+++ b/.changeset/lazy-manifest-archiving.md
@@ -1,0 +1,18 @@
+---
+"@memberjunction/ng-explorer-core": patch
+---
+
+Regenerate the lazy-feature manifest for the archiving dashboards subpath (#3988 follow-up)
+
+#3988 added the `./archiving-dashboards.module` subpath export to `@memberjunction/ng-dashboards` —
+that was the fix, the module had been unreachable. Making it reachable moves its two registered
+classes into their own lazy chunk, so `lazy-feature-config.ts` had to be regenerated and was not.
+
+`ArchiveConfigResource` and `ArchiveRunsResource` now resolve through
+`archiving-dashboards.module` instead of the catch-all `./module`; the total entry count is
+unchanged at 118 because this is a relocation, not an addition. Without it the committed manifest
+points those two at a chunk that no longer declares them, which is precisely the shape that lets
+tree-shaking drop a registered class from a bundled app.
+
+The PR-scoped CI path does not regenerate manifests (`npx turbo run build` skips the root
+postbuild), so this class of staleness is caught by the post-merge full run on `next` by design.

--- a/packages/Angular/Explorer/explorer-core/src/generated/lazy-feature-config.ts
+++ b/packages/Angular/Explorer/explorer-core/src/generated/lazy-feature-config.ts
@@ -29,6 +29,12 @@ const loadNgDashboardsAiDashboardsModule = {
   load: () => import('@memberjunction/ng-dashboards/ai-dashboards.module').then(() => {})
 };
 
+// --- @memberjunction/ng-dashboards → ./archiving-dashboards.module (2 entries) ---
+const loadNgDashboardsArchivingDashboardsModule = {
+  chunkId: '@memberjunction/ng-dashboards/archiving-dashboards.module',
+  load: () => import('@memberjunction/ng-dashboards/archiving-dashboards.module').then(() => {})
+};
+
 // --- @memberjunction/ng-dashboards → ./communication-dashboards.module (7 entries) ---
 const loadNgDashboardsCommunicationDashboardsModule = {
   chunkId: '@memberjunction/ng-dashboards/communication-dashboards.module',
@@ -77,7 +83,7 @@ const loadNgDashboardsMcpModule = {
   load: () => import('@memberjunction/ng-dashboards/mcp.module').then(() => {})
 };
 
-// --- @memberjunction/ng-dashboards → ./module (3 entries) ---
+// --- @memberjunction/ng-dashboards → ./module (1 entries) ---
 const loadNgDashboardsModule = {
   chunkId: '@memberjunction/ng-dashboards/module',
   load: () => import('@memberjunction/ng-dashboards/module').then(() => {})
@@ -163,6 +169,10 @@ export const LAZY_FEATURE_CONFIG: Record<string, { chunkId: string; load: () => 
   'BaseResourceComponent::VectorManagementResource': loadNgDashboardsAiDashboardsModule,
   'BaseResourceComponent::VisualizationResource': loadNgDashboardsAiDashboardsModule,
 
+  // @memberjunction/ng-dashboards → ./archiving-dashboards.module
+  'BaseResourceComponent::ArchiveConfigResource': loadNgDashboardsArchivingDashboardsModule,
+  'BaseResourceComponent::ArchiveRunsResource': loadNgDashboardsArchivingDashboardsModule,
+
   // @memberjunction/ng-dashboards → ./communication-dashboards.module
   'BaseDashboard::CommunicationDashboard': loadNgDashboardsCommunicationDashboardsModule,
   'BaseResourceComponent::CommunicationLogsResource': loadNgDashboardsCommunicationDashboardsModule,
@@ -247,8 +257,6 @@ export const LAZY_FEATURE_CONFIG: Record<string, { chunkId: string; load: () => 
   'BaseResourceComponent::MCPResource': loadNgDashboardsMcpModule,
 
   // @memberjunction/ng-dashboards → ./module
-  'BaseResourceComponent::ArchiveConfigResource': loadNgDashboardsModule,
-  'BaseResourceComponent::ArchiveRunsResource': loadNgDashboardsModule,
   'BaseResourceComponent::DatabaseDesignerDashboard': loadNgDashboardsModule,
 
   // @memberjunction/ng-dashboards → ./predictive-studio-dashboards.module


### PR DESCRIPTION
**Unblocks `next`**, which is red on the *Class-registration manifest freshness gate* (run [33351873399](https://github.com/MemberJunction/MJ/actions/runs/33351873399)). The `Run unit tests` failure on the same commit is not independent — its lanes report `guards: success, build: failure, test: skipped`.

## Cause

#3988 added the `./archiving-dashboards.module` subpath export to `@memberjunction/ng-dashboards`. That *was* the fix — the module was unreachable. But making it reachable moves its two registered classes into their own lazy chunk, so `lazy-feature-config.ts` had to be regenerated, and it wasn't.

`ArchiveConfigResource` and `ArchiveRunsResource` now resolve through `archiving-dashboards.module` instead of the catch-all `./module`. **This is a relocation, not an addition** — `LAZY_FEATURE_CONFIG_COUNT` stays 118.

Left stale, the committed manifest points those two at a chunk that no longer declares them, which is exactly the shape that lets tree-shaking drop a registered class from a bundled app.

## Why this wasn't caught before merge

By design, and the gate says so itself:

> *(PR-filtered runs skip this: `npx turbo run build` doesn't run the root postbuild, so there's nothing regenerated to compare — the merge backstop always catches it.)*

#3988 was legitimately green. #3916 and #3931 merged in the same window and are clean — neither touches a `@RegisterClass` or a manifest.

## How the content was produced

**Not hand-authored.** The file hashes to `fcade6be19` — byte-for-byte identical to what the failing CI run produced when it regenerated and diffed, and it applies cleanly onto the recorded pre-image `32cf997ca9`.

Regenerating locally was not possible and I want to be explicit about that rather than imply a clean local run: this workspace resolves `@memberjunction/*` into a clone sitting on an older branch with a 6.0.0 CLI, and regenerating against it **deletes five live registrations** (`workflows-dashboards.module`, `GridWidthLabInspector`, `TabStripLabInspector`; 118 → 113). That output was discarded. The transcribed CI diff is the authoritative generator's own result.

The next full run on `next` regenerates and will find no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)