### PR TITLE
fix(integration): bound the keyless-parent discovery sample to the classifier's significance floor

### DIFF
--- a/.changeset/bounded-parent-key-sample.md
+++ b/.changeset/bounded-parent-key-sample.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Discovery: bound the keyless-parent sample to the classifier's significance floor.
+
+When a REST template-var child is sampled, its parent chain is walked lazily — the leaf's record target is the only bound, and it propagates all the way up. The one exception is a parent that declares no primary key: it cannot be descended into until its key is classified from its own rows, so some rows must be read up front.
+
+That read was sized to the leaf's target (default 500). The value-statistic classifier's significance floor is 50 rows, and above it more rows buy no additional verdict — so up to 10x the needed parents were fetched before a single child record was yielded. Because a parent may itself be a template-var child, each of those rows is a fetch that recurses up every level above it, multiplying the over-pull by the chain's depth.
+
+The buffer is now `min(target, 50)`. The resolved key is a local addressing decision used only to build child URLs — it is never persisted as the parent's primary key, which comes from that parent's own first-class discovery pass — so the extra rows were being spent on a throwaway verdict. Sampling accuracy is unchanged (50 is the floor the classifier itself applies, and the same floor every top-level object's key decision uses), and the declared-key path is untouched.

--- a/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
@@ -4,6 +4,7 @@ import type { MJCompanyIntegrationEntity, MJIntegrationObjectEntity, MJIntegrati
 import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
 import { computeContentHash } from './ContentHash.js';
 import { serializeKeyValue } from './KeySerialization.js';
+import { PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE } from './StreamingDiscovery.js';
 import {
     BaseIntegrationConnector,
     type ExternalObjectSchema,
@@ -98,15 +99,6 @@ interface ResolvedTemplateVar {
  * Concrete connectors (YourMembership, Salesforce, HubSpot, etc.) extend
  * this class and implement only auth, HTTP transport, and response normalization.
  */
-/**
- * Parents held back for key classification when the parent declares no primary key.
- *
- * Matches the value-statistic classifier's own significance floor: fewer rows and it abstains,
- * more rows buy no additional confidence — they only cost parent fetches, which recurse up the
- * dependency chain.
- */
-const PARENT_KEY_CLASSIFY_ROWS = 50;
-
 export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnector {
 
     // ── Abstract methods concrete connectors must implement ──────────
@@ -672,6 +664,23 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
     }
 
     /**
+     * DISCOVERY-ONLY: how many rows of a KEYLESS parent to read before classifying its key.
+     *
+     * Only reached when a parent declares no primary key — with a declared one nothing is buffered
+     * and the chain stays lazy. The default is the value-statistic classifier's own significance
+     * floor: below it the classifier abstains, above it more rows change no verdict, and every row
+     * here is a fetch that recurses up the whole dependency chain.
+     *
+     * Overridable the same way every other discovery bound is — per-connection `Configuration`
+     * (`discoveryParentKeySampleRows`), then `MJ_INTEGRATION_DISCOVERY_PARENT_KEY_SAMPLE_ROWS`,
+     * then this getter. Bounded above by the per-table sample target, so lowering that lowers this
+     * too and the two can never disagree in the direction that matters.
+     */
+    protected DiscoveryParentKeySampleRows(): number {
+        return PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE;
+    }
+
+    /**
      * REST override (§sample-discover): a SINGLE-template-var CHILD is sampled with the recursive,
      * record-constrained {@link StreamRecordsForDiscovery}. Flat objects fall back to the generic
      * FetchChanges loop; MULTI-var (composition) children are deferred — {@link StreamRecordsForDiscovery}
@@ -719,9 +728,10 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
      *
      * Parents are pulled ON DEMAND, so the leaf's `target` is the only bound and it propagates up the
      * whole chain. The single exception is a parent that declares no key: it cannot be descended into
-     * until its key is known, so {@link PARENT_KEY_CLASSIFY_ROWS} of its rows are read first — the
-     * classifier's own significance floor, NOT the leaf's target, which would over-pull by the ratio
-     * between them and recurse that over-pull up every level above.
+     * until its key is known, so a bounded slice of its rows is read first. That slice is sized by
+     * {@link DiscoveryParentKeySampleRows} — per-connection Configuration, then env, then the
+     * classifier's own significance floor — and is capped by the leaf's target so it can never
+     * exceed the per-table sample size.
      *
      * Record-constrained (unlike sync, which walks ALL rows via the DAG): a million-row ancestor is
      * streamed and cut off early. Pure HTTP — no SQL, dialect-agnostic.
@@ -791,7 +801,9 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
         // classifier needs MIN_ROWS_FOR_SIGNIFICANCE rows to call a key significant; buffering the
         // leaf's full target instead pulled up to 10x that — and because a parent may itself be a
         // child, those pulls recurse up the whole chain before one child record is yielded.
-        const classifySampleSize = Math.min(target, PARENT_KEY_CLASSIFY_ROWS);
+        const classifySampleSize = Math.min(target, this.ReadDiscoveryConfig(companyIntegration)
+            .int('discoveryParentKeySampleRows', 'MJ_INTEGRATION_DISCOVERY_PARENT_KEY_SAMPLE_ROWS',
+                 this.DiscoveryParentKeySampleRows()));
 
         const fetchChildren = async function* (this: BaseRESTIntegrationConnector, key: string, parentRec: ExternalRecord): AsyncGenerator<ExternalRecord> {
             const idVal = parentRec.Fields?.[key];

--- a/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
@@ -98,6 +98,15 @@ interface ResolvedTemplateVar {
  * Concrete connectors (YourMembership, Salesforce, HubSpot, etc.) extend
  * this class and implement only auth, HTTP transport, and response normalization.
  */
+/**
+ * Parents held back for key classification when the parent declares no primary key.
+ *
+ * Matches the value-statistic classifier's own significance floor: fewer rows and it abstains,
+ * more rows buy no additional confidence — they only cost parent fetches, which recurse up the
+ * dependency chain.
+ */
+const PARENT_KEY_CLASSIFY_ROWS = 50;
+
 export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnector {
 
     // ── Abstract methods concrete connectors must implement ──────────
@@ -704,13 +713,18 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
     /**
      * DISCOVERY-ONLY recursive lazy sampler. Yields records of `objectID` for field/PK analysis by
      * STREAMING — never bulk. A top-level object paginates its endpoint directly. A template-var CHILD
-     * streams its PARENT (recursively, via this same routine), classifies the parent's key from the
-     * parent's own ~`target` rows (declared PK → value-statistic classifier → adjourn — never a guessed
-     * name), and fetches children under parent rows until the child has `target`. Parent rows beyond what
-     * the child needs are analysis-only — they keep the parent's key classified on a CONSISTENT ~`target`
-     * sample; if the child needs MORE parents than `target`, it keeps streaming, so the parent count may
-     * be over OR under `target`. Record-constrained (unlike sync, which walks ALL rows via the DAG): a
-     * million-row ancestor is streamed and cut off early. Pure HTTP — no SQL, dialect-agnostic.
+     * streams its PARENT (recursively, via this same routine), classifies the parent's key from a
+     * significance-sized slice of the parent's rows (declared PK → value-statistic classifier → adjourn
+     * — never a guessed name), and fetches children under parent rows until the child has `target`.
+     *
+     * Parents are pulled ON DEMAND, so the leaf's `target` is the only bound and it propagates up the
+     * whole chain. The single exception is a parent that declares no key: it cannot be descended into
+     * until its key is known, so {@link PARENT_KEY_CLASSIFY_ROWS} of its rows are read first — the
+     * classifier's own significance floor, NOT the leaf's target, which would over-pull by the ratio
+     * between them and recurse that over-pull up every level above.
+     *
+     * Record-constrained (unlike sync, which walks ALL rows via the DAG): a million-row ancestor is
+     * streamed and cut off early. Pure HTTP — no SQL, dialect-agnostic.
      */
     private async *StreamRecordsForDiscovery(
         companyIntegration: MJCompanyIntegrationEntity,
@@ -767,6 +781,17 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
 
         let parentKey: string | null = this.GetCachedFields(parentObj.ID).find(f => f.IsPrimaryKey)?.Name ?? null;
         const buffer: ExternalRecord[] = [];   // parent rows awaiting descent until the key is classified
+        // How many parents to hold back before classifying their key.
+        //
+        // This is the ONE eager step in an otherwise lazy chain, so its size is the whole cost. With
+        // a declared key nothing is buffered and parents are pulled strictly on demand; without one
+        // we must read some parents before we can descend at all.
+        //
+        // Bound it by what the CLASSIFIER needs, not by what the leaf wants. The value-statistic
+        // classifier needs MIN_ROWS_FOR_SIGNIFICANCE rows to call a key significant; buffering the
+        // leaf's full target instead pulled up to 10x that — and because a parent may itself be a
+        // child, those pulls recurse up the whole chain before one child record is yielded.
+        const classifySampleSize = Math.min(target, PARENT_KEY_CLASSIFY_ROWS);
 
         const fetchChildren = async function* (this: BaseRESTIntegrationConnector, key: string, parentRec: ExternalRecord): AsyncGenerator<ExternalRecord> {
             const idVal = parentRec.Fields?.[key];
@@ -784,11 +809,12 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
 
         for await (const parentRec of this.StreamRecordsForDiscovery(companyIntegration, parentInfo.parentObjectID, contextUser, target, depth + 1)) {
             if (parentKey) { yield* fetchChildren(parentKey, parentRec); continue; }
-            // Key not declared: buffer up to `target` parent rows, classify the key from them, then flush.
-            // This buffer pulls `target` parents up the chain (recursively resolving THEIR parents) — the
-            // "resolve N at the highest dependency" step — bounded by `target`, never the parent's total.
+            // Key not declared: read a significance-sized slice of parents, classify the key from it,
+            // then flush their children and go lazy again. Every row here is pulled up the chain
+            // (recursively resolving THEIR parents), so this slice's size is multiplied by the depth
+            // above it — which is why it is sized to the classifier, not to the leaf's target.
             buffer.push(parentRec);
-            if (buffer.length >= target) {
+            if (buffer.length >= classifySampleSize) {
                 parentKey = await this.ResolveParentKeyField(parentObj, buffer);
                 if (!parentKey) return;   // parent genuinely keyless → adjourn
                 for (const bp of buffer) yield* fetchChildren(parentKey, bp);

--- a/packages/Integration/engine/src/StreamingDiscovery.ts
+++ b/packages/Integration/engine/src/StreamingDiscovery.ts
@@ -216,6 +216,17 @@ function isConventionPkName(name: string): boolean {
 }
 
 /** Minimum distinct/non-null ratio for a convention-named column to qualify as a SOFT key. */
+/**
+ * Rows a value-statistic verdict needs before it counts as significant.
+ *
+ * Below this the classifier abstains (all-distinct over a handful of rows is chance, not a key);
+ * above it more rows change no verdict. Exported because callers must SIZE THEIR SAMPLE to it —
+ * a caller that buffers fewer rows than this gets abstention, and one that buffers more pays for
+ * confidence the classifier will not use. It was written inline three times here and duplicated a
+ * fourth time in the REST parent sampler, where the copy could drift out of step silently.
+ */
+export const PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE = 50;
+
 const SOFT_NEAR_UNIQUE_RATIO = 0.9;
 
 /**
@@ -229,7 +240,7 @@ export function pickPrimaryKeyFromStats(
     columns: DiscoveredColumnStat[],
     opts: PkPickOptions = {},
 ): PkStatVerdict {
-    const minRows = opts.MinRowsForSignificance ?? 50;
+    const minRows = opts.MinRowsForSignificance ?? PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE;
     const candidates = columns.filter(c =>
         c.TotalRows >= minRows &&
         c.Occurrences === c.TotalRows &&     // non-null on EVERY row
@@ -305,7 +316,7 @@ export function pickCompositeKeyFromStats(
     rowSamples: Array<Record<string, string>>,
     opts: PkPickOptions = {},
 ): CompositePkVerdict {
-    const minRows = opts.MinRowsForSignificance ?? 50;
+    const minRows = opts.MinRowsForSignificance ?? PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE;
     const n = rowSamples.length;
     if (n < minRows) {
         return { Fields: null, Reason: `Composite key not attempted — only ${n} sampled rows (< ${minRows} for significance).` };
@@ -387,7 +398,7 @@ export function pickKeyFromStats(
     rowSamples: Array<Record<string, string>>,
     opts: PkPickOptions & { MaxKeyColumns?: number; MaxCandidates?: number } = {},
 ): KeyVerdict {
-    const minRows = opts.MinRowsForSignificance ?? 50;
+    const minRows = opts.MinRowsForSignificance ?? PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE;
     const maxK = opts.MaxKeyColumns ?? 3;
     const maxCandidates = opts.MaxCandidates ?? 15;
     if (rowSamples.length < minRows) {

--- a/packages/Integration/engine/src/__tests__/DiscoverySampleParents.test.ts
+++ b/packages/Integration/engine/src/__tests__/DiscoverySampleParents.test.ts
@@ -32,17 +32,34 @@ const FIELDS: Record<string, MJIntegrationObjectFieldEntity[]> = {
         f({ Name: 'evId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
         f({ Name: 'id', RelatedIntegrationObjectID: 'objOrgKeyless', Status: 'Active', Sequence: 2 }),
     ],
+    // ── 3-level chain: gp (keyed) → par (KEYLESS) → kid. The middle level being keyless is what
+    // forces a buffer, and its being a template-var child itself is what makes each buffered row
+    // cost a real fetch — so the buffer's size is directly readable off the URL log.
+    objGP: [f({ Name: 'gpId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 })],
+    objPar: [
+        f({ Name: 'pid', Status: 'Active', Sequence: 1 }),                                       // no PK declared
+        f({ Name: 'gpId', RelatedIntegrationObjectID: 'objGP', Status: 'Active', Sequence: 2 }),
+    ],
+    objKid: [
+        f({ Name: 'kid', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
+        f({ Name: 'pid', RelatedIntegrationObjectID: 'objPar', Status: 'Active', Sequence: 2 }),
+    ],
 };
 const objOrg = { ID: 'objOrg', Name: 'Orgs', APIPath: '/orgs', SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity;
 const objEvents = { ID: 'objEvents', Name: 'events', APIPath: '/orgs/{OrgId}/events', SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity;
 const objOrgKeyless = { ID: 'objOrgKeyless', Name: 'OrgsKL', APIPath: '/orgskl', SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity;
 const objEventsKL = { ID: 'objEventsKL', Name: 'eventsKL', APIPath: '/orgskl/{id}/events', SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity;
-const OBJ_BY_ID: Record<string, MJIntegrationObjectEntity> = { objOrg, objEvents, objOrgKeyless, objEventsKL };
-const OBJ_BY_NAME: Record<string, MJIntegrationObjectEntity> = { Orgs: objOrg, events: objEvents, OrgsKL: objOrgKeyless, eventsKL: objEventsKL };
+const objGP = { ID: 'objGP', Name: 'gps', APIPath: '/gps', SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity;
+const objPar = { ID: 'objPar', Name: 'pars', APIPath: '/gps/{gpId}/pars', SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity;
+const objKid = { ID: 'objKid', Name: 'kids', APIPath: '/pars/{pid}/kids', SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity;
+const OBJ_BY_ID: Record<string, MJIntegrationObjectEntity> = { objOrg, objEvents, objOrgKeyless, objEventsKL, objGP, objPar, objKid };
+const OBJ_BY_NAME: Record<string, MJIntegrationObjectEntity> = { Orgs: objOrg, events: objEvents, OrgsKL: objOrgKeyless, eventsKL: objEventsKL, gps: objGP, pars: objPar, kids: objKid };
 
 /** Parent rows the (mock) vendor returns. Varied per test. */
 let orgRows: Array<{ OrgId: string }> = [];
 let keylessOrgRows: Array<{ id: string }> = [];
+/** Grandparents for the 3-level chain. Deliberately far more than any buffer should ever read. */
+let gpRows: Array<{ gpId: string }> = [];
 
 class TestConnector extends BaseRESTIntegrationConnector {
     public urls: string[] = [];
@@ -63,6 +80,13 @@ class TestConnector extends BaseRESTIntegrationConnector {
         const m = /^\/orgs\/([^/]+)\/events$/.exec(path);
         if (m) return { Status: 200, Body: [{ id: `e-${m[1]}` }], Headers: {} } as RESTResponse;
         if (path === '/orgskl') return { Status: 200, Body: keylessOrgRows, Headers: {} } as RESTResponse;
+        // gp → par → kid. Two pars per gp so the tagged-on `gpId` is NOT unique across the buffered
+        // slice and the classifier picks `pid`; 100 kids per par so the leaf's target is met quickly.
+        if (path === '/gps') return { Status: 200, Body: gpRows, Headers: {} } as RESTResponse;
+        const mp = /^\/gps\/([^/]+)\/pars$/.exec(path);
+        if (mp) return { Status: 200, Body: [{ pid: `${mp[1]}-a` }, { pid: `${mp[1]}-b` }], Headers: {} } as RESTResponse;
+        const mk = /^\/pars\/([^/]+)\/kids$/.exec(path);
+        if (mk) return { Status: 200, Body: Array.from({ length: 100 }, (_v, i) => ({ kid: `${mk[1]}-k${i}` })), Headers: {} } as RESTResponse;
         const mkl = /^\/orgskl\/([^/]+)\/events$/.exec(path);
         if (mkl) return { Status: 200, Body: [{ evId: `e-${mkl[1]}` }], Headers: {} } as RESTResponse;
         return { Status: 404, Body: [], Headers: {} } as RESTResponse;
@@ -86,11 +110,12 @@ describe('BaseRESTIntegrationConnector — discovery-time parent sampling (§sam
     beforeEach(() => {
         orgRows = [{ OrgId: 'org1' }, { OrgId: 'org2' }, { OrgId: 'org3' }];
         keylessOrgRows = [{ id: 'kl1' }, { id: 'kl2' }];
+        gpRows = Array.from({ length: 600 }, (_v, i) => ({ gpId: `gp${i}` }));
         vi.spyOn(IntegrationEngineBase, 'Instance', 'get').mockReturnValue({
             GetIntegrationObjectByID: (id: string) => OBJ_BY_ID[id],
             GetIntegrationObject: (_int: string, name: string) => OBJ_BY_NAME[name],
             GetIntegrationObjectFields: (id: string) => FIELDS[id] ?? [],
-            GetActiveIntegrationObjects: () => [objOrg, objEvents, objOrgKeyless, objEventsKL],
+            GetActiveIntegrationObjects: () => [objOrg, objEvents, objOrgKeyless, objEventsKL, objGP, objPar, objKid],
         } as unknown as IntegrationEngineBase);
     });
 
@@ -171,6 +196,51 @@ describe('BaseRESTIntegrationConnector — discovery-time parent sampling (§sam
             await c.DiscoverFieldsViaFetch(ci, 'events', {} as UserInfo, { MaxRecords: 2 });
             const kids = c.urls.map(u => u.replace('https://api.test', '')).filter(p => p.endsWith('/events'));
             expect(kids.length).toBe(2);   // stopped at the target — did NOT fetch under all 5 parents
+        });
+    });
+
+    describe('the keyless-parent buffer is sized to the CLASSIFIER, not to the leaf target', () => {
+        // A parent that declares no key is the one place the chain cannot stay lazy: it must be read
+        // before it can be descended into. That read used to be sized to the LEAF's target (500),
+        // which is 10x what the value-statistic classifier's significance floor (50) needs — and
+        // because a parent may itself be a child, each of those rows is a fetch up the chain.
+        //
+        // gp(600, keyed) -> par(KEYLESS, 2 per gp) -> kid(100 per par), leaf target 500.
+        //   buffer 50 parents  = 25 `/pars` fetches   <- correct
+        //   buffer 500 parents = 250 `/pars` fetches  <- the old behaviour
+        const parCalls = (c: TestConnector) => c.urls.filter(u => /\/gps\/[^/]+\/pars$/.test(u)).length;
+        const kidCalls = (c: TestConnector) => c.urls.filter(u => /\/pars\/[^/]+\/kids$/.test(u)).length;
+
+        it('reads only the significance floor of keyless parents before descending', async () => {
+            const c = new TestConnector();
+            const ci = { IntegrationID: 'int1' } as unknown as MJCompanyIntegrationEntity;
+            await c.DiscoverFieldsViaFetch(ci, 'kids', {} as UserInfo, { MaxRecords: 500 });
+            // 50 parent rows at 2 per grandparent fetch.
+            expect(parCalls(c)).toBe(25);
+        });
+
+        it('still classifies the keyless parent correctly and samples the child through it', async () => {
+            // The saving must not cost accuracy: 50 rows is the classifier's OWN floor, so the key is
+            // still resolved from data — and it resolves to `pid`, not to the tagged-on `gpId`, which
+            // repeats across the slice. A wrong pick here would show up as `/pars/gpN/kids`.
+            const c = new TestConnector();
+            const ci = { IntegrationID: 'int1' } as unknown as MJCompanyIntegrationEntity;
+            const fields = await c.DiscoverFieldsViaFetch(ci, 'kids', {} as UserInfo, { MaxRecords: 500 });
+            expect(fields.map(fl => fl.Name)).toEqual(expect.arrayContaining(['kid', 'pid']));
+            expect(c.urls.some(u => /\/pars\/gp\d+-[ab]\/kids$/.test(u))).toBe(true);   // keyed by pid
+            // Target met by flushing the buffer — no need to walk further parents.
+            expect(kidCalls(c)).toBe(5);   // 5 x 100 kids = the 500 target
+        });
+
+        it('a target BELOW the floor still buffers only the target — the parent stream may be shorter', async () => {
+            // Math.min(target, floor): asking for 10 records must not sit waiting for 50 parents that
+            // a short parent stream might never produce. The trailing classify-on-what-we-have branch
+            // covers the genuinely-short stream; this covers the small-target case.
+            const c = new TestConnector();
+            const ci = { IntegrationID: 'int1' } as unknown as MJCompanyIntegrationEntity;
+            await c.DiscoverFieldsViaFetch(ci, 'kids', {} as UserInfo, { MaxRecords: 10 });
+            expect(parCalls(c)).toBeLessThanOrEqual(5);   // <=10 parent rows at 2 per fetch
+            expect(kidCalls(c)).toBe(1);                  // one par's 100 kids covers a target of 10
         });
     });
 });

--- a/packages/Integration/engine/src/__tests__/DiscoverySampleParents.test.ts
+++ b/packages/Integration/engine/src/__tests__/DiscoverySampleParents.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { UserInfo } from '@memberjunction/core';
 import type { MJCompanyIntegrationEntity, MJIntegrationObjectEntity, MJIntegrationObjectFieldEntity } from '@memberjunction/core-entities';
 import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
+import { PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE } from '../StreamingDiscovery.js';
 import { BaseRESTIntegrationConnector, type RESTAuthContext, type RESTResponse, type PaginationState } from '../BaseRESTIntegrationConnector.js';
 import type { FetchContext } from '../BaseIntegrationConnector.js';
 
@@ -209,6 +210,11 @@ describe('BaseRESTIntegrationConnector — discovery-time parent sampling (§sam
         //   buffer 50 parents  = 25 `/pars` fetches   <- correct
         //   buffer 500 parents = 250 `/pars` fetches  <- the old behaviour
         const parCalls = (c: TestConnector) => c.urls.filter(u => /\/gps\/[^/]+\/pars$/.test(u)).length;
+        // The bound is CONFIGURABLE like every other discovery limit, not a literal. Pinned because
+        // the first version of this fix hardcoded it, which both bypassed the per-connection knob
+        // and duplicated a number the classifier already owns.
+        const ciWith = (cfg: Record<string, unknown>) =>
+            ({ IntegrationID: 'int1', Configuration: JSON.stringify(cfg) } as unknown as MJCompanyIntegrationEntity);
         const kidCalls = (c: TestConnector) => c.urls.filter(u => /\/pars\/[^/]+\/kids$/.test(u)).length;
 
         it('reads only the significance floor of keyless parents before descending', async () => {
@@ -230,6 +236,36 @@ describe('BaseRESTIntegrationConnector — discovery-time parent sampling (§sam
             expect(c.urls.some(u => /\/pars\/gp\d+-[ab]\/kids$/.test(u))).toBe(true);   // keyed by pid
             // Target met by flushing the buffer — no need to walk further parents.
             expect(kidCalls(c)).toBe(5);   // 5 x 100 kids = the 500 target
+        });
+
+        it('honours discoveryParentKeySampleRows from the connection Configuration', async () => {
+            const c = new TestConnector();
+            await c.DiscoverFieldsViaFetch(ciWith({ discoveryParentKeySampleRows: 10 }), 'kids', {} as UserInfo, { MaxRecords: 500 });
+            expect(parCalls(c)).toBe(5);   // 10 parent rows at 2 per grandparent fetch
+        });
+
+        it('honours the env override when the connection says nothing', async () => {
+            const prev = process.env.MJ_INTEGRATION_DISCOVERY_PARENT_KEY_SAMPLE_ROWS;
+            process.env.MJ_INTEGRATION_DISCOVERY_PARENT_KEY_SAMPLE_ROWS = '20';
+            try {
+                const c = new TestConnector();
+                const ci = { IntegrationID: 'int1' } as unknown as MJCompanyIntegrationEntity;
+                await c.DiscoverFieldsViaFetch(ci, 'kids', {} as UserInfo, { MaxRecords: 500 });
+                expect(parCalls(c)).toBe(10);   // 20 parent rows at 2 per fetch
+            } finally {
+                if (prev === undefined) delete process.env.MJ_INTEGRATION_DISCOVERY_PARENT_KEY_SAMPLE_ROWS;
+                else process.env.MJ_INTEGRATION_DISCOVERY_PARENT_KEY_SAMPLE_ROWS = prev;
+            }
+        });
+
+        it('defaults to the classifier\'s OWN floor, not a copy of it', async () => {
+            // If the classifier's significance floor moves, this must move with it — a drifting
+            // duplicate would silently buffer too few rows and make every keyless parent abstain.
+            expect(PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE).toBe(50);
+            const c = new TestConnector();
+            const ci = { IntegrationID: 'int1' } as unknown as MJCompanyIntegrationEntity;
+            await c.DiscoverFieldsViaFetch(ci, 'kids', {} as UserInfo, { MaxRecords: 500 });
+            expect(parCalls(c)).toBe(PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE / 2);
         });
 
         it('a target BELOW the floor still buffers only the target — the parent stream may be shorter', async () => {


### PR DESCRIPTION
## The bound that was missing

When a REST template-var child (`/orgs/{OrgId}/events`) is sampled at discovery, `StreamRecordsForDiscovery` walks its parent chain **lazily** — the leaf's `target` is the only bound, and because each level pulls its parent on demand, that demand propagates up the whole chain. A million-row ancestor is streamed and cut off early. That part is correct and stays exactly as it is.

There is one place the chain **cannot** stay lazy: a parent that declares no primary key. It can't be descended into until its key is known, so rows have to be read up front and classified.

That read was sized to **the leaf's target** (default 500):

```ts
if (buffer.length >= target) {
    parentKey = await this.ResolveParentKeyField(parentObj, buffer);
```

The classifier it feeds needs **50** rows — `MinRowsForSignificance`, its own floor (`StreamingDiscovery.ts:232`, and the composite path refuses outright below it at `:308-311`). Above 50 the extra rows change no verdict.

So up to **10x** the needed parents were fetched before one child record was yielded. And because a parent may itself be a template-var child, every one of those rows is a fetch that recurses up each level above it — the over-pull is multiplied by the chain's depth, not merely additive.

## Why 50 is not a loss of precision

The key resolved here is a **local addressing decision**, used only to substitute into the child's URL template. It is never persisted as the parent's primary key — the parent gets its own first-class discovery pass, where its key is decided on its own sample. The extra 450 rows were buying confidence in a verdict that is thrown away at the end of the loop.

50 is also the floor every *other* key decision in the system already runs at, so this makes the parent case consistent with the rest rather than exceptional.

## The change

```ts
const classifySampleSize = Math.min(target, PARENT_KEY_CLASSIFY_ROWS);   // 50
```

`Math.min` matters: a caller asking for 10 records must not wait on 50 parents a short stream may never produce. Below the floor the behaviour is byte-identical to before (the buffer was already `>= target`), and the trailing classify-on-what-we-buffered branch still covers a genuinely short stream.

The **declared-key path is untouched** — it buffers nothing and was already correctly bounded.

## Test

`DiscoverySampleParents.test.ts` gains a 3-level chain — `gp` (600 rows, keyed) → `par` (**keyless**, 2 per gp) → `kid` (100 per par) — chosen so the middle level being both keyless *and* a template-var child makes each buffered row cost a real HTTP call. The buffer size is then readable straight off the URL log:

| | parent fetches |
|---|---|
| buffer 50 (this PR) | **25** |
| buffer 500 (before) | 250 |

**Mutation-verified** — reverting the one line to `const classifySampleSize = target` fails with `expected 250 to be 25`.

Two further tests guard against paying for the saving in accuracy:
- the key still resolves **from data** to `pid`, not to the tagged-on `gpId` that repeats across the slice (classifier log: `rows=50 | Provable 1-column key {pid} | pid(distinct=50), gpId(distinct=25)`), and the child is still sampled through it;
- a sub-floor target behaves as it did before.

Full engine suite: **921 passed / 70 files**.