### PR TITLE
feat(ai-betty-bot): optional userId caller identifier on Betty requests

### DIFF
--- a/.changeset/betty-bot-user-identifier.md
+++ b/.changeset/betty-bot-user-identifier.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ai-betty-bot": patch
+---
+
+`BettyBotLLM` accepts an optional `userId` constructor argument, forwarded to Betty's `/response` endpoint as the `userId` body field so a caller can identify itself for Betty's utilization attribution and get its own rate-limit bucket instead of an anonymous per-IP one (the behavior that tripped Betty's bot detection on Izzy's server IP). Omitting the argument leaves the request body byte-identical to before, so existing consumers are unaffected; the settings/JWT call never carries the identifier.

--- a/packages/AI/Providers/BettyBot/src/__tests__/BettyBotLLM.test.ts
+++ b/packages/AI/Providers/BettyBot/src/__tests__/BettyBotLLM.test.ts
@@ -104,6 +104,15 @@ describe('BettyBotLLM', () => {
     it('should initialize TokenExpiration as a Date', () => {
       expect((llm as unknown as Record<string, unknown>)['TokenExpiration']).toBeInstanceOf(Date);
     });
+
+    it('should leave UserId undefined when not provided', () => {
+      expect((llm as unknown as Record<string, unknown>)['UserId']).toBeUndefined();
+    });
+
+    it('should store the userId when provided', () => {
+      const withUser = new BettyBotLLM('test-api-key', 'izzy');
+      expect((withUser as unknown as Record<string, unknown>)['UserId']).toBe('izzy');
+    });
   });
 
   /* ---- SupportsStreaming ---- */
@@ -271,6 +280,60 @@ describe('BettyBotLLM', () => {
       expect(data.choices).toHaveLength(3);
       expect(data.choices[1].message.content).toContain('Doc 1');
       expect(data.choices[2].finish_reason).toBe('references_json');
+    });
+  });
+
+  /* ---- userId identifier ---- */
+  describe('userId', () => {
+    const successfulExchange = () => {
+      mockHttpPost.mockResolvedValueOnce({
+        Data: { status: 'SUCCESS', errorMessage: '', enabledFeatures: [], token: 'jwt' },
+      });
+      mockHttpPost.mockResolvedValueOnce({
+        Data: { status: 'ok', errorMessage: '', conversationId: 1, response: 'Hi', references: [] },
+      });
+    };
+
+    const callNonStreaming = (instance: BettyBotLLM, params: Record<string, unknown>): Promise<Record<string, unknown>> => {
+      return (instance as unknown as { nonStreamingChatCompletion: (p: unknown) => Promise<Record<string, unknown>> })
+        .nonStreamingChatCompletion(params);
+    };
+
+    it('should send only { input } when constructed without a userId', async () => {
+      successfulExchange();
+
+      await callNonStreaming(llm, {
+        messages: [{ role: ChatMessageRole.user, content: 'hello' }],
+        model: 'betty',
+      });
+
+      expect(mockHttpPost).toHaveBeenCalledTimes(2);
+      expect(mockHttpPost.mock.calls[1][0]).toBe('https://betty-api.test.co/response');
+      expect(mockHttpPost.mock.calls[1][1]).toStrictEqual({ input: 'hello' });
+    });
+
+    it('should include userId in the response body when constructed with one', async () => {
+      const withUser = new BettyBotLLM('test-api-key', 'izzy');
+      successfulExchange();
+
+      await callNonStreaming(withUser, {
+        messages: [{ role: ChatMessageRole.user, content: 'hello' }],
+        model: 'betty',
+      });
+
+      expect(mockHttpPost.mock.calls[1][1]).toStrictEqual({ input: 'hello', userId: 'izzy' });
+    });
+
+    it('should never send userId on the settings (JWT) call', async () => {
+      const withUser = new BettyBotLLM('test-api-key', 'izzy');
+      successfulExchange();
+
+      await callNonStreaming(withUser, {
+        messages: [{ role: ChatMessageRole.user, content: 'hello' }],
+        model: 'betty',
+      });
+
+      expect(mockHttpPost.mock.calls[0][1]).toStrictEqual({ token: 'test-api-key' });
     });
   });
 

--- a/packages/AI/Providers/BettyBot/src/models/BettyBotLLM.ts
+++ b/packages/AI/Providers/BettyBot/src/models/BettyBotLLM.ts
@@ -1,4 +1,4 @@
-import { AIErrorInfo, BaseLLM, ChatParams, ChatResult, ChatMessageRole, ClassifyParams, ClassifyResult, SummarizeParams, SummarizeResult, ModelUsage, ErrorAnalyzer } from '@memberjunction/ai';
+import { AIErrorInfo, BaseLLM, ChatParams, ChatResult, ChatMessageRole, ClassifyParams, ClassifyResult, SummarizeParams, SummarizeResult, ModelUsage, ErrorAnalyzer, ChatMessageContent } from '@memberjunction/ai';
 import { RegisterClass } from '@memberjunction/global';
 import { HttpPost, HttpRequestConfig, IsHttpError, IsCancellationError } from '@memberjunction/network-utils';
 import * as Config from '../config';
@@ -10,12 +10,21 @@ export class BettyBotLLM extends BaseLLM {
     private APIKey: string;
     private JWTToken: string;
     private TokenExpiration: Date;
+    private UserId?: string;
 
-    constructor(apiKey: string) {
+    /**
+     * @param apiKey Betty Bot API key, exchanged for a JWT via the settings endpoint
+     * @param userId Optional caller identifier forwarded to Betty as the `userId` request-body field.
+     * Betty uses it to attribute traffic in its utilization reports and to give the caller its own
+     * rate-limit bucket instead of an anonymous per-IP bucket. When omitted, the request body is
+     * identical to what was sent before this parameter existed.
+     */
+    constructor(apiKey: string, userId?: string) {
         super(apiKey);
         this.APIKey = apiKey;
         this.JWTToken = '';
         this.TokenExpiration = new Date();
+        this.UserId = userId;
     }
 
     /**
@@ -108,9 +117,12 @@ export class BettyBotLLM extends BaseLLM {
                 return errorResult;
             }
 
-            const data = {
+            const data: { input: ChatMessageContent; userId?: string } = {
                 input: userMessage.content,
             };
+            if(this.UserId){
+                data.userId = this.UserId;
+            }
 
             const bettyResponse = await HttpPost<BettyResponse>(endpoint, data, config);
             if(!bettyResponse || !bettyResponse.Data){


### PR DESCRIPTION
## What

AACSB's Betty utilization reports flagged Izzy's server IP as a bot: MJ's Betty provider sends every request anonymously, so all traffic lands in one per-IP rate bucket. Betty's API already accepts a caller identifier via the `userId` request-body field (feeds their `spLinkUserID`/`spMessageCount`, giving the caller its own attribution row and rate-limit bucket) — but `BettyBotLLM.nonStreamingChatCompletion` posts only `{ input }`, with no way to send one.

## How

`BettyBotLLM` gains an optional second constructor arg, `userId?: string`. When set, the `/response` body becomes `{ input, userId }`; when omitted, the body is **byte-identical** to today, so existing consumers (`betty.action.ts` in CoreActions is the only in-repo call site) are unaffected. The settings/JWT call never carries the identifier. Consumers opt in per instance, e.g. `new BettyBotLLM(apiKey, 'izzy')`.

Deliberately *not* used: Betty's documented `clientId` field — its only consumer on Betty's side is commented out, so it goes nowhere today.

## Tests

5 new vitest cases in the package suite: UserId stored / left undefined; response body is exactly `{ input }` without an identifier and exactly `{ input, userId }` with one; the settings (JWT) call never includes it. `packages/AI/Providers/BettyBot`: **22/22 passing**, builds clean. Deterministic integration tier run against a from-scratch clean-room DB: all runnable server-transport members pass (client-transport members require MJAPI, exercised by this PR's Integration Tier gate).

## Notes

- **Backport (`backport lts/5`)**: Izzy runs on the 5.x LTS line, so the fix must reach `lts/5` to ship before the 6.x era. Additive, no migration, no metadata — patch-only per line rules. The single non-merge commit carries the whole payload (§5.2 `merge_commits: skip`). `lts/5`'s copy of `BettyBotLLM.ts` has the same constructor/body-build shape, so the cherry-pick is expected to land clean.
- Downstream sequencing: once released, Izzy adopts via a routine version bump plus the one-line call-site change; the Betty team then labels/allowlists the agreed literal (`izzy`) in their reports and bot-detection rule. Their per-org "Require User Auth" feature must not be enabled for AACSB until Izzy's change is deployed (it would hard-reject identifier-less callers, including other MJ Betty consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)