### PR TITLE
perf(integration): spend the requested concurrency on writes, not just fetches

### DIFF
--- a/.changeset/apply-path-concurrency.md
+++ b/.changeset/apply-path-concurrency.md
@@ -1,0 +1,20 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+`syncConcurrency` now applies to writes, not just fetches.
+
+Opting into concurrency already made the apply path give up batch atomicity — on that path each
+record auto-commits on its own pooled connection specifically so concurrent streams cannot collide
+on a held transaction — and then applied the records one at a time anyway. The caller paid the price
+of concurrency and received none of it.
+
+The transaction-free path now runs a bounded pool of workers pulling from a shared cursor, capped by
+the requested `syncConcurrency` (clamped to 16). A fixed pool rather than `Promise.all` over the
+batch, because 500 simultaneous saves would swamp the connection pool.
+
+Both error behaviours are preserved: a poison record is still dead-lettered while its siblings
+commit, and a `SchemaNotGeneratedError` still fail-stops the whole map — now by stopping the workers
+at their next pull rather than grinding through the remaining records against a table that does not
+exist. `ApplyRecords` takes the concurrency as a defaulted trailing parameter, so the serial path and
+any caller that does not pass it are unchanged.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -2934,7 +2934,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
 
             const beforeApply = result.RecordsCreated + result.RecordsUpdated + result.RecordsSkipped + result.RecordsErrored;
             try {
-                if (!partitionReconcile) await this.ApplyRecords(resolved, config.companyIntegration, entityMap, result, contextUser, logger, this.getSyncConcurrency(config) <= 1);
+                if (!partitionReconcile) await this.ApplyRecords(resolved, config.companyIntegration, entityMap, result, contextUser, logger, this.getSyncConcurrency(config) <= 1, this.getSyncConcurrency(config));
             } catch (applyErr) {
                 if (applyErr instanceof SchemaNotGeneratedError) {
                     // The destination spCreate/Update/Delete doesn't exist
@@ -4145,7 +4145,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 // connection, so when streams run in parallel (syncConcurrency>1) it must not interleave
                 // with another stream's open write transaction (else "Transaction in progress" / dirty read).
                 const resolved = await this.runWriteExclusive(() => this.matchEngine.Resolve(recs, entityMap, fieldMaps, contextUser));
-                await this.ApplyRecords(resolved, config.companyIntegration, entityMap, result, contextUser, logger, this.getSyncConcurrency(config) <= 1);
+                await this.ApplyRecords(resolved, config.companyIntegration, entityMap, result, contextUser, logger, this.getSyncConcurrency(config) <= 1, this.getSyncConcurrency(config));
                 appliedRecords += recs.length;
             }
         } catch (applyErr) {
@@ -4191,7 +4191,14 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         // lost batch atomicity is absorbed by the engine's idempotency (upsert-by-identity + content
         // hash) and the safe-floor watermark (advances only on a clean batch). Default true = the
         // proven atomic serial path, unchanged.
-        useTransaction: boolean = true
+        useTransaction: boolean = true,
+        /**
+         * Requested apply concurrency. Only consulted on the transaction-free path (the one
+         * `useTransaction: false` selects), where records auto-commit independently and can
+         * therefore overlap. Defaults to 1, so a caller that does not pass it keeps the serial
+         * behaviour exactly.
+         */
+        concurrency: number = 1
     ): Promise<void> {
         // Batched application with per-record failure isolation (the "grace gap" fix).
         // Happy path: each batch of up to APPLY_BATCH_SIZE records commits as a single
@@ -4403,7 +4410,23 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     // connection. Per-record error isolation: a poison record is logged + counted; the
                     // rest still commit; the idempotent re-sync + safe-floor watermark reconcile any
                     // partial batch (the atomicity the transactional path provides is not needed here).
-                    for (const record of batch) {
+                    // The records are independent and each auto-commits on its own pooled
+                    // connection, so this is the one place in the apply path where the requested
+                    // concurrency can actually be spent. Running them one at a time made
+                    // syncConcurrency a fetch-only setting: the caller opted into concurrency, paid
+                    // for it by giving up batch atomicity, and then still wrote serially.
+                    //
+                    // A fixed pool of workers pulling from a shared cursor, rather than
+                    // Promise.all over the batch: 500 simultaneous saves would swamp the connection
+                    // pool. The cap is the same knob the fetch side uses, clamped to a sane ceiling.
+                    const applyLimit = Math.max(1, Math.min(16, Math.floor(concurrency) || 1));
+                    let cursor = 0;
+                    // Set by whichever worker sees it; every worker stops at the next pull and the
+                    // error is rethrown after they settle. SchemaNotGeneratedError means the whole
+                    // map cannot proceed, so finishing the remaining records would be wasted work
+                    // against a table that does not exist.
+                    let fatal: unknown;
+                    const applyOne = async (record: MappedRecord): Promise<void> => {
                         result.RecordsProcessed++;
                         try {
                             // §10 — bounded inline retry for provably-transient save failures (auto-commit per
@@ -4421,7 +4444,8 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                             );
                         } catch (err) {
                             if (err instanceof SchemaNotGeneratedError) {
-                                throw err;
+                                fatal ??= err;
+                                return;
                             }
                             // §10 — permanent / retry-exhausted → dead-letter (count + log), move on; watermark advances regardless.
                             result.RecordsErrored++;
@@ -4434,7 +4458,20 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                                 Severity: classified.Severity,
                             });
                         }
-                    }
+                    };
+                    // allSettled, not all: a worker must never reject, and the counters/dead-letter
+                    // list are only coherent once every worker has stopped touching them.
+                    await Promise.allSettled(
+                        Array.from({ length: Math.min(applyLimit, batch.length) }, async () => {
+                            for (;;) {
+                                if (fatal !== undefined) return;
+                                const next = cursor++;
+                                if (next >= batch.length) return;
+                                await applyOne(batch[next]);
+                            }
+                        }),
+                    );
+                    if (fatal !== undefined) throw fatal;
                 }
 
                 // After the batch settles (committed, or per-record retried), refresh

--- a/packages/Integration/engine/src/__tests__/ApplyPathConcurrency.test.ts
+++ b/packages/Integration/engine/src/__tests__/ApplyPathConcurrency.test.ts
@@ -1,0 +1,136 @@
+/**
+ * `syncConcurrency` was a fetch-only setting. Opting into it made the apply path give up batch
+ * atomicity — each record auto-commits on its own pooled connection — and then still wrote the
+ * records one at a time, so the caller paid the price of concurrency and got none of it.
+ *
+ * These tests pin the pool's semantics rather than its shape: how many run at once, that every
+ * record is applied exactly once, and that the two error behaviours (dead-letter vs fail-stop)
+ * survive being run in parallel.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { IntegrationEngine, SchemaNotGeneratedError } from '../IntegrationEngine.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+type ApplyHost = {
+    ApplyRecords: (...args: unknown[]) => Promise<void>;
+};
+
+/** Drives the real ApplyRecords with ApplySingleRecord stubbed, on the transaction-free path. */
+function makeHost(apply: (rec: { id: number }) => Promise<void>) {
+    const host = Object.create(IntegrationEngine.prototype) as unknown as ApplyHost & Record<string, unknown>;
+    Object.assign(host, {
+        ApplySingleRecord: async (record: { id: number }) => apply(record),
+        TouchLastReconciledAt: async () => undefined,
+        FlushRecordMaps: async () => undefined,
+        runWriteExclusive: async (fn: () => Promise<void>) => fn(),
+        getSyncConcurrency: () => 1,
+    });
+    Object.defineProperty(host, 'ProviderToUse', { value: {}, configurable: true });
+    return host;
+}
+
+const records = (n: number) => Array.from({ length: n }, (_, id) => ({ id, ExternalRecord: { ExternalID: String(id) }, ChangeType: 'Create' }));
+const result = () => ({ RecordsProcessed: 0, RecordsCreated: 0, RecordsUpdated: 0, RecordsDeleted: 0, RecordsErrored: 0, RecordsSkipped: 0, Errors: [] });
+
+/** ApplyRecords(records, ci, entityMap, result, user, logger, useTransaction=false, concurrency) */
+const run = (host: ApplyHost, recs: unknown[], res: unknown, concurrency: number) =>
+    host.ApplyRecords(recs, { ID: 'CI' }, { ID: 'EM', ExternalObjectName: 'Obj' }, res, { ID: 'U' }, undefined, false, concurrency);
+
+describe('ApplyRecords — transaction-free path honours concurrency', () => {
+    it('runs up to `concurrency` records at once instead of one at a time', async () => {
+        let inFlight = 0;
+        let peak = 0;
+        const host = makeHost(async () => {
+            inFlight++; peak = Math.max(peak, inFlight);
+            await new Promise((r) => setTimeout(r, 5));
+            inFlight--;
+        });
+        const res = result();
+
+        await run(host, records(20), res, 4);
+
+        expect(peak).toBe(4);
+        expect(res.RecordsProcessed).toBe(20);
+    });
+
+    it('never exceeds the cap — 500 records must not become 500 simultaneous saves', async () => {
+        let inFlight = 0;
+        let peak = 0;
+        const host = makeHost(async () => {
+            inFlight++; peak = Math.max(peak, inFlight);
+            await new Promise((r) => setTimeout(r, 1));
+            inFlight--;
+        });
+
+        await run(host, records(200), result(), 8);
+
+        expect(peak).toBeLessThanOrEqual(8);
+    });
+
+    it('applies every record exactly once', async () => {
+        const seen: number[] = [];
+        const host = makeHost(async (rec) => { seen.push(rec.id); });
+
+        await run(host, records(50), result(), 5);
+
+        expect(seen).toHaveLength(50);
+        expect(new Set(seen).size).toBe(50);
+    });
+
+    it('stays serial when concurrency is 1 — the default must not change behaviour', async () => {
+        let inFlight = 0;
+        let peak = 0;
+        const host = makeHost(async () => {
+            inFlight++; peak = Math.max(peak, inFlight);
+            await new Promise((r) => setTimeout(r, 1));
+            inFlight--;
+        });
+
+        await run(host, records(10), result(), 1);
+
+        expect(peak).toBe(1);
+    });
+
+    it('dead-letters a poison record and still applies its healthy siblings', async () => {
+        const host = makeHost(async (rec) => {
+            if (rec.id === 3) throw new Error('permanent failure');
+        });
+        const res = result();
+
+        await run(host, records(10), res, 4);
+
+        expect(res.RecordsErrored).toBe(1);
+        expect(res.Errors[0]).toMatchObject({ ExternalID: '3' });
+        expect(res.RecordsProcessed).toBe(10); // the other nine still went through
+    });
+
+    it('fail-stops the whole map on SchemaNotGeneratedError instead of grinding through the batch', async () => {
+        // The destination table does not exist, so finishing the remaining records is wasted work
+        // against a table that cannot accept them.
+        let attempts = 0;
+        const host = makeHost(async () => {
+            attempts++;
+            await new Promise((r) => setTimeout(r, 1));
+            throw new SchemaNotGeneratedError('Obj', 'spCreateObj');
+        });
+
+        await expect(run(host, records(100), result(), 4)).rejects.toBeInstanceOf(SchemaNotGeneratedError);
+        expect(attempts).toBeLessThan(100); // stopped early rather than trying all 100
+    });
+});
+
+describe('wiring', () => {
+    const source = readFileSync(join(__dirname, '..', 'IntegrationEngine.ts'), 'utf8');
+
+    it('uses allSettled so a worker rejection cannot escape mid-batch', () => {
+        // Promise.all would abandon the remaining workers while they still mutate the counters.
+        expect(source).toMatch(/await Promise\.allSettled\(/);
+    });
+
+    it('passes the requested concurrency at both call sites', () => {
+        const calls = source.match(/this\.ApplyRecords\([^;]*\);/g) ?? [];
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+        for (const c of calls) expect(c).toMatch(/getSyncConcurrency\(config\)\);\s*$/);
+    });
+});


### PR DESCRIPTION
## The gap

`syncConcurrency` is honoured for fetching. For applying, it selects a different code path and is then ignored.

Setting it above 1 switches the apply to a **transaction-free** path — each record auto-commits on its own pooled connection, deliberately, so concurrent streams' fetch-phase reads cannot collide on a held global transaction. Having given up batch atomicity to make concurrency possible, that path then does:

```ts
for (const record of batch) {
    result.RecordsProcessed++;
    await WithRetry(() => this.ApplySingleRecord(record, …));
}
```

One at a time. The caller pays the price of concurrency and receives none of it.

This is the largest single throughput item in the engine: on a write-bound object the apply phase is where the wall clock goes, and it is running at width 1 no matter what the connection asks for.

## The change

The transaction-free branch now runs a bounded pool of workers pulling from a shared cursor:

- **A fixed pool, not `Promise.all` over the batch.** A batch is up to 500 records; 500 simultaneous saves would swamp the connection pool. Width is the requested `syncConcurrency`, clamped to 16.
- **`Promise.allSettled`, not `Promise.all`.** A worker must never reject out from under its siblings — the counters and the dead-letter list are only coherent once every worker has stopped touching them.
- **`ApplyRecords` takes `concurrency` as a defaulted trailing parameter** (default 1), so the serial transactional path and any caller that omits it are unchanged. Both existing call sites already computed this value for the `useTransaction` argument; they now hand it over rather than recompute it.

## Error semantics are preserved, not merely re-implemented

- **Dead-letter** — a permanent/retry-exhausted record is still counted and logged while its siblings commit. Unchanged.
- **Fail-stop** — `SchemaNotGeneratedError` means the destination procedure does not exist, so the whole map is doomed. Previously the `throw` escaped the loop immediately. Now the first worker to see it records it, every worker stops at its next pull, and it is rethrown **after they settle** — so the caller sees coherent counters, and we stop rather than grinding through hundreds more records against a table that cannot accept them.

## Tests

`ApplyPathConcurrency.test.ts` (8), driving the real `ApplyRecords` with `ApplySingleRecord` stubbed:

- peak in-flight reaches the requested width (the test that fails if this regresses to serial)
- 200 records at width 8 never exceed 8 in flight
- every record applied exactly once
- **concurrency 1 stays strictly serial** — the default must not change behaviour
- a poison record is dead-lettered and its nine siblings still process
- `SchemaNotGeneratedError` rejects the call and stops early (`attempts < 100`)
- wiring pins: `allSettled` is used, and both call sites pass the concurrency

Verified adversarially: forcing `applyLimit = 1` fails the peak-concurrency test.

Full engine suite green (67 files, 897 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)