### PR TITLE
fix(integration): a completed sync stores its watermark as a Timestamp again

### DIFF
--- a/.changeset/watermark-update-restores-type.md
+++ b/.changeset/watermark-update-restores-type.md
@@ -1,0 +1,16 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+A completed sync's watermark is stored as a Timestamp again, not left typed as a Cursor.
+
+The watermark row is shared with the keyset resume position, which flips `WatermarkType` to
+`'Cursor'` mid-run. Creating a watermark stamps `'Timestamp'`, but updating one set only the value
+and `LastSyncAt` — so an entity map that saved a keyset cursor mid-run and then completed cleanly
+was left holding a timestamp value still typed as a cursor. `Load`'s consumers read the type to
+decide what the value means, so the next run could hand that timestamp back to the connector as a
+seek key.
+
+`UpdateExistingWatermark` now restores `WatermarkType='Timestamp'`, matching what creation already
+did. `RestoreValue` stays type-preserving on purpose: it undoes a mid-run durability floor, it does
+not declare a run complete.

--- a/packages/Integration/engine/src/WatermarkService.ts
+++ b/packages/Integration/engine/src/WatermarkService.ts
@@ -227,12 +227,20 @@ export class WatermarkService {
 
     /**
      * Updates an existing watermark record with a new value and timestamp.
+     *
+     * The type is restored, not just the value. This row is shared with the keyset resume position
+     * ({@link SaveKeysetPosition}), which flips it to `WatermarkType='Cursor'` mid-run. Creating a
+     * watermark stamps `'Timestamp'` but updating one used to leave the type alone, so a map that
+     * saved a cursor mid-run and then completed cleanly ended up holding a TIMESTAMP value typed as
+     * a CURSOR — and {@link Load}'s consumers read the type to decide what the value means, feeding
+     * it back to the connector as a seek key on the next run.
      */
     private async UpdateExistingWatermark(
         watermark: ICompanyIntegrationSyncWatermark,
         newValue: string
     ): Promise<void> {
         watermark.WatermarkValue = newValue;
+        watermark.WatermarkType = 'Timestamp';
         watermark.LastSyncAt = new Date();
         const saved = await watermark.Save();
         if (!saved) {

--- a/packages/Integration/engine/src/__tests__/WatermarkService.test.ts
+++ b/packages/Integration/engine/src/__tests__/WatermarkService.test.ts
@@ -92,6 +92,30 @@ describe('WatermarkService', () => {
             expect(mockWatermark.WatermarkValue).toBe('2024-06-15T00:00:00Z');
         });
 
+        it('restores WatermarkType to Timestamp — the row is shared with the keyset cursor', async () => {
+            // SaveKeysetPosition flips this same row to 'Cursor' mid-run. Creating a watermark
+            // stamps 'Timestamp', but updating one used to leave the type alone — so a map that
+            // saved a cursor and then completed cleanly ended up holding a TIMESTAMP value still
+            // typed as a CURSOR, which the next run hands back to the connector as a seek key.
+            const mockWatermark = createMockWatermark('em-1', 'id-90210');
+            mockWatermark.WatermarkType = 'Cursor';
+            mockRunViewFn.mockResolvedValue({ Success: true, Results: [mockWatermark] });
+
+            await service.Update('em-1', '2024-06-15T00:00:00Z', mockContextUser);
+
+            expect(mockWatermark.WatermarkValue).toBe('2024-06-15T00:00:00Z');
+            expect(mockWatermark.WatermarkType).toBe('Timestamp');
+        });
+
+        it('leaves an already-Timestamp row on Timestamp', async () => {
+            const mockWatermark = createMockWatermark('em-1', '2024-01-01T00:00:00Z');
+            mockRunViewFn.mockResolvedValue({ Success: true, Results: [mockWatermark] });
+
+            await service.Update('em-1', '2024-06-15T00:00:00Z', mockContextUser);
+
+            expect(mockWatermark.WatermarkType).toBe('Timestamp');
+        });
+
         it('should create new watermark when none exists', async () => {
             // Load returns empty (no existing watermark)
             mockRunViewFn.mockResolvedValue({
@@ -119,6 +143,19 @@ describe('WatermarkService', () => {
 
             await expect(service.Update('em-fail', 'new-value', mockContextUser))
                 .rejects.toThrow('Failed to update watermark');
+        });
+    });
+
+    describe('RestoreValue (§8a floor undo)', () => {
+        it('does NOT touch the type — it undoes a value, it does not declare a run complete', async () => {
+            const mockWatermark = createMockWatermark('em-1', 'id-90210');
+            mockWatermark.WatermarkType = 'Cursor';
+            mockRunViewFn.mockResolvedValue({ Success: true, Results: [mockWatermark] });
+
+            await service.RestoreValue('em-1', null, mockContextUser);
+
+            expect(mockWatermark.WatermarkValue).toBeNull();
+            expect(mockWatermark.WatermarkType).toBe('Cursor');
         });
     });
 


### PR DESCRIPTION
## The bug

One row holds two different kinds of value. `SaveKeysetPosition` writes the mid-run seek position there and flips `WatermarkType` to `'Cursor'`; a normal incremental watermark is a timestamp.

Creating a watermark stamps `'Timestamp'` (`CreateNewWatermark`). **Updating** one set only `WatermarkValue` and `LastSyncAt` — never the type.

So the sequence "save a keyset cursor mid-run, then complete the run cleanly" leaves the row holding a **timestamp value still typed as a cursor**. `Load`'s consumers read the type to decide what the value means, which means the next run can hand that timestamp back to the connector as a seek key.

The asymmetry is the whole bug: create says what the value is, update didn't.

## The change

`UpdateExistingWatermark` sets `WatermarkType = 'Timestamp'`, matching what creation already did. All four callers of `Update()` pass timestamp semantics — the mid-run durability floor, the final watermark, the partial watermark, and the Push `latestChangeAt`.

`RestoreValue` is deliberately left alone: it undoes a mid-run durability floor after a page-skip gap, it does not declare a run complete, so it must not re-label the row.

## Risk

A connector that emitted a watermark value which is not a valid timestamp would previously have slipped through as a cursor and will now be validated as a timestamp. No shipped connector does this — the incremental path emits ISO timestamps — but it is the one behaviour change worth naming, and it is covered by the post-deploy smoke on a keyset connector and a watermark-based REST connector.

## Tests

Added to `WatermarkService.test.ts`: a Cursor-typed row updated with a timestamp comes out Timestamp-typed; an already-Timestamp row stays Timestamp; and `RestoreValue` leaves a Cursor row's type untouched.

Verified adversarially: removing the one added line fails exactly the first test.

Full engine suite green (66 files, 892 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)