### PR TITLE
perf(integration): serialize writes per entity map, not per provider

### DIFF
--- a/.changeset/per-entity-map-write-chains.md
+++ b/.changeset/per-entity-map-write-chains.md
@@ -1,0 +1,20 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Writes for different entity maps no longer queue behind each other.
+
+Every engine write went through one provider-wide chain. That was necessary but too broad: the
+provider holds a single transaction on a single connection, so a write issued while that transaction
+is open joins it — and the chain was the only thing preventing one batch's transaction from
+swallowing an unrelated map's watermark save. The cost was that maps syncing concurrently also
+serialized all their bookkeeping, including when no transaction existed at all.
+
+`WriteSerializer` replaces the chain with a two-mode lock. Work that opens the provider transaction
+runs exclusively, exactly as before. Work scoped to one entity map that opens no transaction —
+watermark bookkeeping, match resolution, and the post-batch flushes of a batched apply — runs keyed
+by entity map: different maps overlap, the same map stays ordered.
+
+Waits are acyclic by construction: an exclusive section snapshots the in-flight keyed work at call
+time, and a keyed call captures the barrier at call time, so nothing ever waits on work created
+after it. Chains continue past rejections, so one errored batch cannot wedge later writers.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -59,6 +59,7 @@ import { mostRecentWinner, type RecencyWinner } from './ConflictRecency.js';
 import { IntegrationProgressEmitter } from '@memberjunction/integration-progress-artifacts';
 import type { BaseIntegrationConnector, FetchContext, FetchBatchResult } from './BaseIntegrationConnector.js';
 import { CollapseDuplicateIdentities } from './BatchIdentity.js';
+import { WriteSerializer } from './WriteSerializer.js';
 import { ResumeConcurrency, RunResumesBounded } from './ResumeConcurrency.js';
 
 /** Default batch size for fetching records from external systems */
@@ -560,19 +561,36 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
      * phase stays parallel (the real throughput win — it's network-bound). WeakMap so a
      * retired provider's chain entry is collectable.
      */
-    private static readonly writeChains = new WeakMap<IMetadataProvider, { chain: Promise<unknown> }>();
-    private runWriteExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    private static readonly writeSerializers = new WeakMap<IMetadataProvider, WriteSerializer>();
+    /** The write lock for this engine's provider, created on first use. */
+    private writeSerializer(): WriteSerializer {
         const provider = this.ProviderToUse;
-        let holder = IntegrationEngine.writeChains.get(provider);
-        if (!holder) {
-            holder = { chain: Promise.resolve() };
-            IntegrationEngine.writeChains.set(provider, holder);
+        let s = IntegrationEngine.writeSerializers.get(provider);
+        if (!s) {
+            s = new WriteSerializer();
+            IntegrationEngine.writeSerializers.set(provider, s);
         }
-        // Run fn after the prior write completes (whether it resolved or rejected); keep the chain
-        // alive past failures so one errored batch never deadlocks subsequent writers.
-        const run = holder.chain.then(() => fn(), () => fn());
-        holder.chain = run.then(() => undefined, () => undefined);
-        return run;
+        return s;
+    }
+
+    /**
+     * Runs `fn` with NO other write in flight against the provider. Required for work that opens
+     * the provider's single global transaction — while it is open, any other write would join it.
+     */
+    private runWriteExclusive<T>(fn: () => Promise<T>): Promise<T> {
+        return this.writeSerializer().RunExclusive(fn);
+    }
+
+    /**
+     * Runs `fn` ordered against other writes for the SAME entity map, concurrently with other maps.
+     *
+     * Only for work that opens no provider transaction — watermark bookkeeping, match resolution,
+     * and the post-batch flushes of a batched (TransactionGroup-carrying) apply. Those were queued
+     * behind every other map's writes purely because the lock could not tell them apart from a
+     * transaction-holding section.
+     */
+    private runWriteForMap<T>(entityMapID: string, fn: () => Promise<T>): Promise<T> {
+        return this.writeSerializer().RunKeyed(entityMapID, fn);
     }
 
     /**
@@ -2497,7 +2515,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 excludedFields: Array.from(excludedSourceNames).sort(),
             });
         }
-        const watermark = await this.runWriteExclusive(() => this.watermarkService.Load(entityMapID, contextUser, 'Pull'));
+        const watermark = await this.runWriteForMap(entityMapID, () => this.watermarkService.Load(entityMapID, contextUser, 'Pull'));
         logger?.emit('sync.entity-map.start', {
             phase: 'pull-detail',
             externalObjectName: entityMap.ExternalObjectName,
@@ -2769,7 +2787,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     // value — a crash from here on resumes from the pre-run watermark and re-covers
                     // the gap. Later checkpoints stop writing floors (gate above).
                     if (watermarkFloorSaved !== null) {
-                        await this.runWriteExclusive(() => this.watermarkService.RestoreValue(entityMapID, preRunWatermarkValue, contextUser));
+                        await this.runWriteForMap(entityMapID, () => this.watermarkService.RestoreValue(entityMapID, preRunWatermarkValue, contextUser));
                         watermarkFloorSaved = null;
                     }
                     logger?.warning(
@@ -2930,7 +2948,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             // not begun"). Holding the same write-lock for the read keeps the connection single-owner.
             const resolved = partitionReconcile
                 ? []
-                : await this.runWriteExclusive(() => this.matchEngine.Resolve(mapped, entityMap, fieldMaps, contextUser));
+                : await this.runWriteForMap(entityMap.ID, () => this.matchEngine.Resolve(mapped, entityMap, fieldMaps, contextUser));
 
             const beforeApply = result.RecordsCreated + result.RecordsUpdated + result.RecordsSkipped + result.RecordsErrored;
             try {
@@ -2975,7 +2993,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
 
                 // Update progress on the watermark record so the DB reflects live sync state
                 if (batch.HasMore) {
-                    await this.runWriteExclusive(() => this.watermarkService.UpdateProgress(entityMapID, afterApply, contextUser));
+                    await this.runWriteForMap(entityMapID, () => this.watermarkService.UpdateProgress(entityMapID, afterApply, contextUser));
                 }
             }
 
@@ -3012,7 +3030,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 // post-loop save below handles graceful early-exits precisely; this covers a SIGKILL
                 // between graceful checkpoints, costing at most ~25 batches of re-fetch on resume.
                 if (isKeysetConnector && currentAfterKey) {
-                    await this.runWriteExclusive(() => this.watermarkService.SaveKeysetPosition(entityMapID, currentAfterKey, contextUser));
+                    await this.runWriteForMap(entityMapID, () => this.watermarkService.SaveKeysetPosition(entityMapID, currentAfterKey, contextUser));
                 }
                 // The WATERMARK twin of the keyset floor above. Without it, a watermark-based
                 // connector had NO durable position at all until the run ended: a SIGKILL / OOM /
@@ -3030,7 +3048,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     && currentWatermark && currentWatermark !== initialWatermark
                     && currentWatermark !== watermarkFloorSaved) {
                     const floor = currentWatermark;
-                    await this.runWriteExclusive(() => this.watermarkService.Update(entityMapID, floor, contextUser, 'Pull'));
+                    await this.runWriteForMap(entityMapID, () => this.watermarkService.Update(entityMapID, floor, contextUser, 'Pull'));
                     watermarkFloorSaved = floor;
                 }
             }
@@ -3072,7 +3090,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             // NOTE: a connector that ALSO returns a monotonic watermark (MonotonicWatermark=true) skips
             // this branch and falls through to SAVE that watermark below, so its next incremental NARROWS
             // (microtime > watermark) instead of re-scanning the whole object every run.
-            await this.runWriteExclusive(() => this.watermarkService.ClearKeysetPosition(entityMapID, contextUser));
+            await this.runWriteForMap(entityMapID, () => this.watermarkService.ClearKeysetPosition(entityMapID, contextUser));
             result.WatermarkAfter = null;
         } else if (fetchCompletedCleanly) {
             // Save a watermark on every clean fetch, even when the connector
@@ -3110,12 +3128,12 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             } else {
                 finalWatermark = new Date().toISOString();
             }
-            await this.runWriteExclusive(() => this.watermarkService.Update(entityMapID, finalWatermark, contextUser, 'Pull'));
+            await this.runWriteForMap(entityMapID, () => this.watermarkService.Update(entityMapID, finalWatermark, contextUser, 'Pull'));
             result.WatermarkAfter = finalWatermark;
         } else if (isKeysetConnector && currentAfterKey) {
             // The keyset scan stopped early (cancel / fetch error / safety limit). Persist the precise
             // last ordering key so the next run resumes the seek from here instead of restarting.
-            await this.runWriteExclusive(() => this.watermarkService.SaveKeysetPosition(entityMapID, currentAfterKey, contextUser));
+            await this.runWriteForMap(entityMapID, () => this.watermarkService.SaveKeysetPosition(entityMapID, currentAfterKey, contextUser));
             result.WatermarkAfter = currentAfterKey;
         } else if (!hadFetchGap && currentWatermark && currentWatermark !== initialWatermark) {
             // A WATERMARK-based connector stopped early (cancel / safety limit / duplicate batch /
@@ -3134,7 +3152,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             // deliberately NOT when hadFetchGap — a skipped page leaves a HOLE behind this watermark,
             // which is why that path holds it for a full re-fetch next run.
             const partialWatermark = currentWatermark;
-            await this.runWriteExclusive(() => this.watermarkService.Update(entityMapID, partialWatermark, contextUser, 'Pull'));
+            await this.runWriteForMap(entityMapID, () => this.watermarkService.Update(entityMapID, partialWatermark, contextUser, 'Pull'));
             result.WatermarkAfter = partialWatermark;
         }
 
@@ -4144,7 +4162,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 // (~line 1644). matchEngine.Resolve reads existing MJ rows on the SHARED provider
                 // connection, so when streams run in parallel (syncConcurrency>1) it must not interleave
                 // with another stream's open write transaction (else "Transaction in progress" / dirty read).
-                const resolved = await this.runWriteExclusive(() => this.matchEngine.Resolve(recs, entityMap, fieldMaps, contextUser));
+                const resolved = await this.runWriteForMap(entityMap.ID, () => this.matchEngine.Resolve(recs, entityMap, fieldMaps, contextUser));
                 await this.ApplyRecords(resolved, config.companyIntegration, entityMap, result, contextUser, logger, this.getSyncConcurrency(config) <= 1, this.getSyncConcurrency(config));
                 appliedRecords += recs.length;
             }
@@ -4269,7 +4287,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             // the outer one, which deadlocks. Under the outer mutex the writes are already
             // serialized, so they run inline; without it they take the mutex individually.
             const serializeWrite = batchedWrites
-                ? <T,>(fn: () => Promise<T>): Promise<T> => this.runWriteExclusive(fn)
+                ? <T,>(fn: () => Promise<T>): Promise<T> => this.runWriteForMap(entityMap.ID, fn)
                 : <T,>(fn: () => Promise<T>): Promise<T> => fn();
 
             const applyOneBatch = async () => {

--- a/packages/Integration/engine/src/WriteSerializer.ts
+++ b/packages/Integration/engine/src/WriteSerializer.ts
@@ -1,0 +1,69 @@
+/**
+ * Orders the engine's writes against one provider.
+ *
+ * The provider holds a SINGLE transaction bound to a single connection, so any write issued while
+ * that transaction is open joins it. That is why every engine write was funnelled through one
+ * provider-wide chain: it made it impossible for a batch's transaction to swallow an unrelated
+ * entity map's watermark save.
+ *
+ * The cost was that writes belonging to DIFFERENT entity maps also queued behind each other, even
+ * when no transaction was involved at all — which is the common case once a connection uses batched
+ * writes, since those carry their own TransactionGroup and never open the provider's.
+ *
+ * So this is a two-mode lock rather than a single queue:
+ *
+ *   - {@link RunExclusive} is for work that opens the provider transaction. Nothing else writes
+ *     while it runs, and it waits for everything already in flight.
+ *   - {@link RunKeyed} is for work scoped to one entity map that opens no transaction. Different
+ *     keys overlap; the SAME key stays ordered, so one map never races its own writes.
+ *
+ * DEADLOCK SAFETY: each call waits only on work that existed BEFORE it. An exclusive section
+ * snapshots the in-flight keyed work at call time; a keyed call captures the barrier at call time.
+ * Neither ever waits on something created after it, so the wait graph cannot contain a cycle.
+ *
+ * A rejected operation never breaks ordering for anyone else: every chain continues past failures,
+ * so one errored batch cannot deadlock later writers.
+ */
+export class WriteSerializer {
+    /** Resolves when the most recently queued exclusive section has finished. */
+    private barrier: Promise<unknown> = Promise.resolve();
+    /** Tail of in-flight work per key, so same-key calls stay ordered. */
+    private readonly keyed = new Map<string, Promise<unknown>>();
+    /** Keyed work not yet settled — what an exclusive section must wait out. */
+    private readonly active = new Set<Promise<unknown>>();
+
+    /** Runs `fn` with no other write in flight against this provider. */
+    public RunExclusive<T>(fn: () => Promise<T>): Promise<T> {
+        // Snapshot: everything queued before this call. Work queued AFTER waits on our barrier
+        // instead, which is what keeps the wait graph acyclic.
+        const gate = Promise.allSettled([this.barrier, ...this.active]);
+        const run = gate.then(() => fn());
+        this.barrier = run.then(() => undefined, () => undefined);
+        return run;
+    }
+
+    /**
+     * Runs `fn` ordered against other work for the same `key`, concurrently with other keys, and
+     * never overlapping an exclusive section queued before it.
+     */
+    public RunKeyed<T>(key: string, fn: () => Promise<T>): Promise<T> {
+        const priorSameKey = this.keyed.get(key) ?? Promise.resolve();
+        const gate = Promise.allSettled([this.barrier, priorSameKey]);
+        const run = gate.then(() => fn());
+        const settled = run.then(() => undefined, () => undefined);
+        this.keyed.set(key, settled);
+        this.active.add(settled);
+        void settled.then(() => {
+            this.active.delete(settled);
+            // Drop the key only if nothing newer claimed it, so a long run over many entity maps
+            // does not grow this map without bound.
+            if (this.keyed.get(key) === settled) this.keyed.delete(key);
+        });
+        return run;
+    }
+
+    /** Keys currently tracked — for tests and diagnostics only. */
+    public get TrackedKeyCount(): number {
+        return this.keyed.size;
+    }
+}

--- a/packages/Integration/engine/src/__tests__/BatchedWriteMode.test.ts
+++ b/packages/Integration/engine/src/__tests__/BatchedWriteMode.test.ts
@@ -82,7 +82,9 @@ describe('the write mutex, and why the batched path must not nest it', () => {
         });
         const second = e.runWriteExclusive(async () => { order.push('second:start'); });
 
-        await Promise.resolve();
+        // Flush the scheduler rather than a single microtask: the lock's gate settles a small
+        // promise set before entering, so "has it started yet" is not a one-tick question.
+        await new Promise((r) => setTimeout(r, 0));
         expect(order).toEqual(['first:start']);   // second has not started
 
         releaseFirst();

--- a/packages/Integration/engine/src/__tests__/WriteSerializer.test.ts
+++ b/packages/Integration/engine/src/__tests__/WriteSerializer.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The provider holds ONE transaction on ONE connection, so a write issued while that transaction is
+ * open joins it. Serializing every engine write behind a single provider-wide chain made that
+ * impossible — at the cost of queueing unrelated entity maps behind each other even when no
+ * transaction existed.
+ *
+ * The property that must never break: while an exclusive section (the one that opens the provider
+ * transaction) is running, NOTHING else writes. Everything else here is throughput.
+ */
+import { describe, it, expect } from 'vitest';
+import { WriteSerializer } from '../WriteSerializer.js';
+
+const tick = (ms = 5) => new Promise((r) => setTimeout(r, ms));
+
+/** Records an interleaving so tests can assert on overlap rather than on timing. */
+function tracker() {
+    let active = 0;
+    let peak = 0;
+    const order: string[] = [];
+    return {
+        order,
+        get peak() { return peak; },
+        run: (label: string, ms = 5) => async () => {
+            active++; peak = Math.max(peak, active);
+            order.push(`+${label}`);
+            await tick(ms);
+            order.push(`-${label}`);
+            active--;
+            return label;
+        },
+    };
+}
+
+describe('WriteSerializer', () => {
+    it('runs different keys concurrently — the whole point', async () => {
+        const s = new WriteSerializer();
+        const t = tracker();
+        await Promise.all([s.RunKeyed('mapA', t.run('a')), s.RunKeyed('mapB', t.run('b')), s.RunKeyed('mapC', t.run('c'))]);
+        expect(t.peak).toBe(3);
+    });
+
+    it('keeps SAME-key work ordered, so one map never races its own writes', async () => {
+        const s = new WriteSerializer();
+        const t = tracker();
+        await Promise.all([s.RunKeyed('mapA', t.run('1')), s.RunKeyed('mapA', t.run('2')), s.RunKeyed('mapA', t.run('3'))]);
+        expect(t.peak).toBe(1);
+        expect(t.order).toEqual(['+1', '-1', '+2', '-2', '+3', '-3']);
+    });
+
+    it('NOTHING overlaps an exclusive section — the transaction-safety invariant', async () => {
+        const s = new WriteSerializer();
+        const t = tracker();
+        const all = [
+            s.RunKeyed('mapA', t.run('a', 10)),
+            s.RunExclusive(t.run('X', 10)),
+            s.RunKeyed('mapB', t.run('b', 10)),
+            s.RunKeyed('mapC', t.run('c', 10)),
+        ];
+        await Promise.all(all);
+        const start = t.order.indexOf('+X');
+        const end = t.order.indexOf('-X');
+        expect(start).toBeGreaterThanOrEqual(0);
+        // Nothing may start or finish between the exclusive section's own start and end.
+        expect(t.order.slice(start + 1, end)).toEqual([]);
+    });
+
+    it('an exclusive section waits for keyed work already in flight', async () => {
+        const s = new WriteSerializer();
+        const t = tracker();
+        const keyed = s.RunKeyed('mapA', t.run('a', 20));
+        const exclusive = s.RunExclusive(t.run('X', 1));
+        await Promise.all([keyed, exclusive]);
+        expect(t.order).toEqual(['+a', '-a', '+X', '-X']);
+    });
+
+    it('a rejection never deadlocks later writers', async () => {
+        const s = new WriteSerializer();
+        await expect(s.RunKeyed('mapA', async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+        await expect(s.RunExclusive(async () => { throw new Error('bang'); })).rejects.toThrow('bang');
+        // Both chains must still be usable.
+        await expect(s.RunKeyed('mapA', async () => 'ok')).resolves.toBe('ok');
+        await expect(s.RunExclusive(async () => 'fine')).resolves.toBe('fine');
+    });
+
+    it('two exclusive sections never overlap each other', async () => {
+        const s = new WriteSerializer();
+        const t = tracker();
+        await Promise.all([s.RunExclusive(t.run('X', 10)), s.RunExclusive(t.run('Y', 10))]);
+        expect(t.peak).toBe(1);
+    });
+
+    it('does not leak a key per entity map across a long run', async () => {
+        const s = new WriteSerializer();
+        for (let i = 0; i < 50; i++) await s.RunKeyed(`map${i}`, async () => i);
+        await tick(0); // cleanup runs a microtask after the caller's promise settles
+        expect(s.TrackedKeyCount).toBe(0);
+    });
+
+    it('returns the callback value and propagates rejection', async () => {
+        const s = new WriteSerializer();
+        await expect(s.RunKeyed('k', async () => 42)).resolves.toBe(42);
+        await expect(s.RunExclusive(async () => 7)).resolves.toBe(7);
+    });
+});


### PR DESCRIPTION
## Why the lock was provider-wide

The provider holds **one transaction bound to one connection**, so any write issued while that transaction is open joins it. A single provider-wide chain made it impossible for one batch's transaction to swallow an unrelated entity map's watermark save.

That guarantee is real and this PR keeps it. The problem is that the chain could not distinguish *transaction-holding* work from work that opens no transaction at all — so it serialized both. Maps syncing concurrently queued all of their bookkeeping behind each other, and once a connection uses batched writes (which carry their own `TransactionGroup` and never open the provider's) **there is no provider transaction in play at all**, yet every watermark update still waited its turn.

Pairs with #4124: that one lets records within a batch overlap; this one lets entity maps overlap.

## The change

`WriteSerializer` — a two-mode lock, one per provider:

- **`RunExclusive`** — for the branch that opens the provider transaction (`applyOneBatch` on the non-batched path). Nothing else writes while it runs, and it waits for everything already in flight. This is the old behaviour, preserved exactly.
- **`RunKeyed(entityMapID, …)`** — for work scoped to one map that opens no transaction: watermark bookkeeping (load, progress, keyset position, floor, final, partial, restore), match resolution, and a batched apply's post-batch flushes. Different maps overlap; the **same** map stays ordered, so a map never races its own writes.

After the change exactly one call site remains exclusive — the one that calls `provider.BeginTransaction()`.

## Deadlock safety is structural, not argued

An exclusive section **snapshots** the in-flight keyed work at call time; a keyed call **captures the barrier** at call time. Neither ever waits on work created after it, so the wait graph cannot contain a cycle.

This matters because my first draft *did* deadlock — a keyed call waited on a pending exclusive section that was itself waiting on that keyed call. The test suite caught it as a 30-second hang, which is why the invariant is now a property of the construction rather than a comment.

Chains continue past rejections, so one errored batch cannot wedge later writers.

## Tests

`WriteSerializer.test.ts` (8): different keys run concurrently; same key stays strictly ordered; **nothing overlaps an exclusive section** (the transaction-safety invariant, asserted by checking no event appears between the section's own start and end); an exclusive section waits out keyed work already in flight; two exclusive sections never overlap; a rejection leaves both modes usable; keys do not leak across a 50-map run; values and rejections propagate.

Full engine suite green (68 files, 905 tests) — including the existing test documenting that a *nested* exclusive call still deadlocks, which is intended and unchanged.

One existing test flushed a single microtask to assert a write had begun. The gate now settles a small promise set before entering, so that test flushes the scheduler instead. Its assertion is unchanged.

## What this does not do

The non-batched path still holds the exclusive lock for a whole batch, because it owns a provider transaction throughout — so the gain lands on connections using batched writes, which is where the concurrency work is aimed anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)