### PR TITLE
fix(docs): build docs sets for dotted LTS line branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,24 +110,27 @@ jobs:
           # process at line cut, so its existence is the source of truth for
           # "this line has public docs".
           #
-          # 🚨 KNOWN GAP — dotted line branches (lts/6.1) get NO docs set: the
-          # filter below takes bare majors only. Do NOT "fix" this by widening
-          # the grep alone. docs-site/src/lib/documented-line.mjs THROWS on a
-          # dotted DOCS_VERSION ("Documented line must look like v6"), and
-          # because `deploy` needs `build`, one failing matrix entry takes the
-          # WHOLE site's deploy down — every line, not just the dotted one.
-          # Today's silent omission would become a total docs outage the day
-          # lts/6.1 is cut.
+          # Dotted line branches (lts/6.1) are first-class here: under the LTS
+          # version grammar every certified line after the 5.x bootstrap lands
+          # at a MINOR, so `lts/<major>.<minor>` is the steady state and a bare
+          # `lts/5` is the bootstrap exception.
           #
-          # The real fix spans docs-site, not this file: split documented-line's
-          # single value into a line-id string (v6.1) and an integer major (6),
-          # because license-line.mjs derives BOTH the BUSL cutoff comparison and
-          # `blob/lts/${documentedMajor}` from it — and Number('6.10') is 6.1,
-          # so a dotted line would link at the wrong branch. This file's own
-          # remaining work is small by comparison: this filter, `sort -V` instead
-          # of `sort -n` (sort -n orders 6.10 before 6.9), and the 404
-          # forwarder's `^(\/v\d+)\/` deep-link regex.
-          mapfile -t LTS < <(git ls-remote --heads origin 'lts/*' | sed -E 's#.*refs/heads/lts/##' | grep -E '^[0-9]+$' | sort -n)
+          # Three things had to move together for that to hold, and they are
+          # load-bearing for each other — do not revert one alone:
+          #   1. this filter, which accepts an optional dotted minor;
+          #   2. `sort -V`, because `sort -n` reads 6.10 as 6.1 and so orders it
+          #      BEFORE 6.9 — and $DEFAULT is the last element, i.e. the site's
+          #      front door;
+          #   3. docs-site/src/lib/documented-line.mjs, which used to THROW on a
+          #      dotted DOCS_VERSION. Because `deploy` needs `build`, one failing
+          #      matrix entry takes the WHOLE site's deploy down — every line,
+          #      not just the dotted one — so widening this grep on its own would
+          #      have turned a silent omission into a total docs outage.
+          # That module now exports an integer `documentedMajor` (6) separately
+          # from the `documentedLineId` string ("6.1") that license-line.mjs
+          # builds `blob/lts/<id>` from, because Number('6.1') and Number('6.10')
+          # are the same float.
+          mapfile -t LTS < <(git ls-remote --heads origin 'lts/*' | sed -E 's#.*refs/heads/lts/##' | grep -E '^[0-9]+(\.[0-9]+)?$' | sort -V)
           # Edge set: the major comes from the newest edge TAG (tags are pushed by
           # the publish workflow, so this is released state too), and its content
           # is built from main — see the ref below.
@@ -348,7 +351,12 @@ jobs:
           # program entirely, so sending the canonical program URL there would
           # answer the question on the one set where it does not apply. Falls
           # back to $DEFAULT before any BUSL line is published.
-          CERT_SET=$(jq -r '[.[] | select((.id | ltrimstr("v") | tonumber) >= 6)] | max_by(.id | ltrimstr("v") | tonumber) | .id // empty' <<<"$VERSIONS")
+          # Ranked on a [major, minor] array rather than `tonumber`: jq compares
+          # arrays element-wise, so v6.10 correctly outranks v6.9. `tonumber`
+          # reads both "6.1" and "6.10" as the float 6.1 and would pick either.
+          CERT_SET=$(jq -r '
+            map(. + {v: (.id | ltrimstr("v") | split(".") | map(tonumber))})
+            | [.[] | select(.v[0] >= 6)] | max_by(.v) | .id // empty' <<<"$VERSIONS")
           [ -n "$CERT_SET" ] || CERT_SET="$DEFAULT"
           echo "::notice::/mjcertified -> /$CERT_SET/mjcertified/"
 
@@ -389,7 +397,7 @@ jobs:
               location.replace(fallback + path + location.search + location.hash);
               return;
             }
-            var deep = path.match(/^(\/v\d+)\/(classes|interfaces|enums|functions|modules|variables|types|documents|media|hierarchy)\/(.+)\$/);
+            var deep = path.match(/^(\/v\d+(?:\.\d+)?)\/(classes|interfaces|enums|functions|modules|variables|types|documents|media|hierarchy)\/(.+)\$/);
             if (deep) {
               location.replace(deep[1] + '/api/' + deep[2] + '/' + deep[3] + location.search + location.hash);
             }

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -9,7 +9,7 @@
     "dev": "npm run ingest && astro dev",
     "build": "npm run ingest && astro build",
     "preview": "astro preview",
-    "test": "node --test scripts/lib/*.test.mjs"
+    "test": "node --test scripts/lib/*.test.mjs src/lib/*.test.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.36.0",

--- a/docs-site/src/lib/documented-line.mjs
+++ b/docs-site/src/lib/documented-line.mjs
@@ -2,31 +2,69 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 /**
- * The release line this build documents, as the "v6.x" pill text used in the
- * site header and the landing hero.
+ * The release line this build documents.
+ *
+ * A line id is either a bare major ("v6" — the Edge set, built from main) or a
+ * dotted minor ("v6.1" — an LTS line, built from its lts/6.1 branch). Both
+ * shapes are first-class: under the LTS version grammar every certified line
+ * after the 5.x bootstrap lands at a MINOR (6.1, 6.2, …), so dotted ids are the
+ * steady state, not an edge case.
+ *
+ * Three values come out of the id, and they are deliberately NOT the same value
+ * wearing different hats — conflating them is what this module exists to
+ * prevent:
+ *
+ *   documentedLine    "v6.1.x"  display only — the header/hero pill text
+ *   documentedMajor   6         an INTEGER, for era comparisons (see license-line.mjs)
+ *   documentedLineId  "6.1"     the branch suffix, for lts/<id> URLs
+ *
+ * `Number("6.1")` is 6.1, not 6, so a dotted line read as a major breaks every
+ * `>= N` era test; worse, `Number("6.10")` is ALSO 6.1, so 6.1 and 6.10 become
+ * indistinguishable. The integer major and the id string never collide.
  *
  * Versioned deploys set DOCS_VERSION per line (one build per line — see
  * .github/workflows/docs.yml), and that always wins. Local previews have no
  * env, so the line is derived from @memberjunction/core's version on the
  * checked-out ref — the product version, which the workspace root's
- * placeholder package.json is not.
+ * placeholder package.json is not. That fallback yields a bare major even on an
+ * lts/6.1 checkout; a preview of a line's own pill needs DOCS_VERSION set.
  */
+const LINE_ID = /^v(\d+)(?:\.(\d+))?$/;
+
 function repoLine() {
-  const corePkg = fileURLToPath(new URL('../../../packages/MJCore/package.json', import.meta.url));
-  const version = JSON.parse(readFileSync(corePkg, 'utf8')).version ?? '';
-  const major = version.split('.')[0];
-  if (!/^\d+$/.test(major)) {
-    throw new Error(`Cannot derive the documented line from @memberjunction/core version "${version}" and DOCS_VERSION is unset`);
-  }
-  return `v${major}`;
+    const corePkg = fileURLToPath(new URL('../../../packages/MJCore/package.json', import.meta.url));
+    const version = JSON.parse(readFileSync(corePkg, 'utf8')).version ?? '';
+    const major = version.split('.')[0];
+    if (!/^\d+$/.test(major)) {
+        throw new Error(`Cannot derive the documented line from @memberjunction/core version "${version}" and DOCS_VERSION is unset`);
+    }
+    return `v${major}`;
 }
 
 const line = process.env.DOCS_VERSION || repoLine();
-if (!/^v\d+$/.test(line)) {
-  throw new Error(`Documented line must look like "v6", got "${line}"`);
+const parsed = LINE_ID.exec(line);
+if (!parsed) {
+    throw new Error(`Documented line must look like "v6" or "v6.1", got "${line}"`);
 }
 
+/** The "v6.x" / "v6.1.x" pill text used in the site header and the landing hero. */
 export const documentedLine = `${line}.x`;
 
-/** The major version this build documents, as a number — e.g. 6 for the "v6.x" line. */
-export const documentedMajor = Number(line.slice(1));
+/** The era this build documents, as an integer — 6 for both the "v6" and "v6.1" lines. */
+export const documentedMajor = Number(parsed[1]);
+
+/**
+ * The line's branch suffix — "5" for lts/5, "6.1" for lts/6.1.
+ *
+ * A string on purpose: it is a branch-name fragment, never an arithmetic value.
+ */
+export const documentedLineId = line.slice(1);
+
+// The regex above already constrains both, but these are the two invariants the
+// rest of the site derives licensing and branch URLs from, so state them.
+if (!Number.isInteger(documentedMajor)) {
+    throw new Error(`documentedMajor must be an integer, got ${documentedMajor} from "${line}"`);
+}
+if (documentedLineId.length === 0) {
+    throw new Error(`documentedLineId must be a non-empty branch suffix, got "" from "${line}"`);
+}

--- a/docs-site/src/lib/documented-line.test.mjs
+++ b/docs-site/src/lib/documented-line.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// documented-line.mjs resolves the line ONCE at import time, so a value per
+// test needs a fresh module registry. A child process is the honest way to get
+// one — query-string cache busting would not reach the nested import that
+// license-line.mjs makes.
+const MODULE = fileURLToPath(new URL('./documented-line.mjs', import.meta.url));
+
+/** Import the module under `DOCS_VERSION=<line>` and return its exports. */
+function load(line) {
+    const env = { ...process.env };
+    if (line === undefined) delete env.DOCS_VERSION;
+    else env.DOCS_VERSION = line;
+    const src = `import * as m from ${JSON.stringify(MODULE)};
+        process.stdout.write(JSON.stringify({
+            documentedLine: m.documentedLine,
+            documentedMajor: m.documentedMajor,
+            documentedLineId: m.documentedLineId,
+        }));`;
+    return JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', src], { env, encoding: 'utf8' }));
+}
+
+/** The message a rejected DOCS_VERSION produces, or null if it was accepted. */
+function loadError(line) {
+    try {
+        load(line);
+        return null;
+    } catch (err) {
+        return String(err.stderr ?? err.message);
+    }
+}
+
+test('a bare major keeps the shape it always had', () => {
+    assert.deepEqual(load('v6'), { documentedLine: 'v6.x', documentedMajor: 6, documentedLineId: '6' });
+    assert.deepEqual(load('v5'), { documentedLine: 'v5.x', documentedMajor: 5, documentedLineId: '5' });
+});
+
+test('a dotted LTS line resolves instead of throwing', () => {
+    // The regression this module exists for: the old guard was /^v\d+$/, so a
+    // dotted DOCS_VERSION threw, and one failing matrix entry took the whole
+    // docs deploy down (deploy needs build) the day lts/6.1 was cut.
+    assert.deepEqual(load('v6.1'), { documentedLine: 'v6.1.x', documentedMajor: 6, documentedLineId: '6.1' });
+});
+
+test('the major is an integer, not the line read as a float', () => {
+    // Number('6.1') === 6.1 would break every `>= N` era comparison downstream.
+    const line = load('v6.1');
+    assert.equal(line.documentedMajor, 6);
+    assert.ok(Number.isInteger(line.documentedMajor));
+});
+
+test('6.1 and 6.10 stay distinct', () => {
+    // Number('6.1') and Number('6.10') are the same float. The id is a string
+    // precisely so these two lines can never collapse into one another.
+    assert.equal(load('v6.1').documentedLineId, '6.1');
+    assert.equal(load('v6.10').documentedLineId, '6.10');
+    assert.notEqual(load('v6.1').documentedLineId, load('v6.10').documentedLineId);
+    assert.equal(load('v6.10').documentedMajor, 6);
+});
+
+test('malformed line ids are rejected, not coerced', () => {
+    for (const bad of ['6.1', 'v', 'vx', 'v6.1.2', 'v6.', 'v-1', 'latest']) {
+        assert.match(loadError(bad) ?? '', /Documented line must look like/, `expected "${bad}" to be rejected`);
+    }
+});
+
+test('with no DOCS_VERSION the line comes from the checked-out core version', () => {
+    // Local previews have no env. The fallback yields a bare major even on an
+    // lts/6.1 checkout — documented behavior, not an oversight.
+    const line = load(undefined);
+    assert.match(line.documentedLine, /^v\d+\.x$/);
+    assert.ok(Number.isInteger(line.documentedMajor));
+    assert.equal(line.documentedLineId, String(line.documentedMajor));
+});

--- a/docs-site/src/lib/license-line.mjs
+++ b/docs-site/src/lib/license-line.mjs
@@ -1,4 +1,4 @@
-import { documentedMajor } from './documented-line.mjs';
+import { documentedMajor, documentedLineId } from './documented-line.mjs';
 
 /**
  * The license the release line THIS BUILD documents ships under.
@@ -38,8 +38,12 @@ export const sourceModel = isBusl ? 'Source Available' : 'Open Source';
  *
  * A pre-BUSL line must not link at the default branch: that file now carries
  * the BUSL, so the link would hand an ISC user the wrong license. Those lines
- * are maintained on their own lts/N branch, which still carries the ISC text.
+ * are maintained on their own lts/<id> branch, which still carries the ISC text.
+ *
+ * The branch is built from `documentedLineId`, NOT `documentedMajor`: a line's
+ * branch is named for the whole line (lts/5, lts/6.1), so a dotted line read as
+ * a major would link at lts/6 — a branch that does not exist.
  */
 export const licenseUrl = isBusl
   ? 'https://github.com/MemberJunction/MJ/blob/main/LICENSE'
-  : `https://github.com/MemberJunction/MJ/blob/lts/${documentedMajor}/LICENSE`;
+  : `https://github.com/MemberJunction/MJ/blob/lts/${documentedLineId}/LICENSE`;

--- a/docs-site/src/lib/license-line.test.mjs
+++ b/docs-site/src/lib/license-line.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// Same one-process-per-case rule as documented-line.test.mjs: license-line.mjs
+// resolves everything at import time from a DOCS_VERSION read one module deeper.
+const MODULE = fileURLToPath(new URL('./license-line.mjs', import.meta.url));
+
+/** Import the module under `DOCS_VERSION=<line>` and return its exports. */
+function load(line) {
+    const src = `import * as m from ${JSON.stringify(MODULE)};
+        process.stdout.write(JSON.stringify({
+            isBusl: m.isBusl,
+            licenseName: m.licenseName,
+            licenseShort: m.licenseShort,
+            sourceModel: m.sourceModel,
+            licenseUrl: m.licenseUrl,
+        }));`;
+    const env = { ...process.env, DOCS_VERSION: line };
+    return JSON.parse(execFileSync(process.execPath, ['--input-type=module', '-e', src], { env, encoding: 'utf8' }));
+}
+
+test('the 5.x line is ISC and links at its own branch', () => {
+    const v5 = load('v5');
+    assert.equal(v5.isBusl, false);
+    assert.equal(v5.licenseName, 'ISC License');
+    assert.equal(v5.licenseShort, 'ISC');
+    assert.equal(v5.sourceModel, 'Open Source');
+    // Never main: that LICENSE now carries the BUSL, so linking there would
+    // hand an ISC user the wrong license.
+    assert.equal(v5.licenseUrl, 'https://github.com/MemberJunction/MJ/blob/lts/5/LICENSE');
+});
+
+test('a dotted BUSL line is still BUSL', () => {
+    // The era test is `documentedMajor >= 6`. Before the split it compared the
+    // float 6.1, which happened to work here and broke elsewhere.
+    for (const line of ['v6', 'v6.1', 'v6.10']) {
+        const l = load(line);
+        assert.equal(l.isBusl, true, line);
+        assert.equal(l.licenseName, 'Business Source License 1.1', line);
+        assert.equal(l.licenseShort, 'BUSL 1.1', line);
+        assert.equal(l.sourceModel, 'Source Available', line);
+        assert.equal(l.licenseUrl, 'https://github.com/MemberJunction/MJ/blob/main/LICENSE', line);
+    }
+});
+
+test('a dotted pre-BUSL line links at lts/<line>, not lts/<major>', () => {
+    // The conflation regression: `blob/lts/${documentedMajor}` on a dotted line
+    // produced lts/5 — a real branch, but the wrong one — and for 5.10 vs 5.1
+    // it produced the same URL for two different lines.
+    assert.equal(load('v5.1').licenseUrl, 'https://github.com/MemberJunction/MJ/blob/lts/5.1/LICENSE');
+    assert.equal(load('v5.10').licenseUrl, 'https://github.com/MemberJunction/MJ/blob/lts/5.10/LICENSE');
+    assert.notEqual(load('v5.1').licenseUrl, load('v5.10').licenseUrl);
+});


### PR DESCRIPTION
## Why

Cutting `lts/6.1` would have taken **the entire docs site down**, not just omitted one set.

`documented-line.mjs` guarded `DOCS_VERSION` with `/^v\d+$/` and threw on a dotted value. Because `deploy` needs `build`, one failing matrix entry fails the whole deploy — every line, `/v5` included. `docs.yml`'s enumeration filter was masking that behind a silent omission by taking bare majors only.

Under the LTS version grammar every certified line after the 5.x bootstrap lands at a **minor** (6.1, 6.2, …), so dotted branches are the steady state, not an edge case. The fix is the one `docs.yml:113-129` already specified in its own `🚨 KNOWN GAP` comment; that comment is replaced with a description of the current behaviour.

## The core change

`documented-line.mjs` splits one overloaded value into three that can't be confused:

| Export | Value | Purpose |
|---|---|---|
| `documentedLine` | `"v6.1.x"` | display only — the header/hero pill |
| `documentedMajor` | `6` | an **integer**, for era comparisons |
| `documentedLineId` | `"6.1"` | the branch suffix, for `lts/<id>` URLs |

The split *is* the point. `Number('6.1')` is `6.1`, which breaks every `>= N` era test — and `Number('6.10')` is **also** `6.1`, so two different lines collapse into one. `license-line.mjs` derived both the BUSL cutoff and `blob/lts/${documentedMajor}` from that single value; it now takes the id for the branch URL, since a dotted line read as a major links at `lts/6`, a branch that does not exist.

## 👀 For the reviewer: three `docs.yml` changes are load-bearing for each other

Reverting any one alone reintroduces the outage. Called out because they look independent:

1. **The filter** accepts an optional dotted minor.
2. **`sort -V` replaces `sort -n`.** Not cosmetic — `sort -n` reads `6.10` as `6.1` and orders it *before* `6.9`, and `$DEFAULT` is the last element, i.e. the site's front door. Simulated against realistic branches:
   ```
   new:  5 6.1 6.2 6.9 6.10      ← 6.10 last
   old:  5                        ← every dotted line silently vanished
   ```
3. **`documented-line.mjs` no longer throws.** Widening the grep without this would have converted a silent omission into a total outage.

Also: the 404 forwarder's `^(\/v\d+)\/` deep-link regex accepts a dotted prefix, and `CERT_SET` ranks on a `[major, minor]` array instead of `tonumber` — jq compares arrays element-wise, so `v6.10` correctly outranks `v6.9`.

## Verification

- **`DOCS_VERSION=v6.1 npm run build` → 367 pages, complete.** The outage is gone. Renders pill `v6.1.x`, `BUSL 1.1` / `Source Available`, license at `blob/main/LICENSE`.
- **v5 regression build → 367 pages**, pill `v5.x`, `ISC` / `Open Source`, `blob/lts/5/LICENSE`. Unchanged — this matters because `/v5` is the site's current default set.
- **Full docs-site suite: 33/33** (24 pre-existing + 9 new).
- `docs.yml` still parses; `resolve` / `build` / `deploy` intact.
- Shell and jq logic simulated directly against realistic branch and version lists.

The new tests run one process per case, because these modules resolve at import time and query-string cache busting wouldn't reach the nested import `license-line.mjs` makes.

## Incidental change

`docs-site/package.json`'s `test` glob widened from `scripts/lib/*.test.mjs` to also cover `src/lib/*.test.mjs` — `src/lib` had no test coverage at all. `docs-site-ci.yml` already runs `npm test` on any `docs-site/**` change, so the new tests gate PRs without a workflow change.

## What this does NOT do

`isBusl` still derives from the documented major rather than the content ref. This change makes it *correct* for `lts/6.1` (integer `6 >= 6` → BUSL), so it's no longer a cut blocker — but the residual where `/v6` could show a BUSL label over ISC content is a public licensing statement and deliberately left for a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)