### PR TITLE
ci: redeploy docs when release notes land on a line branch

### DIFF
--- a/.github/workflows/redeploy-docs-on-line-content.yml
+++ b/.github/workflows/redeploy-docs-on-line-content.yml
@@ -1,0 +1,60 @@
+name: Redeploy docs when line content changes
+
+# THE GAP THIS CLOSES. docs.yml is release-following by design: workflow_run on
+# publish.yml (main), plus an explicit dispatch. A merge into an lts/* branch
+# reaches neither. So release notes backported to a line landed on the branch the
+# docs site builds from and then sat there, invisible, until the NEXT release
+# happened to deploy. That is what happened to v5.51.2's notes.
+#
+# WHY THIS DISPATCHES RATHER THAN TRIGGERING docs.yml DIRECTLY. Adding
+# `push: branches: [lts/**]` to docs.yml looks equivalent and is not: its checkout
+# step uses `ref: ${{ github.sha }}`, which for a push to lts/5 is an lts/5 commit.
+# The site would then be built with the LINE's copy of docs-site/ — breaking the one
+# seam that file is explicit about, that the Astro app and rendering logic always
+# come from next so site fixes never need cherry-picking to a line. Dispatching
+# hands docs.yml a trigger shape it already supports and already handles correctly.
+# It is the same call publish.yml's LTS job makes.
+#
+# 🚨 THIS FILE MUST EXIST ON EACH LINE BRANCH TO DO ANYTHING. A push to lts/5 runs
+# the workflows present ON lts/5, not the ones on next. That is why the PR adding
+# this carries `backport lts/5`. Lines cut from next in future inherit it at the cut;
+# an existing line that never received it is silently uncovered, which looks exactly
+# like the bug this fixes — check the line branch first if notes fail to appear.
+
+on:
+  push:
+    branches:
+      - 'lts/**'
+    # Scoped to release notes, the concrete gap. docs.yml also ingests guides/,
+    # package READMEs and root docs from the line, so a backported doc fix has the
+    # same problem; widening this list is a one-line change if that comes up. Kept
+    # narrow for now so a code-only backport does not rebuild the whole site.
+    paths:
+      - 'releases/**'
+
+permissions:
+  actions: write   # gh workflow run
+  contents: read
+
+# Several backports can land on a line in quick succession. The site is rebuilt
+# whole every time, so only the last dispatch is worth anything.
+concurrency:
+  group: redeploy-docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dispatch-docs:
+    name: Dispatch the docs deploy
+    runs-on: ubuntu-latest
+    steps:
+      # --ref next is deliberate and matches publish.yml: the maintained copy of
+      # docs.yml always runs, never whatever a line branch happens to carry. The
+      # line is not a parameter here because docs.yml rebuilds every line's set on
+      # every run — it enumerates lts/* itself.
+      - name: Dispatch docs.yml from next
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run docs.yml --repo "$GITHUB_REPOSITORY" --ref next
+          echo "::notice::docs deploy dispatched after release-notes content landed on ${GITHUB_REF#refs/heads/}"


### PR DESCRIPTION
Closes the gap I flagged on #4136 and that you hit by hand tonight: v5.51.2's notes reached `lts/5` and needed a manual `gh workflow run docs.yml` to become visible.

## The gap

`docs.yml`'s triggers, comments stripped:

```yaml
on:
  workflow_run:
    workflows: [Build and publish new package versions]   # publish.yml, on main
    branches: [main]
    types: [completed]
  workflow_dispatch: {}
```

A merge into `lts/*` reaches neither. The line branch is precisely what the `/v5/` docs set is built from, so notes land in the right place and stay invisible until the next release deploys.

## Why a dispatcher and not a trigger on `docs.yml`

Adding `push: branches: [lts/**]` to `docs.yml` looks equivalent. It isn't — its checkout is:

```yaml
- name: Checkout repo
  uses: actions/checkout@v4
  with:
    ref: ${{ github.sha }}
```

For a push to `lts/5` that's an `lts/5` commit, so the site would build with the **line's** copy of `docs-site/`. That breaks the one seam `docs.yml` is emphatic about: the Astro app, Starlight overrides and rendering logic always come from `next`, "so site fixes never need cherry-picking to a line."

Dispatching hands `docs.yml` a trigger it already supports and already handles correctly — the same call `publish.yml`'s LTS job makes, with the same `--ref next` reasoning (the maintained copy runs, never whatever a line carries).

## 🚨 The label is load-bearing, and for an unusual reason

A push to `lts/5` runs the workflows present **on `lts/5`**. So this file has to reach the line branch to fire at all — hence `backport lts/5` on this PR. Lines cut from `next` in future inherit it at the cut.

Worth internalising: an existing line that never received this file is silently uncovered, and that looks *identical* to the bug being fixed. If notes ever fail to appear on a line, check whether this workflow exists on that branch before debugging anything else. I've put that note in the file itself.

## For the reviewer

- **`actions: write`** is required for `gh workflow run`. I granted it explicitly here rather than relying on defaults, unlike the equivalent step in `publish.yml` which inherits it.
- **Scope is `releases/**` only.** `docs.yml` also ingests `guides/`, package READMEs and root docs from the line, so a backported doc fix has the same problem. Widening is one line; I kept it narrow so a code-only backport doesn't rebuild the site. Say if you'd rather it were wider.
- **`concurrency` with `cancel-in-progress`** — several backports can land together and the site is rebuilt whole each time, so only the last dispatch matters.
- Does not touch `docs.yml`. **No unrelated changes.**

## Verification

I can't prove this one before merge — the trigger only exists once the file is on a line branch. After it backports to `lts/5`, the next `releases/**` change there should produce a `docs.yml` run with event `workflow_dispatch` and no human involved. Worth watching for on 5.51.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mzB8tRMmfsGMV8X4mHMte