### PR TITLE
fix(integration): a discovery sample that falls back to the catalog says so

### DIFF
--- a/.changeset/discovery-fallback-is-loud.md
+++ b/.changeset/discovery-fallback-is-loud.md
@@ -1,0 +1,18 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+A discovery sample that degrades to the catalog description now says so.
+
+When streaming fails, `DiscoverFieldsViaFetch` falls back to single-sample `DiscoverFields` — the
+catalog's own description, which carries no observed widths. The fallback was announced only to the
+console, so from the pipeline's side it was indistinguishable from a successful sample: the method
+returned fields and the run recorded a discovery that succeeded. The object then kept whatever width
+its catalog guessed, and every longer value it later received was dropped at sync time as a string
+overflow.
+
+`DiscoverFieldsViaFetch` takes an optional `OnFallback` notifier, and the creation pipeline passes
+one that emits a `discover-fields-fallback` stage error naming the object and what is unknown for
+that run. Behaviour is otherwise unchanged — the fallback still happens, callers that pass no
+notifier are byte-identical, and a throwing notifier cannot turn a degraded discovery into a failed
+one.

--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -738,7 +738,18 @@ export abstract class BaseIntegrationConnector {
         companyIntegration: MJCompanyIntegrationEntity,
         objectName: string,
         contextUser: UserInfo,
-        opts: { TimeBudgetMs?: number; BatchSize?: number; MaxRecords?: number } = {}
+        opts: {
+            TimeBudgetMs?: number;
+            BatchSize?: number;
+            MaxRecords?: number;
+            /**
+             * Called when streaming fails and this method degrades to single-sample `DiscoverFields`.
+             * The degradation is silent otherwise, and it is not a small one: the fallback returns
+             * the catalog's own description, which carries no observed widths — so the caller
+             * believes it sampled, and the object keeps whatever width the catalog guessed.
+             */
+            OnFallback?: (err: unknown) => void;
+        } = {}
     ): Promise<ExternalFieldSchema[]> {
         // Discovery budgets are operator-tunable via env (time- or record-count-based — either bounds it);
         // explicit opts win, then env, then the sensible defaults. The record cap usually hits before time.
@@ -806,6 +817,11 @@ export abstract class BaseIntegrationConnector {
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             console.warn(`[DiscoverFieldsViaFetch] <- FAILED "${objectName}" after ${Date.now() - startedMs}ms (${msg}); falling back to single-sample DiscoverFields.`);
+            // Tell the caller BEFORE returning: from the outside a fallback is indistinguishable
+            // from a successful sample, so a discovery that learned nothing about real widths
+            // reports as a discovery that did. A throwing notifier must not turn a degraded
+            // discovery into a failed one.
+            try { opts.OnFallback?.(err); } catch { /* a notifier is never allowed to break discovery */ }
             return this.DiscoverFields(companyIntegration, objectName, contextUser);
         } finally {
             watchdog.End(watchKey);

--- a/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
+++ b/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
@@ -540,7 +540,10 @@ export class IntegrationConnectorCreationPipeline {
                     // SAVE-LESS — stream as much of the feed as the budget allows so the PK decision is
                     // made on a statistically-significant sample, not a single (possibly tiny) file. No
                     // DB write happens here; the real save is the later ApplyAll → StartSync.
-                    fields = await opts.Connector.DiscoverFieldsViaFetch(opts.CompanyIntegration, d.Name, opts.ContextUser);
+                    fields = await opts.Connector.DiscoverFieldsViaFetch(
+                        opts.CompanyIntegration, d.Name, opts.ContextUser,
+                        { OnFallback: (err) => this.ReportSampleFallback(d.Name, err, emitter) }
+                    );
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
                     emitter.stageError('Introspect', `DiscoverFieldsViaFetch failed for "${d.Name}": ${msg}`, { code: 'discover-fields-failed' });
@@ -645,6 +648,23 @@ export class IntegrationConnectorCreationPipeline {
      * overrides. A fetch failure leaves the declaration exactly as it was, so the worst case is the
      * behaviour that shipped before sampling existed.
      */
+    /**
+     * Surfaces a silent degradation: streaming failed, so the fields came from the catalog's own
+     * description instead of from records. That distinction is the whole value of sampling — the
+     * catalog states no observed widths — but from the outside the two are indistinguishable, so
+     * without this an object quietly keeps a guessed width and drops every longer value at sync.
+     */
+    private ReportSampleFallback(objectName: string, err: unknown, emitter: IntegrationProgressEmitter): void {
+        const msg = err instanceof Error ? err.message : String(err);
+        emitter.stageError(
+            'Introspect',
+            `Sampling fell back to the catalog description for "${objectName}" — real widths and ` +
+            `undeclared columns are unknown for this run: ${msg}`,
+            { code: 'discover-fields-fallback' }
+        );
+        console.warn(`[IntrospectPipeline] sample fallback for "${objectName}": ${msg}`);
+    }
+
     private async SampleDeclaredObjectInPlace(
         existing: SourceObjectInfo,
         objectName: string,
@@ -652,7 +672,10 @@ export class IntegrationConnectorCreationPipeline {
         emitter: IntegrationProgressEmitter
     ): Promise<void> {
         try {
-            const dfields = await opts.Connector.DiscoverFieldsViaFetch(opts.CompanyIntegration, objectName, opts.ContextUser);
+            const dfields = await opts.Connector.DiscoverFieldsViaFetch(
+                opts.CompanyIntegration, objectName, opts.ContextUser,
+                { OnFallback: (err) => this.ReportSampleFallback(objectName, err, emitter) }
+            );
             const sampled = dfields.map(f => ({
                 Name: f.Name, Label: f.Label, Description: f.Description, SourceType: f.DataType,
                 IsRequired: f.IsRequired, AllowsNull: f.AllowsNull, MaxLength: f.MaxLength ?? null,

--- a/packages/Integration/engine/src/__tests__/DiscoverySampleFallbackIsLoud.test.ts
+++ b/packages/Integration/engine/src/__tests__/DiscoverySampleFallbackIsLoud.test.ts
@@ -1,0 +1,81 @@
+/**
+ * When streaming fails, `DiscoverFieldsViaFetch` degrades to single-sample `DiscoverFields` — the
+ * catalog's own description, which carries NO observed widths. From the outside that is
+ * indistinguishable from a successful sample: the method returns fields and the pipeline records a
+ * discovery that succeeded. So an object silently keeps whatever width its catalog guessed, and
+ * every longer value it later receives is dropped at sync time as a string overflow.
+ *
+ * These tests pin that the degradation is announced, and that announcing it can never make a
+ * degraded discovery into a failed one.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { BaseIntegrationConnector } from '../BaseIntegrationConnector.js';
+import type { ExternalFieldSchema } from '../BaseIntegrationConnector.js';
+
+const catalogField = (Name: string): ExternalFieldSchema => ({
+    Name, Label: Name, DataType: 'string', IsRequired: false, AllowsNull: true,
+    MaxLength: undefined, IsPrimaryKey: false, IsUniqueKey: false, IsReadOnly: false, IsForeignKey: false,
+} as unknown as ExternalFieldSchema);
+
+type Host = Pick<BaseIntegrationConnector, 'DiscoverFieldsViaFetch'>;
+
+/** A connector whose stream throws, so every call takes the fallback path. */
+function makeConnector(): { host: Host; discoverFields: ReturnType<typeof vi.fn> } {
+    const discoverFields = vi.fn(async () => [catalogField('id'), catalogField('note')]);
+    const host = Object.create(BaseIntegrationConnector.prototype) as Host;
+    Object.assign(host, {
+        DiscoverFields: discoverFields,
+        DiscoverySampleRecordStream: async function* () { throw new Error('stream unavailable'); },
+    });
+    return { host, discoverFields };
+}
+
+const companyIntegration = { ID: 'CI-1', Configuration: null } as never;
+const contextUser = { ID: 'U-1' } as never;
+
+describe('DiscoverFieldsViaFetch — the fallback announces itself', () => {
+    it('calls OnFallback with the underlying error when streaming fails', async () => {
+        const { host, discoverFields } = makeConnector();
+        const onFallback = vi.fn();
+
+        const fields = await host.DiscoverFieldsViaFetch(companyIntegration, 'Invoice', contextUser, { OnFallback: onFallback });
+
+        expect(onFallback).toHaveBeenCalledTimes(1);
+        expect(String((onFallback.mock.calls[0] as unknown[])[0])).toContain('stream unavailable');
+        // The fallback still happened — this is a notification, not a behaviour change.
+        expect(discoverFields).toHaveBeenCalledTimes(1);
+        expect(fields.map((f) => f.Name)).toEqual(['id', 'note']);
+    });
+
+    it('behaves exactly as before when no notifier is supplied', async () => {
+        const { host, discoverFields } = makeConnector();
+
+        const fields = await host.DiscoverFieldsViaFetch(companyIntegration, 'Invoice', contextUser);
+
+        expect(discoverFields).toHaveBeenCalledTimes(1);
+        expect(fields.map((f) => f.Name)).toEqual(['id', 'note']);
+    });
+
+    it('a throwing notifier cannot turn a degraded discovery into a failed one', async () => {
+        const { host, discoverFields } = makeConnector();
+        const onFallback = vi.fn(() => { throw new Error('emitter is closed'); });
+
+        const fields = await host.DiscoverFieldsViaFetch(companyIntegration, 'Invoice', contextUser, { OnFallback: onFallback });
+
+        expect(fields.map((f) => f.Name)).toEqual(['id', 'note']);
+        expect(discoverFields).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire when streaming succeeds', async () => {
+        const onFallback = vi.fn();
+        const host = Object.create(BaseIntegrationConnector.prototype) as Host;
+        Object.assign(host, {
+            DiscoverFields: vi.fn(async () => [catalogField('id')]),
+            DiscoverySampleRecordStream: async function* () { yield { id: '1', note: 'x'.repeat(900) }; },
+        });
+
+        await host.DiscoverFieldsViaFetch(companyIntegration, 'Invoice', contextUser, { OnFallback: onFallback });
+
+        expect(onFallback).not.toHaveBeenCalled();
+    });
+});

--- a/packages/Integration/engine/src/__tests__/IntrospectUnionSampling.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntrospectUnionSampling.test.ts
@@ -90,7 +90,7 @@ describe('StageIntrospect — declared ∪ runtime sampling', () => {
 
         const schema = await host().StageIntrospect(makeEmitter(), opts);
 
-        expect(fetchFields).toHaveBeenCalledWith(opts.CompanyIntegration, 'Invoice', opts.ContextUser);
+        expect(fetchFields).toHaveBeenCalledWith(opts.CompanyIntegration, 'Invoice', opts.ContextUser, expect.anything());
         const note = schema.Objects[0].Fields.find((f) => f.Name === 'note');
         expect(note?.MaxLength).toBe(900); // widened from the declared 255 by what the data actually holds
     });
@@ -183,7 +183,7 @@ describe('StageIntrospect — declared ∪ runtime sampling', () => {
         await host().StageIntrospect(makeEmitter(), opts);
 
         expect(fetchFields).toHaveBeenCalledTimes(1);
-        expect(fetchFields).toHaveBeenCalledWith(opts.CompanyIntegration, 'Invoice', opts.ContextUser);
+        expect(fetchFields).toHaveBeenCalledWith(opts.CompanyIntegration, 'Invoice', opts.ContextUser, expect.anything());
     });
 
     it('leaves the declaration intact when sampling throws, and says which knowledge was lost', async () => {
@@ -259,5 +259,23 @@ describe('StageIntrospect — declared ∪ runtime sampling', () => {
 
             expect(fetchFields.mock.calls.length).toBe(4);   // 0 disables, it does not mean "no time"
         });
+    });
+
+    it('surfaces a connector that silently degraded to the catalog description', async () => {
+        // The connector "succeeds" — it returns fields — but they came from the catalog, not from
+        // records, so no width was observed. Without the stageError the run reports a clean
+        // discovery and the object keeps its guessed width until a sync starts dropping records.
+        const opts = makeOpts({
+            declared: [declaredObject('Invoice')],
+            discoverFieldsViaFetch: vi.fn(async (_ci: unknown, _name: unknown, _user: unknown, o?: { OnFallback?: (e: unknown) => void }) => {
+                o?.OnFallback?.(new Error('stream unavailable'));
+                return [sampledField('id', null, true), sampledField('note', null)];
+            }),
+        });
+        const emitter = makeEmitter();
+
+        await host().StageIntrospect(emitter, opts);
+
+        expect(emitter.errors.some((e) => e.meta?.code === 'discover-fields-fallback')).toBe(true);
     });
 });


### PR DESCRIPTION
> **Stacked on #4117** — review that one first; this PR's base is that branch, so the diff here is only the fallback change. Retarget to `next` once #4117 merges.

## The silence

When streaming fails, `DiscoverFieldsViaFetch` catches **any** error and degrades to single-sample `DiscoverFields` — the catalog's own description, which states no observed widths.

That degradation was announced only with a `console.warn`. From the pipeline's side the call returned fields and the run recorded a discovery that succeeded, so there was no way to tell "we sampled 500 records and these are the real widths" from "we sampled nothing and this is what the catalog claims".

The consequence is not cosmetic. An object that took the fallback keeps whatever width its catalog guessed, and every longer value it later receives is dropped at sync time as a string overflow — records silently missing from a sync that reports success.

## The change

- `DiscoverFieldsViaFetch` accepts an optional `OnFallback(err)` notifier in its opts.
- The creation pipeline passes one at both call sites, emitting a `discover-fields-fallback` stage error that names the object and says what is unknown for that run.

Deliberately narrow:

- The fallback still happens — this is a notification, not a behaviour change. A degraded discovery is better than none.
- A caller that passes no notifier is byte-identical to before, so no connector changes.
- The notifier is invoked inside a `try`: a throwing notifier must never turn a degraded discovery into a failed one.

## Tests

`DiscoverySampleFallbackIsLoud.test.ts` (4): the notifier fires with the underlying error and the fallback still returns its fields; no-notifier behaviour is unchanged; a throwing notifier is swallowed; and it does not fire when streaming succeeds. Plus one pipeline-level test in `IntrospectUnionSampling.test.ts` asserting the stage error actually reaches the run.

Full engine suite green (68 files, 901 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)