### PR TITLE
feat(rsu): give post-restart pending work a bounded, narrowing retry

### DIFF
--- a/.changeset/rsu-retry-budget.md
+++ b/.changeset/rsu-retry-budget.md
@@ -1,0 +1,21 @@
+---
+"@memberjunction/schema-engine": patch
+"@memberjunction/server": patch
+---
+
+Post-restart RSU work gets a bounded second chance instead of failing on first error.
+
+RSU is a long chain — migrations, CodeGen, a git commit, a compile, a restart — and a failure
+partway through the post-restart consumer is frequently transient: the process was restarted
+mid-consumption, or one provider call failed. That item was marked Failed terminally, so the objects
+it would have mapped were silently never mapped and the only recovery was for someone to notice and
+re-apply the connector by hand.
+
+`RuntimeSchemaManager.RetryPendingWork` re-queues such an item with an incremented `Attempts` count,
+leaving the row Pending. Two guards keep it from becoming a loop: the attempt budget
+(`MAX_RSU_PENDING_ATTEMPTS`, 3) and the requirement that something still be outstanding.
+
+The retry carries only the objects that have NOT been mapped yet, so each attempt is strictly
+smaller and one poison object cannot keep re-running its healthy siblings. When the budget is spent
+the item is failed terminally as before, but the message now names the objects that were never
+mapped — that message is the operator's only signal.

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -1691,6 +1691,10 @@ async function processRSUPendingWork(): Promise<void> {
   for (const pending of pendingItems) {
     const pendingWorkID = pending.ID;
     const item = pending.Work;
+    // Declared outside the try so the catch can narrow a retry to what is still outstanding: what
+    // actually got mapped this attempt. Each retry is then strictly smaller, and one poison object
+    // cannot keep re-running its healthy siblings.
+    const mappedObjectNames = new Set<string>();
     try {
       const md = new Metadata(); // global-provider-ok: server startup recovery — runs once before any per-request context exists
 
@@ -1813,6 +1817,7 @@ async function processRSUPendingWork(): Promise<void> {
         }
 
         if (isNewMap) createdEntityMapIDs.push(entityMapID);
+        mappedObjectNames.add(objName);
 
         // Create field maps — filter by SourceObjectFields (null = all)
         try {
@@ -1966,8 +1971,20 @@ async function processRSUPendingWork(): Promise<void> {
       await rsm.CompletePendingWork(pendingWorkID, systemUser);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      console.error(`[RSU] Failed to process pending work for ${item.CompanyIntegrationID}: ${message}`);
-      await rsm.FailPendingWork(pendingWorkID, message, systemUser);
+      const attempt = (item.Attempts ?? 0) + 1;
+      console.error(`[RSU] Failed to process pending work for ${item.CompanyIntegrationID} (attempt ${attempt}): ${message}`);
+      // RSU is a long chain — migrations, CodeGen, commit, compile, restart — and a failure partway
+      // through is often transient (a restart landing mid-consumption, one bad provider call).
+      // Failing terminally on the first error means the objects this item would have mapped are
+      // silently never mapped, and the only recovery is someone noticing and re-applying by hand.
+      const remaining = (item.SourceObjectNames ?? []).filter(n => !mappedObjectNames.has(n));
+      const requeued = await rsm.RetryPendingWork(pendingWorkID, item, remaining, systemUser);
+      if (!requeued) {
+        // Budget spent, or nothing left to retry. This message is the operator's only signal, so
+        // it names what was left undone rather than just the error.
+        const undone = remaining.length > 0 ? ` Objects never mapped: ${remaining.slice(0, 20).join(', ')}${remaining.length > 20 ? ` (+${remaining.length - 20} more)` : ''}.` : '';
+        await rsm.FailPendingWork(pendingWorkID, `${message}${undone} Re-apply this connector to finish it.`, systemUser);
+      }
     }
   }
 

--- a/packages/SchemaEngine/src/RuntimeSchemaManager.ts
+++ b/packages/SchemaEngine/src/RuntimeSchemaManager.ts
@@ -307,6 +307,13 @@ interface PostMigrationResult {
  * `MJ: RSU Pending Works`.PayloadJSON by {@link RuntimeSchemaManager.WritePendingWork}
  * and read back by the post-restart consumer via {@link RuntimeSchemaManager.ReadPendingWork}.
  */
+/**
+ * How many times one pending-work item may be attempted before it is failed terminally. Three is
+ * enough to survive a restart landing mid-consumption plus one genuinely transient error, and few
+ * enough that a broken item surfaces the same day rather than retrying quietly forever.
+ */
+export const MAX_RSU_PENDING_ATTEMPTS = 3;
+
 export interface RSUPendingWork {
   /**
    * What the post-restart consumer should do with this row.
@@ -320,6 +327,16 @@ export interface RSUPendingWork {
    * different ones.
    */
   WorkType?: 'apply-objects' | 'promote-columns';
+
+  /**
+   * How many times a consumer has already tried and failed to finish this work.
+   *
+   * Absent means zero — every row written before this field existed has not been retried. The
+   * consumer increments it when it re-queues work that failed for a reason a later attempt could
+   * plausibly survive (a restart mid-consumption, a transient provider error), and gives up once
+   * {@link MAX_RSU_PENDING_ATTEMPTS} is reached so a genuinely broken item cannot retry forever.
+   */
+  Attempts?: number;
 
   /**
    * `promote-columns` only: what to finish once the restart has loaded the regenerated entity
@@ -688,6 +705,41 @@ export class RuntimeSchemaManager extends BaseSingleton<RuntimeSchemaManager> {
   }
 
   /** Mark a pending work row Failed, recording why. */
+  /**
+   * Re-queues failed work for one more attempt, narrowed to what has NOT yet been done.
+   *
+   * RSU is a long chain — migrations, CodeGen, a git commit, a compile, a restart — and a failure
+   * partway through it is frequently transient: the process was restarted mid-consumption, or a
+   * provider call failed once. Marking such an item Failed terminally means the objects it would
+   * have mapped are silently never mapped, and the only recovery is for someone to notice and
+   * re-apply the connector by hand.
+   *
+   * The remainder matters as much as the retry. Re-running an item whole would redo the objects
+   * that already succeeded; carrying only the outstanding ones makes each attempt strictly smaller
+   * and keeps a single poison object from blocking its siblings forever.
+   *
+   * Returns false when the budget is spent, in which case the caller should fail the item
+   * terminally — the message it writes is the operator's only signal, so it should name what was
+   * left undone.
+   */
+  public async RetryPendingWork(
+    id: string,
+    work: RSUPendingWork,
+    remainingObjectNames: string[],
+    contextUser: UserInfo,
+    provider?: IMetadataProvider,
+  ): Promise<boolean> {
+    const attempts = (work.Attempts ?? 0) + 1;
+    if (attempts >= MAX_RSU_PENDING_ATTEMPTS) return false;
+    if (remainingObjectNames.length === 0) return false;
+    return this.rewritePendingWorkPayload(
+      id,
+      { ...work, Attempts: attempts, SourceObjectNames: remainingObjectNames },
+      contextUser,
+      provider,
+    );
+  }
+
   public async FailPendingWork(
     id: string,
     errorMessage: string,
@@ -695,6 +747,34 @@ export class RuntimeSchemaManager extends BaseSingleton<RuntimeSchemaManager> {
     provider?: IMetadataProvider,
   ): Promise<boolean> {
     return this.setPendingWorkTerminalStatus(id, 'Failed', errorMessage, contextUser, provider);
+  }
+
+  /**
+   * Rewrites a pending row's payload while leaving it PENDING, so the next consumer picks it up.
+   *
+   * Deliberately not a status transition: the row must stay claimable. Only the payload and the
+   * error message change, and ProcessedAt is left alone so "when did this last complete" keeps
+   * meaning that rather than "when was it last touched".
+   */
+  private async rewritePendingWorkPayload(
+    id: string,
+    work: RSUPendingWork,
+    contextUser: UserInfo,
+    provider?: IMetadataProvider,
+  ): Promise<boolean> {
+    const md = provider ?? new Metadata();
+    const row = await md.GetEntityObject<MJRSUPendingWorkEntity>('MJ: RSU Pending Works', contextUser);
+    if (!(await row.Load(id))) {
+      LogError(`[RSU] Pending work ${id} not found when re-queueing`);
+      return false;
+    }
+    row.PayloadJSON = JSON.stringify(work);
+    row.Status = 'Pending';
+    if (!(await row.Save())) {
+      LogError(`[RSU] Failed to re-queue pending work ${id}: ${row.LatestResult?.CompleteMessage ?? 'unknown error'}`);
+      return false;
+    }
+    return true;
   }
 
   private async setPendingWorkTerminalStatus(

--- a/packages/SchemaEngine/src/__tests__/RSUPendingWork.test.ts
+++ b/packages/SchemaEngine/src/__tests__/RSUPendingWork.test.ts
@@ -38,7 +38,7 @@ vi.mock('@memberjunction/core', async () => {
     };
 });
 
-const { RuntimeSchemaManager } = await import('../RuntimeSchemaManager.js');
+const { RuntimeSchemaManager, MAX_RSU_PENDING_ATTEMPTS } = await import('../RuntimeSchemaManager.js');
 
 const mockContextUser = { ID: 'user-1' } as UserInfo;
 
@@ -236,5 +236,83 @@ describe('RuntimeSchemaManager durable pending work', () => {
             // never look like it persisted anything — this queue exists for durability.
             await expect(rsm.WritePendingWork(samplePayload())).rejects.toThrow(/requires a contextUser/);
         });
+    });
+});
+
+/**
+ * RSU is a long chain — migrations, CodeGen, a git commit, a compile, a restart — and a failure
+ * partway through it is often transient: the process restarted mid-consumption, or one provider
+ * call failed. Failing such an item terminally means the objects it would have mapped are silently
+ * never mapped, and the only recovery is someone noticing and re-applying the connector by hand.
+ */
+describe('RetryPendingWork — a bounded second chance, narrowed to what is left', () => {
+    const rsm = RuntimeSchemaManager.Instance;
+
+    beforeEach(() => {
+        loggedErrors = [];
+        runViewProviders = [];
+        mockRunViewFn = vi.fn().mockResolvedValue({ Success: true, Results: [] });
+        mockGetEntityObjectFn = vi.fn();
+    });
+
+    it('re-queues with the remainder only, and leaves the row PENDING so a consumer picks it up', async () => {
+        const row = createMockRow();
+        mockGetEntityObjectFn.mockResolvedValue(row);
+
+        const ok = await rsm.RetryPendingWork('pw-1', samplePayload(), ['Deal'], mockContextUser);
+
+        expect(ok).toBe(true);
+        expect(row.Status).toBe('Pending');
+        const written = JSON.parse(row.PayloadJSON as unknown as string) as RSUPendingWork;
+        expect(written.SourceObjectNames).toEqual(['Deal']);   // 'Contact' already succeeded
+        expect(written.Attempts).toBe(1);
+    });
+
+    it('counts up across attempts', async () => {
+        const row = createMockRow();
+        mockGetEntityObjectFn.mockResolvedValue(row);
+
+        await rsm.RetryPendingWork('pw-1', { ...samplePayload(), Attempts: 1 }, ['Deal'], mockContextUser);
+
+        expect((JSON.parse(row.PayloadJSON as unknown as string) as RSUPendingWork).Attempts).toBe(2);
+    });
+
+    it('refuses once the budget is spent, so a broken item cannot retry forever', async () => {
+        const row = createMockRow();
+        mockGetEntityObjectFn.mockResolvedValue(row);
+
+        const ok = await rsm.RetryPendingWork('pw-1', { ...samplePayload(), Attempts: MAX_RSU_PENDING_ATTEMPTS - 1 }, ['Deal'], mockContextUser);
+
+        expect(ok).toBe(false);
+        expect(row.Save).not.toHaveBeenCalled();   // caller must fail it terminally instead
+    });
+
+    it('refuses when nothing is outstanding — there is nothing to retry', async () => {
+        const row = createMockRow();
+        mockGetEntityObjectFn.mockResolvedValue(row);
+
+        const ok = await rsm.RetryPendingWork('pw-1', samplePayload(), [], mockContextUser);
+
+        expect(ok).toBe(false);
+        expect(row.Save).not.toHaveBeenCalled();
+    });
+
+    it('reports rather than silently dropping the work when the re-queue write fails', async () => {
+        const row = createMockRow({ Save: vi.fn().mockResolvedValue(false) });
+        mockGetEntityObjectFn.mockResolvedValue(row);
+
+        const ok = await rsm.RetryPendingWork('pw-1', samplePayload(), ['Deal'], mockContextUser);
+
+        expect(ok).toBe(false);
+        expect(loggedErrors.some(m => m.includes('re-queue'))).toBe(true);
+    });
+
+    it('does not touch ProcessedAt — that means "when did this complete", not "when was it touched"', async () => {
+        const row = createMockRow({ ProcessedAt: null });
+        mockGetEntityObjectFn.mockResolvedValue(row);
+
+        await rsm.RetryPendingWork('pw-1', samplePayload(), ['Deal'], mockContextUser);
+
+        expect(row.ProcessedAt).toBeNull();
     });
 });


### PR DESCRIPTION
Last of the five ports recovered from the tenant patch audit (#4124, #4125, #4126, #4127).

## The failure it prevents

RSU is a long chain — migrations, CodeGen, a git commit, a compile, a **restart** — and the last leg runs in a fresh process against durable pending work. A failure there is frequently transient: the process was restarted mid-consumption, or one provider call failed once.

Today the first error is terminal:

```ts
} catch (err) {
    await rsm.FailPendingWork(pendingWorkID, message, systemUser);
}
```

The objects that item would have mapped are then **silently never mapped**. Nothing retries, and the only recovery is someone noticing the connector is half-applied and re-applying it by hand.

## The change

`RetryPendingWork` re-queues the item with an incremented `Attempts` and leaves the row **Pending**, so the next consumer claims it. Two guards stop that becoming a loop:

- the attempt budget, `MAX_RSU_PENDING_ATTEMPTS = 3` — enough to survive a restart landing mid-consumption plus one genuinely transient error, few enough that a broken item surfaces the same day rather than retrying quietly forever;
- something must still be outstanding.

**The narrowing matters as much as the retry.** The consumer tracks which objects it actually mapped, and the re-queued payload carries only the rest. Each attempt is therefore strictly smaller, and one poison object cannot keep re-running its healthy siblings. When the budget is spent the item is failed terminally as before — but the message now names the objects that were never mapped, since that message is the operator's only signal.

## Two deliberate details

- **Re-queueing is not a status transition.** The row must stay claimable, so only the payload changes.
- **`ProcessedAt` is left alone**, so it keeps meaning "when did this complete" rather than "when was it last touched".

## Scope

Only the `apply-objects` path retries. The three resolution failures that precede it — CompanyIntegration missing, Integration entity missing, connector unresolvable — stay terminal, because no number of retries fixes a missing record.

## Tests

Six added to `RSUPendingWork.test.ts` (21 total in that file): the re-queue writes the remainder and leaves the row Pending; attempts accumulate; the budget refuses a fourth try and does **not** write, so the caller fails it terminally; an empty remainder refuses; a failed re-queue write is reported rather than silently dropping the work; and `ProcessedAt` is untouched.

`@memberjunction/schema-engine` suite green (5 files, 106 tests); integration engine suite unaffected (70 files, 918 tests). MJServer typecheck returns to its pre-existing baseline (42 errors from optional peers not built in this worktree, identical on clean `next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)