### PR TITLE
feat(integration): let an operator bound a batched apply's memory

### DIFF
--- a/.changeset/batched-write-flush-ceiling.md
+++ b/.changeset/batched-write-flush-ceiling.md
@@ -1,0 +1,19 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+An operator can bound how much a batched apply holds in memory.
+
+A batched write group holds every enrolled record's rendered SQL and parameters until `Submit`, so
+peak memory for an apply is roughly (maps in flight × group size × row size). With wide rows that is
+the largest allocation a sync makes, and a box that has run out of heap has no way to trade a little
+throughput for headroom.
+
+`MJ_INTEGRATION_BATCH_FLUSH_AT` sets a ceiling on deferred writes per group: on reaching it the
+group is submitted and replaced mid-batch.
+
+Unset — the default — means no mid-batch flush at all, so a batch remains exactly one group and one
+transaction. That default is deliberate: splitting a batch into several transactions is a real
+trade, since an earlier flush stays committed if a later one fails. The per-record fallback that
+follows a failed batch is idempotent, so the split is recoverable, but it is no longer
+all-or-nothing — which is why it happens only when explicitly asked for.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -315,6 +315,18 @@ interface BatchPrecheck {
     CoversWholeBatch: boolean;
 }
 
+/**
+ * How many deferred writes may accumulate in one batched group before it is submitted and replaced.
+ *
+ * `undefined` (unset, or any unusable value) means no mid-batch flush at all — the batch is one
+ * group and one transaction, which is the default and the behaviour that shipped. An explicit value
+ * trades that atomicity for bounded memory on a heap-constrained box.
+ */
+export function ReadFlushCeiling(env: NodeJS.ProcessEnv): number | undefined {
+    const raw = parseInt(env.MJ_INTEGRATION_BATCH_FLUSH_AT ?? '', 10);
+    return Number.isFinite(raw) && raw >= 1 ? raw : undefined;
+}
+
 export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     public constructor() {
         super();
@@ -4373,10 +4385,39 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     //
                     // Per-batch groups are also what keeps failures isolated: a poison record fails
                     // the group its own map owns, and every other map in flight is untouched.
+                    // OPT-IN ceiling on how many writes may sit deferred in one group.
+                    //
+                    // A group holds every enrolled record's rendered SQL and parameters until Submit,
+                    // so peak memory for a batched apply is roughly (maps in flight x group size x row
+                    // size). With wide rows that is the largest allocation a sync makes, and a box that
+                    // has run out of heap has no way to trade a little throughput for headroom.
+                    //
+                    // Unset (the default) means NO mid-batch flush: the batch stays exactly one group
+                    // and one transaction, as today. Setting it below the batch size splits the batch
+                    // into several transactions, which is a real trade — an earlier flush stays
+                    // committed if a later one fails — and is why it is off unless asked for. The
+                    // per-record fallback that follows a failed batch is idempotent, so the split is
+                    // recoverable; it is simply no longer all-or-nothing.
+                    const flushAt = ReadFlushCeiling(process.env);
                     const runBatch = async () => {
+                        let enrolledSinceFlush = 0;
                         for (const record of batch) {
                             result.RecordsProcessed++;
                             await this.ApplySingleRecord(record, companyIntegration, entityMap, result, contextUser, logger, precheckHashes, reconciledSkipIds, recordMaps);
+                            if (flushAt === undefined) continue;
+                            if (++enrolledSinceFlush < flushAt) continue;
+                            enrolledSinceFlush = 0;
+                            // Mutating the context object is what makes the swap visible: every frame
+                            // below shares this same object through AsyncLocalStorage, so replacing the
+                            // group here is what the next record's enrolment sees.
+                            const ctx = this.currentRunContext;
+                            const full = ctx?.writeGroup;
+                            if (!full) continue;
+                            const submitted = await serializeWrite(() => full.Submit());
+                            if (!submitted) throw new Error('Batched write group did not commit');
+                            const fresh = await provider.CreateTransactionGroup();
+                            fresh.BatchedSubmit = true;
+                            ctx.writeGroup = fresh;
                         }
                     };
                     try {

--- a/packages/Integration/engine/src/__tests__/BatchedWriteFlushCeiling.test.ts
+++ b/packages/Integration/engine/src/__tests__/BatchedWriteFlushCeiling.test.ts
@@ -1,0 +1,56 @@
+/**
+ * A batched group holds every enrolled record's rendered SQL and parameters until Submit, so peak
+ * memory for an apply is roughly (maps in flight × group size × row size). With wide rows that is
+ * the largest allocation a sync makes, and a box that has exhausted its heap currently has no way
+ * to trade throughput for headroom.
+ *
+ * The ceiling is OFF unless asked for, because splitting a batch into several transactions is a
+ * real trade: an earlier flush stays committed if a later one fails. These tests pin that default
+ * far more than they pin the splitting.
+ */
+import { describe, it, expect } from 'vitest';
+import { ReadFlushCeiling } from '../IntegrationEngine.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('ReadFlushCeiling', () => {
+    it('is UNSET by default — one batch stays one group and one transaction', () => {
+        expect(ReadFlushCeiling({} as NodeJS.ProcessEnv)).toBeUndefined();
+    });
+
+    it('ignores values that cannot mean a ceiling', () => {
+        for (const bad of ['', '0', '-5', 'lots', 'NaN']) {
+            expect(ReadFlushCeiling({ MJ_INTEGRATION_BATCH_FLUSH_AT: bad } as NodeJS.ProcessEnv)).toBeUndefined();
+        }
+    });
+
+    it('accepts an explicit ceiling', () => {
+        expect(ReadFlushCeiling({ MJ_INTEGRATION_BATCH_FLUSH_AT: '100' } as NodeJS.ProcessEnv)).toBe(100);
+        expect(ReadFlushCeiling({ MJ_INTEGRATION_BATCH_FLUSH_AT: '1' } as NodeJS.ProcessEnv)).toBe(1);
+    });
+});
+
+describe('wiring', () => {
+    const source = readFileSync(join(__dirname, '..', 'IntegrationEngine.ts'), 'utf8');
+
+    it('skips the whole mechanism when no ceiling is set', () => {
+        // The guard must come before any counting, so the default path costs nothing.
+        expect(source).toMatch(/if \(flushAt === undefined\) continue;/);
+    });
+
+    it('replaces the group on the SHARED context object, not a local', () => {
+        // Every frame below reads the group through AsyncLocalStorage from this same object, so a
+        // local reassignment would leave the next record enrolling into the submitted group.
+        expect(source).toMatch(/ctx\.writeGroup = fresh;/);
+    });
+
+    it('arms the replacement group for batched submit', () => {
+        // A fresh group defaults to sequential submit; forgetting this would silently drop the
+        // batching win for every record after the first flush.
+        expect(source).toMatch(/const fresh = await provider\.CreateTransactionGroup\(\);\s*\n\s*fresh\.BatchedSubmit = true;/);
+    });
+
+    it('treats a failed mid-batch submit as a batch failure', () => {
+        expect(source).toMatch(/if \(!submitted\) throw new Error\('Batched write group did not commit'\);/);
+    });
+});


### PR DESCRIPTION
Fourth of the throughput series (#4124, #4125, #4126), and the smallest — worth being explicit about *how* small.

## What it does

A batched write group holds every enrolled record's rendered SQL and parameters until `Submit`, so peak memory for a batched apply is roughly **(maps in flight × group size × row size)**. With wide rows that is the largest allocation a sync makes, and a box that has run out of heap currently has no lever at all.

`MJ_INTEGRATION_BATCH_FLUSH_AT` sets a ceiling on deferred writes per group: on reaching it, the group is submitted and replaced mid-batch.

## The default is the point

**Unset means no mid-batch flush at all** — the batch stays exactly one group and one transaction, and the mechanism costs a single `undefined` check per record when not configured.

That is deliberate rather than conservative-by-habit. Splitting a batch into several transactions is a genuine trade: **an earlier flush stays committed if a later one fails.** The per-record fallback that follows a failed batch is idempotent, so the split is recoverable — but the batch is no longer all-or-nothing, and nobody should discover that by upgrading.

## Honest sizing

I ported this from a tenant patch where the ceiling defaults to 500. Worth noting: `APPLY_BATCH_SIZE` is *also* 500, so **in that deployment the flush never fires** — the group is already bounded by the batch. The mechanism there is inert at its default.

So this is not a capability `next` was missing. It is a **knob**, and its only real use is deliberately setting it *below* the batch size on a heap-constrained box. I have defaulted it to off rather than to 500 so that it is honest about being opt-in, instead of shipping code that looks active and never runs.

## Two details that would be silent bugs

- The replacement group is installed on the **shared run-context object** (`ctx.writeGroup = fresh`), not a local. Every frame below reads its group from that object through `AsyncLocalStorage`; a local reassignment would leave every subsequent record enrolling into the already-submitted group.
- The replacement is armed with `BatchedSubmit = true`. A fresh group defaults to sequential submit, so forgetting this would silently drop the batching win for every record after the first flush.

Both are pinned by tests, since neither would fail loudly.

## Tests

`BatchedWriteFlushCeiling.test.ts` (7): unset/invalid values yield no ceiling (the default-off guarantee), explicit values parse, and four wiring pins — the mechanism is skipped entirely when unset, the group is replaced on the shared context, the replacement is armed, and a failed mid-batch submit fails the batch.

Full engine suite green (70 files, 918 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)