### PR TITLE
fix(integration): an object the account cannot serve no longer advances its watermark

### DIFF
--- a/.changeset/unavailable-object-no-watermark.md
+++ b/.changeset/unavailable-object-no-watermark.md
@@ -1,0 +1,18 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+An object the account cannot serve no longer advances its watermark.
+
+The `OBJECT_UNAVAILABLE` branch broke out of the fetch loop leaving `fetchCompletedCleanly` true, so
+control fell into the clean-fetch branch and treated a map that fetched **zero records** as one that
+had seen the complete set. On a full sync — and on a first encounter, where no watermark row exists
+yet — that minted a wall-clock `Timestamp` watermark. When the account later enabled the object, the
+next incremental filtered `modified > <the moment of the failed fetch>` and permanently missed every
+record that already existed, destroying the self-healing this path exists to provide. The same fall-
+through also ran orphan detection on an empty result and, under partition reconcile, overwrote the
+stored rollup snapshot with an empty map.
+
+The map still ends successfully with its single warning and no retry ladder — only the consequences
+of "we saw everything" are withheld. The warning is also now filed under the object name rather than
+the literal `'sync'`, matching every sibling warning, so per-object filtering works.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -2845,7 +2845,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 if (IsObjectUnavailable(fetchErr)) {
                     // Not a failure to retry: the vendor is telling us this account does not serve
                     // this object. Warn once and end the map cleanly — no retry ladder, no
-                    // FETCH_INCOMPLETE, and the watermark left exactly as it was.
+                    // FETCH_INCOMPLETE.
                     //
                     // Deliberately NOT remembered between runs. Persisting it would buy one probe
                     // per object per run, and the object count in any real system is small enough
@@ -2853,8 +2853,23 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                     // both bring: a remembered skip is wrong from the moment the account changes,
                     // and every scheme for noticing that is another thing to get right. Re-asking
                     // every run is self-healing by construction and has no configuration.
+                    //
+                    // But the map fetched NOTHING, so it is NOT a clean fetch, and every consequence
+                    // of "we saw the complete set" must be withheld. Breaking out with the flag still
+                    // true fell through to the clean-fetch branch and:
+                    //   - minted a wall-clock Timestamp watermark for an object that returned zero
+                    //     records. When the account later enables the object, the next incremental
+                    //     filters `modified > <that stamp>` and permanently misses every record that
+                    //     already existed — destroying the self-healing described above. (An
+                    //     incremental over an EXISTING watermark merely rewrote the same value; the
+                    //     damage lands on a full sync and on the first encounter, where no watermark
+                    //     row exists yet and one is created at "now".)
+                    //   - ran orphan detection. An empty fetch is not evidence that MJ's rows are gone.
+                    //   - overwrote the partition rollup snapshot with an empty map, forcing a full
+                    //     re-diff next run.
+                    fetchCompletedCleanly = false;
                     logger?.warning(
-                        'sync',
+                        entityMap.ExternalObjectName ?? entityMap.ID,
                         'OBJECT_UNAVAILABLE',
                         `"${entityMap.ExternalObjectName}" is not available to this account; skipping it until the source starts serving it: ${errMsg}`,
                         { externalObjectName: entityMap.ExternalObjectName },

--- a/packages/Integration/engine/src/__tests__/IntegrationEngine.safefloor.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntegrationEngine.safefloor.test.ts
@@ -826,3 +826,168 @@ describe('IntegrationEngine — mid-run watermark durability floor (§8a)', () =
         }
     });
 });
+
+/**
+ * A connector whose object this account cannot serve: FetchChanges raises the duck-typed
+ * OBJECT_UNAVAILABLE signal (a connector may set the code without importing the class).
+ */
+function createUnavailableObjectConnector(): { connector: BaseIntegrationConnector; fetchCalls: () => number } {
+    let fetchCallCount = 0;
+    const connector = {
+        TestConnection: vi.fn(),
+        DiscoverObjects: vi.fn(),
+        DiscoverFields: vi.fn(),
+        FetchChanges: vi.fn().mockImplementation(async (_ctx: FetchContext): Promise<FetchBatchResult> => {
+            fetchCallCount++;
+            const err = new Error("Record 'contacts' was not found") as Error & { code: string };
+            err.code = 'OBJECT_UNAVAILABLE';
+            throw err;
+        }),
+        GetDefaultFieldMappings: vi.fn().mockReturnValue([]),
+        RateLimitPolicy: null,
+        ExtractRetryAfterMs: () => undefined,
+        PostProcessRecord: (r: ExternalRecord) => r,
+        StableOrderingKey: () => null,   // non-keyset → timestamp watermark path
+    } as unknown as BaseIntegrationConnector;
+    return { connector, fetchCalls: () => fetchCallCount };
+}
+
+describe('IntegrationEngine — an object the account cannot serve leaves no trace', () => {
+    let orchestrator: IntegrationEngine;
+
+    beforeEach(() => {
+        orchestrator = new IntegrationEngine();
+        mockEntityInstances = new Map();
+        mockRunViewFn = vi.fn();
+        mockRunViewsFn = vi.fn(fanOutToRunView);
+        (IntegrationEngine as Record<string, unknown>)['activeSyncs'] = new Map();
+    });
+
+    /** Same wiring as the floor suite: run-config reads plus a captured watermark row. */
+    function wireUnavailableRun() {
+        const companyIntegration = createMockCompanyIntegration();
+        const integration = {
+            ID: 'int-1',
+            Get: vi.fn((f: string) => f === 'ID' ? 'int-1' : null),
+            Name: 'Test',
+            ClassName: 'TestConnector',
+        } as unknown as MJIntegrationEntity;
+
+        mockRunViewsFn.mockResolvedValueOnce([
+            { Success: true, Results: [companyIntegration] },
+            {
+                Success: true,
+                Results: [{
+                    Get: vi.fn((f: string) => f === 'ID' ? 'em-1' : null),
+                    CompanyIntegrationID: 'ci-1',
+                    EntityID: 'entity-1',
+                    ConflictResolution: 'SourceWins',
+                    DeleteBehavior: 'SoftDelete',
+                    Entity: 'Contacts',
+                    ExternalObjectName: 'contacts',
+                } as unknown as ICompanyIntegrationEntityMap],
+            },
+            { Success: true, Results: [integration] },
+            { Success: true, Results: [{ DriverClass: 'TestConnector' }] },
+        ]);
+
+        const persistedValues: Array<string | null> = [];
+        const existingWatermark = {
+            ID: 'wm-1',
+            EntityMapID: 'em-1',
+            Direction: 'Pull' as const,
+            WatermarkType: 'Timestamp' as const,
+            WatermarkValue: PRIOR_WATERMARK as string | null,
+            LastSyncAt: new Date('2024-06-15T09:00:00.000Z'),
+            RecordsSynced: 0,
+            Get: vi.fn(),
+            Save: vi.fn().mockImplementation(async function (this: { WatermarkValue: string | null }) {
+                persistedValues.push(this.WatermarkValue);
+                return true;
+            }),
+        } as unknown as ICompanyIntegrationSyncWatermark;
+
+        mockRunViewFn.mockImplementation(async (params: Record<string, unknown>) => {
+            const entityName = params['EntityName'] as string;
+            if (entityName === 'MJ: Company Integration Field Maps') {
+                return {
+                    Success: true,
+                    Results: [{
+                        SourceFieldName: 'Name', DestinationFieldName: 'Name', TransformPipeline: null,
+                        IsKeyField: false, Status: 'Active', Priority: 0,
+                    } as unknown as ICompanyIntegrationFieldMap],
+                };
+            }
+            if (entityName === 'MJ: Company Integration Sync Watermarks') {
+                return { Success: true, Results: [existingWatermark] };
+            }
+            return { Success: true, Results: [] };
+        });
+
+        return { persistedValues, existingWatermark };
+    }
+
+    async function runUnavailable(fullSync: boolean) {
+        const { connector, fetchCalls } = createUnavailableObjectConnector();
+        const wired = wireUnavailableRun();
+        const { Metadata: MockMetadataClass } = await import('@memberjunction/core');
+        const origGetEntity = MockMetadataClass.prototype.GetEntityObject;
+        MockMetadataClass.prototype.GetEntityObject = vi.fn().mockImplementation(async () => createMockEntity({}));
+        const { ConnectorFactory } = await import('../ConnectorFactory.js');
+        const resolveOrig = ConnectorFactory.Resolve;
+        ConnectorFactory.Resolve = vi.fn().mockReturnValue(connector);
+        try {
+            const result = await orchestrator.RunSync('ci-1', contextUser, 'Manual', undefined, undefined, { FullSync: fullSync });
+            return { result, fetchCalls, ...wired };
+        } finally {
+            ConnectorFactory.Resolve = resolveOrig;
+            MockMetadataClass.prototype.GetEntityObject = origGetEntity;
+        }
+    }
+
+    it('never advances the watermark past the value it had before the run', async () => {
+        // THE BUG: the unavailable branch broke out of the fetch loop leaving fetchCompletedCleanly
+        // true, so control fell into the clean-fetch branch and minted a wall-clock Timestamp for an
+        // object that returned ZERO records. When the account later enables the object, the next
+        // incremental filters `modified > <that stamp>` and permanently misses every pre-existing
+        // record — destroying the self-healing this path exists to provide.
+        const { persistedValues, existingWatermark, fetchCalls } = await runUnavailable(false);
+        // Prove the run REACHED the connector first. Without this the assertions below are vacuous
+        // ("every element of an empty array") and pass even when the run never ran — which is
+        // precisely how the duplicate-record defect survived its own test suite.
+        expect(fetchCalls()).toBe(1);
+        expect((existingWatermark as unknown as { WatermarkValue: string | null }).WatermarkValue).toBe(PRIOR_WATERMARK);
+        for (const v of persistedValues) expect(v).toBe(PRIOR_WATERMARK);
+    });
+
+    it('does not mint a watermark on a FULL sync either', async () => {
+        // The full-sync arm is the one that advances to wall-clock "now", so it is the worse half
+        // of the same defect: it would stamp the moment of the failed fetch.
+        const { persistedValues, existingWatermark, fetchCalls } = await runUnavailable(true);
+        expect(fetchCalls()).toBe(1);
+        expect((existingWatermark as unknown as { WatermarkValue: string | null }).WatermarkValue).toBe(PRIOR_WATERMARK);
+        for (const v of persistedValues) expect(v).toBe(PRIOR_WATERMARK);
+    });
+
+    it('still ends the map successfully — one warning, no retry ladder, no fetch storm', async () => {
+        // Withholding the watermark must not turn a quiet skip back into a failure. The whole point
+        // of the classification is that the map ends cleanly and asks again next run.
+        const { connector, fetchCalls } = createUnavailableObjectConnector();
+        wireUnavailableRun();
+        const { Metadata: MockMetadataClass } = await import('@memberjunction/core');
+        const origGetEntity = MockMetadataClass.prototype.GetEntityObject;
+        MockMetadataClass.prototype.GetEntityObject = vi.fn().mockImplementation(async () => createMockEntity({}));
+        const { ConnectorFactory } = await import('../ConnectorFactory.js');
+        const resolveOrig = ConnectorFactory.Resolve;
+        ConnectorFactory.Resolve = vi.fn().mockReturnValue(connector);
+        try {
+            const result = await orchestrator.RunSync('ci-1', contextUser, 'Manual', undefined, undefined, { FullSync: false });
+            expect(result.RecordsErrored).toBe(0);
+            expect(result.RecordsCreated).toBe(0);
+            expect(fetchCalls()).toBe(1);   // asked once, did not climb a retry ladder
+        } finally {
+            ConnectorFactory.Resolve = resolveOrig;
+            MockMetadataClass.prototype.GetEntityObject = origGetEntity;
+        }
+    });
+});

--- a/packages/Integration/engine/src/__tests__/ObjectUnavailableWiring.test.ts
+++ b/packages/Integration/engine/src/__tests__/ObjectUnavailableWiring.test.ts
@@ -47,11 +47,20 @@ describe('engine wiring', () => {
     });
 
     it('warns once instead of erroring, so a dead object is not noise', () => {
-        const idx = source.indexOf('if (IsObjectUnavailable(fetchErr)) {');
-        const branch = source.slice(idx, idx + 1200);
+        // Bounded by the NEXT branch, not by a magic character count — a fixed-size window silently
+        // stops covering the code it is meant to assert about the moment a comment grows.
+        const branch = source.slice(
+            source.indexOf('if (IsObjectUnavailable(fetchErr)) {'),
+            source.indexOf("if (ClassifyError(fetchErr).Code === 'RATE_LIMIT_EXCEEDED') {"));
         expect(branch).toMatch(/logger\?\.warning\(/);
         // Not an error event: 71 of these on one connection is what buried the real failures.
         expect(branch).not.toMatch(/logger\?\.emit\('sync\.record\.error'/);
+        // The warning is filed under the OBJECT, not the literal 'sync' — every sibling warning
+        // passes the object name, and filtering these per-object is the point of having 71 of them.
+        expect(branch).toMatch(/logger\?\.warning\(\s*\n\s*entityMap\.ExternalObjectName \?\? entityMap\.ID,/);
+        // An empty fetch is not a clean one — this is what withholds the watermark, the orphan
+        // sweep and the rollup overwrite. Behaviour asserted in IntegrationEngine.safefloor.test.ts.
+        expect(branch).toMatch(/fetchCompletedCleanly = false;/);
     });
 
     it('does NOT persist the verdict — it is re-asked every run', () => {


### PR DESCRIPTION
## The defect

The `OBJECT_UNAVAILABLE` branch ends the map with one warning and no retry ladder — that part is right. But it `break`s out of the fetch loop leaving `fetchCompletedCleanly` **true**, so a map that fetched **zero records** falls into the clean-fetch branch and is treated as having seen the complete set:

```ts
} else if (fetchCompletedCleanly) {
    let finalWatermark: string;
    if (currentWatermark) { ... } else { finalWatermark = new Date().toISOString(); }
    await ...watermarkService.Update(entityMapID, finalWatermark, contextUser, 'Pull');
```

So a **wall-clock Timestamp watermark is created for an object that returned nothing.** When the account later enables the object, the next incremental filters `modified > <the moment of the failed fetch>` and **permanently misses every record that already existed** — precisely inverting the self-healing that justified not persisting a skip marker in the first place.

Scope, stated exactly: an incremental run over an *existing* watermark rewrote the same value and was harmless. The damage lands on **a full sync** (advances to "now") and on a **first encounter**, where no watermark row exists yet and one is created at "now".

Two more consequences rode the same fall-through: orphan detection ran against an empty result set, and under partition reconcile the stored rollup snapshot was overwritten with an empty map, forcing a full re-diff every run.

## The fix

`fetchCompletedCleanly = false` in that branch. The map still ends successfully with its single warning and no retry ladder — only the consequences of "we saw everything" are withheld.

Both later watermark branches are inert here by construction: the keyset branch needs a `currentAfterKey` (nothing was fetched), and the partial-save branch needs `currentWatermark !== initialWatermark` (unchanged). So nothing is written at all, which is the intent.

Also fixes the warning's category argument — it passed the literal `'sync'` where every sibling warning passes the object name, so per-object filtering of these didn't work. That matters when one connection produces dozens of them.

## Tests

End-to-end through `RunSync`, incremental and full sync, asserting the watermark row still holds its pre-run value and that no save wrote anything else.

Each test **first asserts it reached the connector** (`fetchCalls() === 1`). Without that the assertions are "every element of an empty array" and pass even when the run never happened — which is exactly how the duplicate-record defect survived its own suite. That guard caught a genuinely inert case while writing these.

Also un-brittles `ObjectUnavailableWiring.test.ts`: it sliced a magic **1200-character window** from the source, so it silently stopped covering the `logger?.warning(` call it asserts on the moment a comment grew. Now bounded by the next branch, and it pins both the object-name category and the `fetchCompletedCleanly = false`.

**Mutation-verified**: removing the one line fails the full-sync test with `expected '<wall-clock now>' to be '<prior watermark>'`.

Engine suite: **73 files / 963 tests** green.