### PR TITLE
fix(ci): record 5.51.2 in the ledger, and stop the record step dying on a dirty tree

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1134,7 +1134,14 @@ jobs:
             exit 1
           fi
           git fetch origin next
-          git checkout -B record-release-lines origin/next
+          # -f is load-bearing. The build step rewrites tracked generated files — on 5.51.2 it was
+          # packages/GraphQLDataProvider/src/version.generated.ts — so the tree is dirty by the time
+          # this step runs, and a plain checkout aborts with "local changes would be overwritten".
+          # That is exactly how 5.51.2 shipped to npm with no ledger entry: everything that matters
+          # (release commit, tag, GitHub Release) had already been pushed, and the job then died on
+          # its last step. Discarding here is safe for that same reason — what is being thrown away
+          # is build output, regenerated on the next run.
+          git checkout -f -B record-release-lines origin/next
           node ci/append-release-line.mjs --version "${VERSION#v}" --db-impact "${DB_IMPACT:-none}" --since "$PREV" --until "$VERSION"
           node ci/validate-release-lines.mjs --base origin/next --mode push
           git add release-lines.json

--- a/release-lines.json
+++ b/release-lines.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./ci/release-lines.schema.json",
   "edge": {
-    "newest": "6.1.0-edge.3",
+    "newest": "6.1.0-edge.4",
     "releases": {
       "6.1.0-edge.0": {
         "dbImpact": "schema"
@@ -13,6 +13,9 @@
         "dbImpact": "schema"
       },
       "6.1.0-edge.3": {
+        "dbImpact": "schema"
+      },
+      "6.1.0-edge.4": {
         "dbImpact": "schema"
       }
     }
@@ -34,13 +37,16 @@
     "5.51": {
       "status": "certified",
       "certifiedBuild": "5.51.0",
-      "newest": "5.51.1",
+      "newest": "5.51.2",
       "candidateDate": "2026-07-31",
       "certifiedDate": "2026-08-14",
       "supportEnds": "2027-02-14",
       "upgradeImpact": "none",
       "releases": {
         "5.51.1": {
+          "dbImpact": "none"
+        },
+        "5.51.2": {
           "dbImpact": "none"
         }
       },


### PR DESCRIPTION
## What happened

5.51.2 published to npm cleanly — 296 packages, `latest` correctly carrying 5.51.2 via the new #3963 path — and then the run went red on its **last** step, so `release-lines.json` never got its entry.

```
error: Your local changes to the following files would be overwritten by checkout:
	packages/GraphQLDataProvider/src/version.generated.ts
Please commit your changes or stash them before you switch branches.
Aborting
##[error]Process completed with exit code 1
```

The LTS bookkeeping step does `git checkout -B record-release-lines origin/next`. The build step earlier in the same job rewrites tracked generated files, so the tree is dirty by then and the checkout aborts. This is not specific to 5.51.2 — it will happen on **every** line release.

The failure is benign in the sense that everything that matters (packages on npm, release commit, tag, GitHub Release) was already pushed before it. It is not benign in the sense that the ledger silently falls behind the registry, which is the exact drift this step was built to prevent.

## The fix

`git checkout -f -B`. Discarding is safe here for the same reason the failure was recoverable: by this point the release commit, tag and GitHub Release are all pushed, and what gets thrown away is build output that regenerates on the next run.

## Backfill

Both entries were generated by `ci/append-release-line.mjs`, not hand-written, so they match exactly what the workflow would have produced:

| Version | dbImpact | Source |
|---|---|---|
| 5.51.2 | `none` | code-only — no migrations in `v5.51.1..v5.51.2` |
| 6.1.0-edge.4 | `schema` | classified from 5 migrations in `v6.1.0-edge.3..v6.1.0-edge.4` |

`node ci/validate-release-lines.mjs --base origin/next --mode push` → `OK`.

**`edge.4` was missed for a different reason** and needs no code change: its publish run (`32990299006`, 2026-08-26) has no ledger step at all — the Edge bookkeeping step did not exist yet. The Edge path also has no `checkout -B` of its own; it reuses the `next` checkout from the merge step above it, so the dirty-tree bug does not reach it.

## For the reviewer

- **The `-f` is the only behavioural change.** It discards uncommitted work in the runner's tree at that point in the job. Worth confirming you agree nothing else in that job can be holding state that matters by step 25 — my read is that steps 20/21 have already pushed everything.
- **`edge.4`'s `dbImpact: schema` is the script's classification, not my judgement.** The script prints its own caveat: a generated-object repair (§12) also trips the DDL regex. If edge.4 was a repair rather than genuine schema change, correct it to `repair`.
- `certifiedBuild`, `status` and the dates are untouched — `assertOnlyMechanicalChange` enforces that, and the validator confirms it.
- **No unrelated changes.**

## Still outstanding after this (not in scope here)

- `lts-5` still points at 5.51.1 — the catch-up hit `npm error code E401`, so `CRAIG_BC_NPM_TOKEN` needs rotating. Tracked in #4133.
- `releases/v5.51.2.md` does not exist — release notes still need writing and backporting to `lts/5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mzB8tRMmfsGMV8X4mHMte