### PR TITLE
perf(integration): let a batch that proved a row absent skip the per-record check

### DIFF
--- a/.changeset/prefetch-proves-absence.md
+++ b/.changeset/prefetch-proves-absence.md
@@ -1,0 +1,20 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+A batch that already proved a row absent no longer re-checks it per record.
+
+Each apply batch queries the destination for the rows it is about to touch. `CreateRecord` then
+asked again, one record at a time, with an `InnerLoad` — a `SELECT *` returning every column
+including any `NVARCHAR(MAX)` — usually to discover the row is not there. On a first full sync that
+is one wasted round trip per record.
+
+The prefetch now also asks about create-path keys (the key the mapped fields carry, which is exactly
+what `CreateRecord` was about to probe) and returns three separate facts: the stored content hashes,
+the set of keys proven to EXIST, and whether the query covered every record in the batch. Presence is
+tracked separately from hashes on purpose — a row can exist while carrying no hash, and conflating
+the two would turn an update into a duplicate insert.
+
+`CreateRecord` skips its existence load only when absence is proven: the batch covered every record
+AND this key was missing from the result. A partial prefetch, a failed query, or a
+destination-generated key all mean "unknown", and fall through to the load exactly as before.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -296,6 +296,25 @@ export function PositiveInt(v: unknown): number | undefined {
     return typeof v === 'number' && Number.isFinite(v) && v > 0 ? Math.floor(v) : undefined;
 }
 
+/**
+ * What one apply batch already knows about its destination rows before writing any of them.
+ *
+ * Two separate facts, deliberately not conflated: a row can EXIST while carrying no content hash
+ * (written before hashing, or hashed NULL), so "absent from the hash map" cannot mean "absent from
+ * the table". {@link Present} answers existence; {@link Hashes} answers unchanged-ness.
+ */
+interface BatchPrecheck {
+    /** Destination PK (PrimaryKeys order, '|'-joined) → its stored content hash, where one exists. */
+    Hashes: Map<string, string>;
+    /** Destination PKs proven to EXIST, whether or not they carry a hash. */
+    Present: Set<string>;
+    /**
+     * True only when the prefetch asked about EVERY candidate PK in the batch. Absence is provable
+     * only then — a partial or failed prefetch means "unknown", never "not there".
+     */
+    CoversWholeBatch: boolean;
+}
+
 export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     public constructor() {
         super();
@@ -4615,7 +4634,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         result: SyncResult,
         contextUser: UserInfo,
         logger: SyncLogger | undefined,
-        precheckHashes: Map<string, string> | undefined,
+        precheckHashes: BatchPrecheck | undefined,
         reconciledSkipIds?: string[],
         recordMaps?: RecordMapBatch,
         // When false, each record is applied WITHOUT a provider transaction (auto-commit).
@@ -4727,7 +4746,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         result: SyncResult,
         contextUser: UserInfo,
         logger?: SyncLogger,
-        precheckHashes?: Map<string, string>,
+        precheckHashes?: BatchPrecheck,
         reconciledSkipIds?: string[],
         recordMaps?: RecordMapBatch
     ): Promise<void> {
@@ -4748,7 +4767,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         try {
             switch (record.ChangeType) {
                 case 'Create': {
-                    const outcome = await this.CreateRecord(record, companyIntegration, entityMap, contextUser, recordMaps, logger);
+                    const outcome = await this.CreateRecord(record, companyIntegration, entityMap, contextUser, recordMaps, logger, precheckHashes);
                     if (outcome === 'updated') result.RecordsUpdated++;
                     else if (outcome === 'skipped') result.RecordsSkipped++;
                     else result.RecordsCreated++;
@@ -4826,7 +4845,9 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         contextUser: UserInfo,
         recordMaps?: RecordMapBatch,
         /** Optional — lets the keyless-key guard below surface on the run's event stream. */
-        keylessLogger?: SyncLogger
+        keylessLogger?: SyncLogger,
+        /** What the batch already proved about its destination rows, if anything. */
+        precheck?: BatchPrecheck
     ): Promise<'created' | 'updated' | 'skipped'> {
         const md = this.ProviderToUse;
         const entity = await md.GetEntityObject(record.MJEntityName, contextUser);
@@ -4869,7 +4890,19 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             return 'skipped';
         }
 
-        const existed = mappedPK != null
+        // The batch's prefetch may already have proved this row absent. When it did, the load below
+        // is a SELECT * — every column including any NVARCHAR(MAX) — issued once per record, to
+        // learn something the batch established in a single query. Skipping it is the whole point
+        // of widening that prefetch to the create path.
+        //
+        // Only ever used to skip work when absence is PROVEN: the prefetch must have covered every
+        // record in the batch, and this key must be missing from it. Anything less falls through to
+        // the load, because a wrong "absent" turns an update into a duplicate insert.
+        const provablyAbsent = mappedPK != null
+            && precheck?.CoversWholeBatch === true
+            && !precheck.Present.has(pkFields.map(f => String(mappedPK[f.Name] ?? '')).join('|'));
+
+        const existed = mappedPK != null && !provablyAbsent
             ? await entity.InnerLoad(this.BuildEntityPrimaryKey(mappedPK, pkFields))
             : false;
 
@@ -4974,7 +5007,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         entityMap: ICompanyIntegrationEntityMap,
         result: SyncResult,
         contextUser: UserInfo,
-        precheckHashes?: Map<string, string>,
+        precheckHashes?: BatchPrecheck,
         reconciledSkipIds?: string[],
         recordMaps?: RecordMapBatch,
         /** Forwarded to CreateRecord's keyless-key guard on the upsert fallback paths. */
@@ -4982,7 +5015,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     ): Promise<void> {
         if (!record.MatchedMJRecordID) {
             // No matched ID — upsert by PK (insert; or update/skip if the PK already exists)
-            const outcome = await this.CreateRecord(record, companyIntegration, entityMap, contextUser, recordMaps, logger);
+            const outcome = await this.CreateRecord(record, companyIntegration, entityMap, contextUser, recordMaps, logger, precheckHashes);
             if (outcome === 'updated') result.RecordsUpdated++;
             else if (outcome === 'skipped') result.RecordsSkipped++;
             else result.RecordsCreated++;
@@ -4995,7 +5028,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         // unchanged — skip the per-record DB load AND the write. The dirty-flag check
         // below is the fallback for entities without the hash column.
         if (precheckHashes) {
-            const stored = precheckHashes.get(record.MatchedMJRecordID);
+            const stored = precheckHashes.Hashes.get(record.MatchedMJRecordID);
             if (stored && stored === computeContentHash(record.MappedFields ?? {})) {
                 result.RecordsSkipped++;
                 // Re-establish the external↔MJ record map even on the content-hash skip. A record can
@@ -5032,7 +5065,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         const loaded = await entity.InnerLoad(this.BuildEntityPrimaryKey(record.MatchedMJRecordID, pkFields));
         if (!loaded) {
             // Matched-ID row vanished — fall back to upsert by PK (insert; or update/skip if PK exists)
-            const outcome = await this.CreateRecord(record, companyIntegration, entityMap, contextUser, recordMaps, logger);
+            const outcome = await this.CreateRecord(record, companyIntegration, entityMap, contextUser, recordMaps, logger, precheckHashes);
             if (outcome === 'updated') result.RecordsUpdated++;
             else if (outcome === 'skipped') result.RecordsSkipped++;
             else result.RecordsCreated++;
@@ -5112,19 +5145,36 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     private async PrefetchContentHashes(
         batch: MappedRecord[],
         contextUser: UserInfo
-    ): Promise<Map<string, string> | undefined> {
-        const ids = Array.from(new Set(
-            batch.filter(r => r.ChangeType === 'Update' && r.MatchedMJRecordID)
-                 .map(r => r.MatchedMJRecordID as string)
-        ));
-        if (ids.length === 0) return undefined;
-
+    ): Promise<BatchPrecheck | undefined> {
         const entityName = batch[0].MJEntityName;
         const entityInfo = this.ProviderToUse.EntityByName(entityName);
         if (!entityInfo) return undefined;
-        if (!entityInfo.Fields.some(f => f.Name === CONTENT_HASH_COLUMN)) return undefined;
+        if (!entityInfo.Fields?.some(f => f.Name === CONTENT_HASH_COLUMN)) return undefined;
         const pkFields = entityInfo.PrimaryKeys ?? [];
         if (pkFields.length === 0) return undefined;
+
+        // Matched rows contribute the key the matcher already resolved. Unmatched rows contribute
+        // the key their MAPPED FIELDS carry (soft-PK tables key on the external id), which is the
+        // same key CreateRecord is about to probe for one at a time. Asking for all of them in the
+        // one query we are already issuing is what lets that per-record probe be skipped.
+        const wanted = new Set<string>();
+        let everyRecordCovered = true;
+        for (const r of batch) {
+            if (r.ChangeType === 'Update' && r.MatchedMJRecordID) {
+                wanted.add(r.MatchedMJRecordID);
+                continue;
+            }
+            const mappedPK = this.extractMappedPrimaryKey(r, pkFields);
+            if (mappedPK == null) {
+                // A destination-generated key (identity / server-assigned UUID) cannot be known
+                // before the insert, so this record's existence is genuinely unknowable here.
+                everyRecordCovered = false;
+                continue;
+            }
+            wanted.add(pkFields.map(f => String(mappedPK[f.Name] ?? '')).join('|'));
+        }
+        const ids = Array.from(wanted);
+        if (ids.length === 0) return undefined;
         // Map keys must match `record.MatchedMJRecordID`, which is the PK value(s) joined by '|' in
         // PrimaryKeys order (single value for single-PK, "v1|v2" for composite — see MatchEngine).
         const pkNames = pkFields.map(f => f.Name);
@@ -5145,16 +5195,20 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 ResultType: 'simple',
             }, contextUser);
             if (!res.Success) return undefined;
-            const map = new Map<string, string>();
+            const Hashes = new Map<string, string>();
+            const Present = new Set<string>();
             for (const row of res.Results) {
                 // Re-key by the same '|'-join the matcher produced, so the lookup in ApplySingleRecord hits.
                 const key = pkNames.map(n => row[n] ?? '').join('|');
+                // Presence is recorded for EVERY returned row. A row whose hash is NULL still exists,
+                // and treating "no hash" as "no row" would turn an update into a duplicate insert.
+                Present.add(key);
                 const hash = row[CONTENT_HASH_COLUMN];
                 if (typeof hash === 'string' && hash.length > 0) {
-                    map.set(key, hash);
+                    Hashes.set(key, hash);
                 }
             }
-            return map;
+            return { Hashes, Present, CoversWholeBatch: everyRecordCovered };
         } catch (err) {
             // MJ#3047 lesson: this best-effort catch was SILENT, so a failing prefetch (e.g. a reserved-word
             // PK producing an invalid WHERE) disabled the content-hash idempotent skip on EVERY sync with

--- a/packages/Integration/engine/src/__tests__/ApplyPathConcurrency.test.ts
+++ b/packages/Integration/engine/src/__tests__/ApplyPathConcurrency.test.ts
@@ -21,6 +21,9 @@ function makeHost(apply: (rec: { id: number }) => Promise<void>) {
     const host = Object.create(IntegrationEngine.prototype) as unknown as ApplyHost & Record<string, unknown>;
     Object.assign(host, {
         ApplySingleRecord: async (record: { id: number }) => apply(record),
+        // Unrelated collaborator for these tests: they exercise how the batch is WALKED, not what
+        // the batch knows about its destination rows beforehand.
+        PrefetchContentHashes: async () => undefined,
         TouchLastReconciledAt: async () => undefined,
         FlushRecordMaps: async () => undefined,
         runWriteExclusive: async (fn: () => Promise<void>) => fn(),

--- a/packages/Integration/engine/src/__tests__/PrefetchProvesAbsence.test.ts
+++ b/packages/Integration/engine/src/__tests__/PrefetchProvesAbsence.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Scripted by each test before it drives the prefetch.
+const runViewResult = vi.hoisted(() => ({ current: { Success: true, Results: [] as Array<Record<string, unknown>> } }));
+
+vi.mock('@memberjunction/core', async () => {
+    const actual = await vi.importActual<typeof import('@memberjunction/core')>('@memberjunction/core');
+    return {
+        ...actual,
+        RunView: class MockRunView {
+            async RunView() { return runViewResult.current; }
+        },
+    };
+});
+
+const { IntegrationEngine } = await import('../IntegrationEngine.js');
+const { CONTENT_HASH_COLUMN } = await import('../ContentHash.js');
+
+type PrefetchHost = {
+    PrefetchContentHashes: (batch: unknown[], user: unknown) => Promise<{
+        Hashes: Map<string, string>;
+        Present: Set<string>;
+        CoversWholeBatch: boolean;
+    } | undefined>;
+};
+
+const pkField = { Name: 'id' };
+
+/** Drives the real PrefetchContentHashes with RunView's result scripted. */
+function makeHost(rows: Array<Record<string, unknown>>, success = true) {
+    runViewResult.current = { Success: success, Results: rows };
+    const entityInfo = { Fields: [{ Name: 'id' }, { Name: CONTENT_HASH_COLUMN }], PrimaryKeys: [pkField] };
+    const host = Object.create(IntegrationEngine.prototype) as unknown as PrefetchHost & Record<string, unknown>;
+    Object.assign(host, {
+        extractMappedPrimaryKey: (r: { MappedFields?: Record<string, unknown> }) =>
+            r.MappedFields?.id != null ? { id: r.MappedFields.id } : null,
+    });
+    Object.defineProperty(host, 'ProviderToUse', {
+        value: {
+            EntityByName: () => entityInfo,
+            // Dialect is a quoter, not a name — the prefetch builds its WHERE through it.
+            Dialect: {
+                QuoteIdentifier: (n: string) => `[${n}]`,
+                QuoteStringLiteral: (v: string) => `'${v.replace(/'/g, "''")}'`,
+            },
+        },
+        configurable: true,
+    });
+    return host;
+}
+
+const created = (id: string | null) => ({
+    MJEntityName: 'Contacts', ChangeType: 'Create',
+    MappedFields: id == null ? {} : { id },
+    ExternalRecord: { ExternalID: String(id) },
+});
+const updated = (id: string) => ({
+    MJEntityName: 'Contacts', ChangeType: 'Update', MatchedMJRecordID: id,
+    MappedFields: { id }, ExternalRecord: { ExternalID: id },
+});
+
+describe('PrefetchContentHashes — presence is separate from hash', () => {
+    it('records a row as PRESENT even when it carries no content hash', async () => {
+        // A row written before hashing existed, or hashed NULL, is still a row. Treating "absent
+        // from the hash map" as "absent from the table" would turn its update into a second insert.
+        const host = makeHost([{ id: 'a', [CONTENT_HASH_COLUMN]: null }]);
+        const out = await host.PrefetchContentHashes([updated('a')], {});
+        expect(out?.Present.has('a')).toBe(true);
+        expect(out?.Hashes.has('a')).toBe(false);
+    });
+
+    it('asks about CREATE-path keys too, not just matched updates', async () => {
+        const host = makeHost([{ id: 'x', [CONTENT_HASH_COLUMN]: 'h' }]);
+        const out = await host.PrefetchContentHashes([created('x'), created('y')], {});
+        expect(out?.Present.has('x')).toBe(true);
+        expect(out?.Present.has('y')).toBe(false); // asked about, and genuinely not there
+        expect(out?.CoversWholeBatch).toBe(true);
+    });
+
+    it('refuses to claim coverage when a record has no knowable key', async () => {
+        // A destination-generated key (identity / server-assigned UUID) cannot be known before the
+        // insert, so this batch cannot prove anything absent.
+        const host = makeHost([{ id: 'x', [CONTENT_HASH_COLUMN]: 'h' }]);
+        const out = await host.PrefetchContentHashes([created('x'), created(null)], {});
+        expect(out?.CoversWholeBatch).toBe(false);
+    });
+
+    it('returns nothing at all when the query fails — unknown, never "not there"', async () => {
+        const host = makeHost([], false);
+        const out = await host.PrefetchContentHashes([created('x')], {});
+        expect(out).toBeUndefined();
+    });
+});
+
+describe('CreateRecord — the elision is gated on proof', () => {
+    const source = readFileSync(join(__dirname, '..', 'IntegrationEngine.ts'), 'utf8');
+
+    it('skips the existence load ONLY when the batch covered every record and this key was missing', () => {
+        const m = source.match(/const provablyAbsent =[\s\S]{0,400}?;/);
+        expect(m).not.toBeNull();
+        const decl = m![0];
+        expect(decl).toMatch(/precheck\?\.CoversWholeBatch === true/);
+        expect(decl).toMatch(/!precheck\.Present\.has\(/);
+        expect(decl).toMatch(/mappedPK != null/);
+    });
+
+    it('still loads whenever absence is not proven', () => {
+        expect(source).toMatch(/const existed = mappedPK != null && !provablyAbsent/);
+    });
+});


### PR DESCRIPTION
## The redundancy

Every apply batch already asks the destination about the rows it is about to touch — that is what `PrefetchContentHashes` does. Then `CreateRecord` asks again, **once per record**:

```ts
const existed = mappedPK != null
    ? await entity.InnerLoad(this.BuildEntityPrimaryKey(mappedPK, pkFields))
    : false;
```

`InnerLoad` is a `SELECT *` — every column, including any `NVARCHAR(MAX)`. On a first full sync the answer is "not there" for every single record, and we paid a round trip each time to hear it.

The prefetch could have answered, except it only collected `ChangeType === 'Update' && MatchedMJRecordID` — the matched path. Create-path keys were never asked about.

Third in the concurrency/throughput series after #4124 and #4125.

## The change

The prefetch now also asks about create-path keys — the key the record's **mapped fields** carry, which is exactly the key `CreateRecord` was about to probe — and returns three separate facts instead of one map:

```ts
interface BatchPrecheck {
    Hashes: Map<string, string>;   // stored content hash, where one exists
    Present: Set<string>;          // keys proven to EXIST, hash or not
    CoversWholeBatch: boolean;     // did we ask about every record?
}
```

**Presence is deliberately separate from hashes.** A row can exist while carrying no content hash — written before hashing existed, or hashed NULL. Reading "absent from the hash map" as "absent from the table" would turn an update into a duplicate insert, and on a soft-PK table nothing at the database level rejects that (soft keys get a non-unique index only). This is the same class of silent multiplication the keyless-record guard exists to prevent.

## The elision is gated on proof, not optimism

```ts
const provablyAbsent = mappedPK != null
    && precheck?.CoversWholeBatch === true
    && !precheck.Present.has(<this record's key>);
```

Three ways the answer is "unknown", each falling through to the load exactly as today:

- the prefetch query **failed** (returns `undefined` entirely — unknown, never "not there")
- some record in the batch has a **destination-generated key** (identity / server-assigned UUID), which cannot be known before the insert, so `CoversWholeBatch` is false for the whole batch
- this record has no mapped PK at all

A wrong "absent" does not cost a round trip — it costs a duplicate row. So the bar is proof.

## Shape

Carried as a typed `BatchPrecheck` rather than non-enumerable properties smuggled onto the returned `Map`, so the three facts and their differing meanings are visible at every call site that threads them.

## Tests

`PrefetchProvesAbsence.test.ts` (6): a hash-less row is still recorded PRESENT; create-path keys are asked about and genuine absence is reported; a destination-generated key drops `CoversWholeBatch`; a failed query returns nothing rather than a false "absent"; plus two source pins that the elision requires both coverage and a missing key, and that the load still runs otherwise.

Verified adversarially: replacing the coverage requirement with a mere `precheck !== undefined` fails the proof test.

Full engine suite green (69 files, 911 tests).

One incidental robustness fix: `entityInfo.Fields` is now accessed with `?.`. Moving the entity guards ahead of the id-building meant that line began running for batches that previously returned earlier, and it is not guaranteed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)