### PR TITLE
5.51.x backport: deterministic JSON escaping repair (#4137)

### DIFF
--- a/.changeset/deterministic-json-escaping-repair.md
+++ b/.changeset/deterministic-json-escaping-repair.md
@@ -1,0 +1,17 @@
+---
+"@memberjunction/global": patch
+"@memberjunction/ai-prompts": patch
+"@memberjunction/ai-core-plus": patch
+---
+
+Recover LLM responses broken by a single unescaped character, and stop misreporting why they broke.
+
+Models embed rich markdown in JSON string fields — mermaid diagrams, HTML mockups, code samples — and reliably escape most of it. One missed quote inside a 25KB response invalidates the whole document. Three defects meant that was unrecoverable and misdiagnosed.
+
+**`CleanJSON` discarded the response over an interior fence.** Once the top-level parse failed for any reason, fence extraction ran unconditionally. That regex has no idea it is looking inside a string value, so a ` ```mermaid ` fence embedded in a markdown field matched, its contents were extracted, the JSON envelope was thrown away, and `CleanJSON` recursed into the fragment. A 28KB agent response with one unescaped quote at offset 23011 was reported as ``Unexpected token 'm', "mermaid\ns"...``. Fence extraction now skips input already shaped like a JSON envelope — a genuinely fence-wrapped response starts with the fence and a prose-buried one starts with prose, so neither is affected. The throw also carries the untouched parse error as `cause`.
+
+**The repair chain reasoned from the wrong error.** `attemptJSONRepair` received whatever escaped `JSON.parse(CleanJSON(rawOutput))`, which may describe one of `CleanJSON`'s intermediate transforms rather than the model's actual output. That message was handed to the AI repair prompt as `ERROR_MESSAGE`, recorded on the prompt run, and re-thrown — so a model was asked to fix an unexpected `'m'` in a mermaid fragment when the real defect was one quote at a known offset, in text it was never shown. `resolveTrueParseError` now derives the error from the raw output directly.
+
+**Nothing could repair an unescaped quote.** JSON5's leniency covers trailing commas, comments and unquoted keys, but an unescaped `"` terminates a string in JSON5 exactly as in JSON, leaving only an LLM round-trip on the full payload. New `RepairJSONEscaping()` in `@memberjunction/global` is error-driven and deterministic: read the failure offset, walk back to the character that ended the string early, escape it, re-parse, repeat. Every pass is validated by a real parse, so it cannot pattern-match its way to a wrong answer the way a global regex rewrite would, and it gives up rather than guessing when it cannot make progress. It runs in `attemptJSONRepair` between the JSON5 and AI stages — microseconds against an LLM round-trip, and it cannot invent content. `_jsonRepairInfo` gains a `LexicalEscaping` method and records the offsets escaped, because that repair infers intent and should never be invisible.
+
+Replayed against 16 real failing production payloads: 16/16 recovered, 180 characters escaped, 12ms total. Each repair verified escapes-only — removing the inserted backslashes reconstructs the original byte-for-byte — with a valid response shape. Against 34 already-valid payloads, 20 containing markdown fences: zero false positives. The production failure that motivated this had burned all ten agent retries, roughly four minutes and 79K completion tokens, before terminating; it now recovers in 0.61ms with the AI stage never reached.

--- a/packages/AI/CorePlus/src/MJAIPromptRunEntityExtended.ts
+++ b/packages/AI/CorePlus/src/MJAIPromptRunEntityExtended.ts
@@ -11,13 +11,22 @@ export interface JSONRepairInfo {
     /** Whether the JSON was repaired */
     repaired: true;
     /** Which repair strategy succeeded */
-    method: 'JSON5' | 'AIRepair';
+    method: 'JSON5' | 'LexicalEscaping' | 'AIRepair';
     /** The original JSON parse error message */
     originalError: string;
     /** First 200 characters of the raw LLM output (for diagnostics) */
     rawOutputPrefix: string;
     /** The prompt run ID of the repair prompt execution (AI repair only) */
     repairPromptRunId?: string;
+    /**
+     * Offsets escaped by the lexical repair, in fix order (LexicalEscaping only).
+     *
+     * Recorded because that repair infers intent: it assumes a quote inside a string value was
+     * meant to be escaped. That is nearly always right, but it is a judgment, so it should never
+     * be invisible. A rising count here means model output is drifting and the prompt likely
+     * needs attention.
+     */
+    repairedOffsets?: number[];
 }
 
 /**

--- a/packages/AI/Prompts/src/AIPromptRunner.ts
+++ b/packages/AI/Prompts/src/AIPromptRunner.ts
@@ -2,7 +2,7 @@ import { BaseLLM, ChatParams, ChatResult, ChatMessageRole, ChatMessage, GetAIAPI
 import { AIModelRunner } from './AIModelRunner';
 import { ValidationAttempt, AIPromptRunResult, AIModelSelectionInfo } from '@memberjunction/ai-core-plus';
 import { BaseEntitySaveQueue, LogErrorEx, LogStatus, LogStatusEx, IsVerboseLoggingEnabled, Metadata, UserInfo, IMetadataProvider } from '@memberjunction/core';
-import { CleanJSON, MJGlobal, JSONValidator, ValidationResult, ValidationErrorInfo, ValidationErrorType, UUIDsEqual, NormalizeUUID } from '@memberjunction/global';
+import { CleanJSON, RepairJSONEscaping, MJGlobal, JSONValidator, ValidationResult, ValidationErrorInfo, ValidationErrorType, UUIDsEqual, NormalizeUUID } from '@memberjunction/global';
 import { MJAIPromptModelEntity, MJAIModelVendorEntity, MJAIConfigurationEntity, MJAIVendorEntity, MJTemplateEntityExtended, MJAICredentialBindingEntity, MJCredentialEntity } from '@memberjunction/core-entities';
 import { MJAIModelEntityExtended, MJAIPromptEntityExtended, MJAIPromptRunEntityExtended } from "@memberjunction/ai-core-plus";
 import { CredentialEngine } from '@memberjunction/credentials';
@@ -5106,8 +5106,36 @@ export class AIPromptRunner {
   }
 
   /**
-   * Attempts to repair malformed JSON using a two-step process.
-   * 
+   * Resolves the parse error that actually describes the model's output.
+   *
+   * The error reaching the repair path comes from `JSON.parse(CleanJSON(rawOutput))`, so it may
+   * describe one of CleanJSON's intermediate transforms rather than the response itself. That
+   * distinction is not cosmetic: a repair pass needs the failure offset in the *original* bytes,
+   * and the AI repair prompt is actively misled by an error describing text it was never shown.
+   *
+   * Observed in production: an unescaped quote at offset 23011 was reported as
+   * `Unexpected token 'm', "mermaid\ns"...` because CleanJSON had extracted a mermaid fence out of
+   * a string value before failing. Every downstream consumer — the repair model, the validation
+   * record, the logs — inherited that misdiagnosis.
+   *
+   * @param rawOutput - The model's unmodified output
+   * @param originalError - The error caught upstream, used as a fallback
+   * @returns The message that best describes what is wrong with `rawOutput`
+   */
+  private resolveTrueParseError(rawOutput: string, originalError: Error): string {
+    try {
+      JSON.parse(rawOutput);
+    } catch (directError: unknown) {
+      return directError instanceof Error ? directError.message : String(directError);
+    }
+    // rawOutput parses cleanly, so the failure came from a later stage; the caller's error stands.
+    return originalError.message;
+  }
+
+  /**
+   * Attempts to repair malformed JSON using a multi-step process: JSON5, then deterministic
+   * lexical repair, then an AI repair prompt.
+   *
    * @param rawOutput - The malformed JSON string
    * @param originalError - The original parsing error
    * @param params - Prompt parameters containing contextUser
@@ -5162,9 +5190,38 @@ export class AIPromptRunner {
       };
       return json5Result;
     } catch (json5Error) {
-      // Step 2: Use AI to repair the JSON
-      this.logStatus('   🤖 JSON5 failed, attempting AI-based JSON repair...', true, params);
-      
+      // The error handed to us may describe a CleanJSON transform rather than the model's actual
+      // output — CleanJSON rewrites the text through several passes before failing, and the error
+      // that escapes describes whatever it was holding at the end. Repairing, and telling a model
+      // what to repair, both require the real syntax error against the real bytes.
+      const trueError = this.resolveTrueParseError(rawOutput, originalError);
+
+      // Step 2: Deterministic lexical repair. The dominant failure by far is an unescaped quote or
+      // raw control character inside a string value — models embed mermaid diagrams, HTML mockups
+      // and code samples in markdown fields and miss an escape. JSON5 cannot help (an unescaped
+      // quote closes a string in JSON5 too), but the defect is mechanical, so fixing it needs no
+      // model call. Runs before the AI stage: it is microseconds against an LLM round-trip on a
+      // payload that may be tens of KB, and it cannot invent content the way a model can.
+      const lexicalRepair = RepairJSONEscaping(rawOutput);
+      if (lexicalRepair.repaired) {
+        this.logStatus(
+          `   ✅ Lexical repair fixed ${lexicalRepair.repairedOffsets.length} unescaped character(s)`,
+          true,
+          params
+        );
+        currentPromptRun._jsonRepairInfo = {
+          repaired: true,
+          method: 'LexicalEscaping',
+          originalError: trueError,
+          rawOutputPrefix: rawOutput.substring(0, 200),
+          repairedOffsets: lexicalRepair.repairedOffsets
+        };
+        return lexicalRepair.value;
+      }
+
+      // Step 3: Use AI to repair the JSON
+      this.logStatus('   🤖 JSON5 and lexical repair failed, attempting AI-based JSON repair...', true, params);
+
       try {
         // Find the "Repair JSON" prompt in the "MJ: System" category
         const repairPrompt = AIEngine.Instance.Prompts.find(p => p.Name.trim().toLowerCase() === 'repair json' && p.Category.trim().toLowerCase() === 'mj: system');
@@ -5178,7 +5235,7 @@ export class AIPromptRunner {
           contextUser: params.contextUser,
           prompt: repairPrompt,
           data: {
-            ERROR_MESSAGE: originalError.message,
+            ERROR_MESSAGE: trueError,
             MALFORMED_JSON: rawOutput
           },
           skipValidation: true // don't want to validate as this would cause recursive infinity scenario if the JSON is invalid. Just one shot, fix or no fix
@@ -5199,7 +5256,7 @@ export class AIPromptRunner {
         currentPromptRun._jsonRepairInfo = {
           repaired: true,
           method: 'AIRepair',
-          originalError: originalError.message,
+          originalError: trueError,
           rawOutputPrefix: rawOutput.substring(0, 200),
           repairPromptRunId: repairResult.promptRun?.ID
         };
@@ -5209,15 +5266,16 @@ export class AIPromptRunner {
         this.logError(aiRepairError, {
           category: 'JSONRepairFailed',
           metadata: {
-            originalError: originalError.message,
+            originalError: trueError,
             json5Error: json5Error.message,
+            lexicalRepairReason: lexicalRepair.reason,
             aiError: aiRepairError.message,
             rawOutput: rawOutput.substring(0, 500)
           },
           maxErrorLength: params.maxErrorLength
         });
         
-        throw new Error(`JSON repair failed after both JSON5 and AI attempts: ${originalError.message}`);
+        throw new Error(`JSON repair failed after JSON5, lexical and AI attempts: ${trueError}`);
       }
     }
   }

--- a/packages/MJGlobal/src/__tests__/util.jsonRepair.test.ts
+++ b/packages/MJGlobal/src/__tests__/util.jsonRepair.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { CleanJSON, RepairJSONEscaping } from '../util';
+
+/**
+ * A response shaped like the ones that motivated this work: a JSON envelope whose string value
+ * holds fenced markdown, with the quotes inside the fence left unescaped. Everything else in the
+ * document — including the newlines — is escaped correctly, which is what makes the defect so
+ * narrow and so recoverable.
+ */
+const mermaidLabels = [
+    'vwMembers ||--o{ vwInvoices : "has invoices"',
+    'vwInvoices ||--o{ vwLineItems : "contains items"',
+].join('\\n    ');
+const brokenEnvelope =
+    '{"title":"Report","functionalRequirements":"## Data\\n\\n```mermaid\\nerDiagram\\n    ' +
+    mermaidLabels +
+    '\\n```\\n\\nDone."}';
+
+describe('CleanJSON — interior markdown fences', () => {
+    it('does not extract a fence that lives inside a string value', () => {
+        // The whole point: a ```mermaid fence inside a string value belongs to the value, not to
+        // the response. Extracting it silently discarded the entire document.
+        let thrown: Error | null = null;
+        try {
+            CleanJSON(brokenEnvelope);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown).not.toBeNull();
+        // The real defect must surface — not a phantom error about the fence contents.
+        expect(thrown!.message).not.toContain('mermaid');
+        expect(thrown!.message).toMatch(/position \d+/);
+    });
+
+    it('exposes the untouched top-level parse error as `cause`', () => {
+        let thrown: Error | null = null;
+        try {
+            CleanJSON(brokenEnvelope);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        const cause = thrown!.cause as Error | undefined;
+        expect(cause).toBeInstanceOf(Error);
+        expect(cause!.message).toMatch(/position \d+/);
+    });
+
+    it('still extracts JSON from a genuinely fence-wrapped response', () => {
+        const result = CleanJSON('```json\n{"extracted": true}\n```');
+        expect(JSON.parse(result!)).toEqual({ extracted: true });
+    });
+
+    it('still extracts JSON buried in surrounding prose', () => {
+        const result = CleanJSON('Some text ```json\n{"extracted": true}\n``` more text');
+        expect(JSON.parse(result!)).toEqual({ extracted: true });
+    });
+
+    it('leaves a valid document containing a fence completely alone', () => {
+        const valid = JSON.stringify({ text: '```mermaid\nerDiagram\n  A ||--o{ B : label\n```' });
+        const result = CleanJSON(valid);
+        expect(JSON.parse(result!)).toEqual(JSON.parse(valid));
+    });
+});
+
+describe('RepairJSONEscaping', () => {
+    it('escapes unescaped quotes inside a string value and preserves the content', () => {
+        const result = RepairJSONEscaping(brokenEnvelope);
+
+        expect(result.repaired).toBe(true);
+        // Two quoted labels, two quotes each.
+        expect(result.repairedOffsets).toHaveLength(4);
+        expect(result.value.title).toBe('Report');
+        // The diagram survives verbatim — repair adds escapes, it never rewrites content.
+        expect(result.value.functionalRequirements).toContain('vwMembers ||--o{ vwInvoices : "has invoices"');
+        expect(result.value.functionalRequirements).toContain('vwInvoices ||--o{ vwLineItems : "contains items"');
+    });
+
+    it('escapes raw control characters inside a string value', () => {
+        const result = RepairJSONEscaping('{"a":"line one\nline two"}');
+
+        expect(result.repaired).toBe(true);
+        expect(result.value.a).toBe('line one\nline two');
+    });
+
+    it('reports repaired: false for already-valid JSON, leaving it untouched', () => {
+        // Valid input needs no repair; `repaired` marks whether anything was changed.
+        const result = RepairJSONEscaping('{"a":1}');
+
+        expect(result.repaired).toBe(false);
+        expect(result.repairedOffsets).toHaveLength(0);
+        expect(result.value).toEqual({ a: 1 });
+    });
+
+    it('gives up rather than guessing on input that is not JSON at all', () => {
+        const result = RepairJSONEscaping('I am executing the action now.');
+
+        expect(result.repaired).toBe(false);
+        expect(result.value).toBeUndefined();
+        expect(result.reason).toBeTruthy();
+    });
+
+    it('gives up on truncated output instead of fabricating structure', () => {
+        // A response cut off mid-string cannot be recovered by escaping, and must not be
+        // "fixed" into something that parses but misrepresents what the model said.
+        const result = RepairJSONEscaping('{"a":"unterminated');
+
+        expect(result.repaired).toBe(false);
+        expect(result.value).toBeUndefined();
+    });
+
+    it('respects the repair ceiling', () => {
+        const result = RepairJSONEscaping(brokenEnvelope, 1);
+
+        expect(result.repaired).toBe(false);
+        expect(result.reason).toContain('after 1 repairs');
+    });
+
+    it('does not treat an already-escaped quote as needing repair', () => {
+        // `\\"` is a literal backslash followed by a real string terminator — the quote is NOT
+        // escaped. Miscounting the backslash run would corrupt the document.
+        const valid = JSON.stringify({ path: 'C:\\' });
+        const result = RepairJSONEscaping(valid);
+
+        expect(result.repaired).toBe(false);
+        expect(result.value).toEqual({ path: 'C:\\' });
+    });
+
+    it('handles null and empty input', () => {
+        expect(RepairJSONEscaping(null).repaired).toBe(false);
+        expect(RepairJSONEscaping('').repaired).toBe(false);
+    });
+});

--- a/packages/MJGlobal/src/util.ts
+++ b/packages/MJGlobal/src/util.ts
@@ -333,8 +333,24 @@ export function CleanJSON(inputString: string | null): string | null {
     // optionally followed by js or javascript (case-insensitive), then captures until the closing ```
     const markdownRegex = /(?:```|\\`\\`\\`)(?:json|JSON)?\s*([\s\S]*?)(?:```|\\`\\`\\`)/gi;
 
+    // Fence extraction is for responses that WRAP their JSON in a fence, or bury it in prose.
+    // It must not run on something that is already shaped like a JSON envelope: a fence found
+    // inside such a string belongs to a string VALUE, not to the response, and extracting it
+    // throws the whole document away.
+    //
+    // This was not hypothetical. An agent response embedded a mermaid diagram in a markdown
+    // string field and left one quote in the diagram unescaped. The top-level parse failed on
+    // that quote, control reached here, the regex matched the ```mermaid fence inside the string
+    // value, and CleanJSON returned the diagram's contents — discarding a 28KB response and
+    // reporting "Unexpected token 'm'". The real defect (one quote, at a known offset) never
+    // surfaced, so neither the JSON5 stage nor the AI repair stage that followed had any chance.
+    //
+    // A genuinely fence-wrapped response starts with the fence, and a prose-buried one starts
+    // with prose, so neither is affected by this guard.
+    const looksLikeJSONEnvelope = processedString.startsWith('{') || processedString.startsWith('[');
+
     // Check if the input contains Markdown code fences for JavaScript
-    const matches = Array.from(processedString.matchAll(markdownRegex));
+    const matches = looksLikeJSONEnvelope ? [] : Array.from(processedString.matchAll(markdownRegex));
 
     if (matches.length > 0) {
         // If there are matches, concatenate all captured groups (in case there are multiple code blocks)
@@ -371,15 +387,229 @@ export function CleanJSON(inputString: string | null): string | null {
         } catch (error) {
             // that was our last attempt and it failed so we need
             // to throw an exception here with the orignal exception
-            throw new Error(`Failed to find a path to CleanJSON\n\n${originalException?.message}`);
-        }     
+            //
+            // `cause` carries the untouched top-level parse error. The message is a summary that
+            // has been mangled by every transform above it; callers that need to act on the actual
+            // syntax error (a repair pass needing the failure offset, for instance) must not have
+            // to scrape it back out of this string.
+            throw new Error(`Failed to find a path to CleanJSON\n\n${originalException?.message}`, {
+                cause: originalException ?? undefined
+            });
+        }
+    }
+}
+
+/**
+ * Outcome of a {@link RepairJSONEscaping} attempt.
+ */
+export interface JSONEscapingRepairResult {
+    /** True only when the input parsed after repair. */
+    repaired: boolean;
+    /** The repaired JSON text, present only when `repaired` is true. */
+    text?: string;
+    /** The parsed value, present only when `repaired` is true. */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value?: any;
+    /** Zero-based offsets that were escaped, in the order they were fixed. */
+    repairedOffsets: number[];
+    /** Why the repair stopped, when `repaired` is false. */
+    reason?: string;
+}
+
+/** Upper bound on repair passes. Each pass fixes exactly one character. */
+const MAX_JSON_ESCAPING_REPAIRS = 40;
+
+/**
+ * Deterministically repairs the single most common way an LLM breaks otherwise-valid JSON:
+ * a double quote or raw control character left unescaped inside a string value.
+ *
+ * ## Why this exists
+ *
+ * Models embed rich markdown in string fields — mermaid diagrams, HTML mockups, code samples —
+ * and reliably escape most of it. A single missed quote inside a 25KB response invalidates the
+ * whole document. Nothing else in the repair chain recovers that: JSON5's leniency covers trailing
+ * commas, comments and unquoted keys, but an unescaped `"` terminates a string in JSON5 exactly as
+ * it does in JSON. The remaining fallback is an LLM round-trip on the full payload, which is slow,
+ * costly, and itself unreliable at that size.
+ *
+ * ## How it works
+ *
+ * Purely error-driven, one character per pass:
+ *
+ * 1. `JSON.parse` the text and read the failure offset from the thrown error.
+ * 2. Scan backwards from that offset for the character that ended the string early.
+ * 3. Escape that one character.
+ * 4. Re-parse. Repeat until it parses or a stopping condition trips.
+ *
+ * Every pass is validated by a real parse, so this never "pattern matches" its way to a wrong
+ * answer the way a global regex rewrite would. It converges in one pass per offending character
+ * (about two per quoted mermaid label) and gives up rather than guessing when it cannot make
+ * progress.
+ *
+ * ## Safety
+ *
+ * This can, in principle, produce valid-but-wrong JSON: escaping a quote that legitimately ended a
+ * string would merge two pieces of structure. Three properties keep that in check — it only runs
+ * after a parse has already failed (so a correct document is never touched), it only ever *adds*
+ * escapes and never deletes or reorders content, and it reports every offset it changed so callers
+ * can log, audit, or schema-check the result before trusting it. Callers holding an expected shape
+ * should validate against it; a wrong guess almost always fails shape validation.
+ *
+ * @param inputString - Raw model output, expected to be a JSON envelope
+ * @param maxRepairs - Maximum characters to escape before giving up
+ * @returns The repair outcome; `repaired` is false when the input could not be recovered
+ *
+ * @example
+ * // A mermaid relationship label whose quotes were not escaped
+ * RepairJSONEscaping('{"doc":"```mermaid\\nerDiagram\\n  A ||--o{ B : "has items"\\n```"}')
+ * // => { repaired: true, repairedOffsets: [...], value: { doc: '...' } }
+ */
+export function RepairJSONEscaping(
+    inputString: string | null,
+    maxRepairs: number = MAX_JSON_ESCAPING_REPAIRS
+): JSONEscapingRepairResult {
+    if (!inputString) {
+        return { repaired: false, repairedOffsets: [], reason: 'Input was empty.' };
+    }
+
+    let text = inputString;
+    const repairedOffsets: number[] = [];
+
+    for (let pass = 0; pass <= maxRepairs; pass++) {
+        try {
+            const value = JSON.parse(text);
+            return { repaired: pass > 0, text, value, repairedOffsets };
+        } catch (error: unknown) {
+            if (pass === maxRepairs) {
+                return {
+                    repaired: false,
+                    repairedOffsets,
+                    reason: `Still unparseable after ${maxRepairs} repairs.`
+                };
+            }
+
+            const message = error instanceof Error ? error.message : String(error);
+            const offset = extractJSONErrorOffset(message);
+            if (offset === null) {
+                return { repaired: false, repairedOffsets, reason: `No failure offset in: ${message}` };
+            }
+
+            const target = findUnescapedStringTerminator(text, offset);
+            if (target === null) {
+                return {
+                    repaired: false,
+                    repairedOffsets,
+                    reason: `No repairable character near offset ${offset}: ${message}`
+                };
+            }
+
+            text = text.slice(0, target) + escapeJSONStringChar(text[target]) + text.slice(target + 1);
+            repairedOffsets.push(target);
+        }
+    }
+
+    return { repaired: false, repairedOffsets, reason: 'Repair loop exhausted.' };
+}
+
+/**
+ * Reads the character offset out of a `JSON.parse` error message.
+ *
+ * Engines word these differently ("...at position 23011", "...at position 23011 (line 21 column
+ * 512)"), so this matches the offset itself rather than any one phrasing.
+ *
+ * @param errorMessage - Message thrown by JSON.parse
+ * @returns The offset, or null when the message carries none
+ */
+function extractJSONErrorOffset(errorMessage: string): number | null {
+    const match = /position (\d+)/i.exec(errorMessage);
+    if (!match) {
+        return null;
+    }
+    const offset = Number.parseInt(match[1], 10);
+    return Number.isFinite(offset) ? offset : null;
+}
+
+/**
+ * Given the offset where parsing failed, finds the character that ended a string value early.
+ *
+ * The parser reports where it found something unexpected, which is at or just after the character
+ * that actually broke the document. Scanning backwards from there finds the closing quote the model
+ * should have escaped — or a raw control character, which is illegal inside a JSON string and is
+ * reported at its own offset.
+ *
+ * @param text - The JSON text being repaired
+ * @param errorOffset - Offset reported by JSON.parse
+ * @returns Offset of the character to escape, or null when nothing nearby is repairable
+ */
+function findUnescapedStringTerminator(text: string, errorOffset: number): number | null {
+    // A raw control character is illegal inside a string and is flagged where it sits.
+    const atOffset = text[errorOffset];
+    if (atOffset !== undefined && isJSONControlCharacter(atOffset)) {
+        return errorOffset;
+    }
+
+    // Otherwise walk back to the quote that closed the string ahead of time. The scan is bounded:
+    // the culprit is adjacent to the failure by construction, and an unbounded walk could reach
+    // back into unrelated, correctly-formed structure.
+    const lowestOffset = Math.max(0, errorOffset - 64);
+    for (let i = Math.min(errorOffset, text.length - 1); i >= lowestOffset; i--) {
+        const char = text[i];
+        if (isJSONControlCharacter(char)) {
+            return i;
+        }
+        if (char === '"' && !isEscaped(text, i)) {
+            return i;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * True when the character must be escaped to appear inside a JSON string literal.
+ *
+ * @param char - Character to test
+ */
+function isJSONControlCharacter(char: string): boolean {
+    return char < ' ';
+}
+
+/**
+ * True when the character at `index` is escaped, accounting for runs of backslashes — in `\\"` the
+ * quote is NOT escaped, because the two backslashes escape each other.
+ *
+ * @param text - The text being inspected
+ * @param index - Index of the character in question
+ */
+function isEscaped(text: string, index: number): boolean {
+    let backslashes = 0;
+    for (let i = index - 1; i >= 0 && text[i] === '\\'; i--) {
+        backslashes++;
+    }
+    return backslashes % 2 === 1;
+}
+
+/**
+ * Escapes one character for inclusion in a JSON string literal.
+ *
+ * @param char - Character to escape
+ */
+function escapeJSONStringChar(char: string): string {
+    switch (char) {
+        case '"': return '\\"';
+        case '\n': return '\\n';
+        case '\r': return '\\r';
+        case '\t': return '\\t';
+        case '\b': return '\\b';
+        case '\f': return '\\f';
+        default: return '\\u' + char.charCodeAt(0).toString(16).padStart(4, '0');
     }
 }
 
 /**
  * This function takes in a string that may contain JavaScript code in a markdown code block and returns the JavaScript code without the code block.
- * @param javaScriptCode 
- * @returns 
+ * @param javaScriptCode
+ * @returns
  */
 export function CleanJavaScript(javaScriptCode: string): string {
     // Regular expression to match JavaScript code blocks within Markdown fences


### PR DESCRIPTION
Backport of #4137 onto the 5.51.x line. Merged to `next` as `879eec8eef`.

**Why this line needs it:** Skip pins MJ 5.51.0, so `next` alone does not reach production. This is the branch that actually fixes the failure.

## The failure

A Skip agent run died mid-demo after burning all ten retries — roughly four minutes and 79K completion tokens — regenerating the same broken response. The response was a 28KB PRD whose `functionalRequirements` field embedded a mermaid ER diagram. Every newline was escaped correctly; the diagram's own quotes were not:

```
vwMembers ||--o{ vwInvoices : "has invoices"
```

A `"` inside a JSON string value ends that string. One character invalidated the document.

## Three defects

**1. `CleanJSON` discarded the response over an interior fence.** After any failed top-level parse, fence extraction ran unconditionally. The regex has no idea it is looking *inside a string value*, so the ` ```mermaid ` fence matched, its contents were extracted, the envelope was thrown away, and `CleanJSON` recursed into the fragment. The real error — `Expected ',' or '}' ... at position 23011` — became ``Unexpected token 'm', "mermaid\ns"...``.

**2. The repair chain reasoned from that wrong error.** It was passed to the AI repair prompt as `ERROR_MESSAGE`, recorded on the prompt run, and re-thrown — so a model was asked to fix a phantom problem in text it was never shown.

**3. Nothing could repair an unescaped quote.** JSON5 covers trailing commas, comments and unquoted keys, but an unescaped `"` terminates a string in JSON5 exactly as in JSON.

## Changes

- **`@memberjunction/global`** — `CleanJSON` skips fence extraction when the input is already a JSON envelope; its throw carries the untouched parse error as `cause`; new `RepairJSONEscaping()`, error-driven and deterministic (read failure offset → walk back to the character that closed the string early → escape it → re-parse → repeat).
- **`@memberjunction/ai-prompts`** — `resolveTrueParseError()` derives the error from raw output; the lexical pass runs between the JSON5 and AI stages.
- **`@memberjunction/ai-core-plus`** — `_jsonRepairInfo` gains a `LexicalEscaping` method and records escaped offsets.

## Safety

Only runs after a parse has already failed, so a correct document is never touched. Only ever *adds* escapes. Every pass is validated by a real parse, so it cannot pattern-match to a wrong answer. Gives up rather than guessing — truncated output is explicitly not "repaired" into something that parses but misrepresents the model. Records every offset changed, so repairs are auditable.

## Verification

**Identical to `next`.** All three source diffs and the test file compared line-for-line against `origin/next~3..origin/next` — byte-for-byte the same. This is a true backport, not a re-implementation.

**16 real failing production payloads** (3 conversations, 2 orgs): 16/16 recovered, 180 characters escaped, 12ms total, every repair verified escapes-only (removing inserted backslashes reconstructs the original byte-for-byte) with a valid response shape.

**34 already-valid payloads**, 20 containing markdown fences: zero false positives, zero damaged by the fence guard.

**Build and tests green on this branch:** `@memberjunction/global` 619 passing, `@memberjunction/ai-prompts` 253 passing, `@memberjunction/ai-core-plus` builds. 13 new tests cover interior fences, `cause` propagation, both legitimate fence-extraction paths, quote and control-character repair, the backslash-run edge case (`\\"`, where the quote is *not* escaped), and the refusal to "fix" truncated output.

Test fixtures are synthetic payloads shaped like the real ones — no client data in the repo.

## Field results

Across a 5-suite, ~1,100-prompt-run eval session on the fixed build: **1 lexical repair fired and succeeded, 0 unrecovered parse failures, 0 retry-exhaustion terminations.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)