### PR TITLE
chore(lts): declare the era-6 platform manifest

### DIFF
--- a/release-lines.json
+++ b/release-lines.json
@@ -31,6 +31,17 @@
         "npm": "11.x",
         "pnpm": "10.x"
       }
+    },
+    "6": {
+      "platform": {
+        "angular": "21.1.3",
+        "node": ">=24.0.0",
+        "typescript": "5.9.x",
+        "rxjs": "7.8.x",
+        "zone.js": "0.16.x",
+        "npm": "11.x",
+        "pnpm": "10.x"
+      }
     }
   },
   "lines": {


### PR DESCRIPTION
## Why

Certification gate 1 requires **"peer-deps ≡ platform manifest (every package's declared peer ranges accept the era's pins, §4.1)"** (`plans/lts-process.md:220`). `release-lines.json` defined era `5` only, so a 6.1 candidate had no era pins to be checked against.

Process doc §3.2 prescribes the shape: *"MJ 6.x pins whatever its manifest says (initially the same pins, until the era genuinely moves — e.g. Angular 22)."* So era 6 copies era 5, with one deliberate exception.

## 👀 The one thing to actually review: the node floor

Every other pin is a verbatim copy. **`node` moves from `>=18.0.0` to `>=24.0.0`.**

Era 5's `>=18.0.0` is a floor nothing tests and the CLI already breaks:

- Node 18 has been EOL since April 2025
- `.nvmrc` is `24`, and all 33 `node-version:` entries across `.github/workflows/` are `24`
- Of the ten packages declaring `engines.node`, three already require `>=20.0.0` — including **MJCLI**, the entry point users actually invoke (the rest: four at `>=16`, three at `>=18.0.0`)

An era is defined as the thing that pins the infrastructure contract, so this is the release where that floor moves rather than one more cycle of a promise we don't keep.

**This excludes Node 22**, which is still in maintenance. That's the tradeoff — flagging it explicitly rather than burying it, since it's the only substantive decision in the diff.

## Every other pin, verified against `next`

Not carried over on faith — each was read off the tree at `origin/next`:

| Pin | Value | Source |
|---|---|---|
| `angular` | `21.1.3` | MJExplorer, all twelve `@angular/*` packages |
| `typescript` | `5.9.x` | root devDep `5.9.3` |
| `rxjs` | `7.8.x` | `^7.8.2` |
| `zone.js` | `0.16.x` | `^0.16.0` |
| `pnpm` | `10.x` | `packageManager: pnpm@10.33.0` |
| `npm` | `11.x` | ships with node 24 |

## Verification

```
node ci/validate-release-lines.mjs                                 → OK
node ci/validate-release-lines.mjs --base origin/next --mode pr    → OK
node ci/validate-release-lines.mjs --base origin/next --mode push  → FAIL (by design)
node --test ci/validate-release-lines.test.mjs                     → 28/28 pass
```

The `push` failure is the correct result — `validate-release-lines.mjs:220` refuses platform changes outside a PR, which is why this is a PR.

## What this does NOT do

Authoring the manifest does not close §15 item 10. **The peer-deps ≡ platform-manifest check itself is still unbuilt** — nothing in `.github/` or `ci/` reads `eras.*.platform` today, and the 5.51.0 scorecard records the same thing in its gate 1 note (b). This PR gives that check something to read; it doesn't write it.

Additive only — era 5 is untouched, no line statuses change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)