### PR TITLE
fix(integration): a stale content hash is repaired, not frozen forever

### DIFF
--- a/.changeset/stale-hash-reconverges.md
+++ b/.changeset/stale-hash-reconverges.md
@@ -1,0 +1,19 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+A row whose content hash goes stale is repaired once, instead of losing its fast path forever.
+
+When a source stops sending a column, the mapper OMITS the absent key rather than mapping it to null
+— a missing value is not a null value. The recomputed content hash therefore differs from the stored
+one, so the hash fast path correctly does not skip. But `SetEntityFields` never touches that column
+either, so the entity is not dirty and the unchanged-record skip fires instead — and that path never
+refreshes the stored hash.
+
+The mismatch was permanent. That row lost the content-hash fast path for good, paying a full load and
+a field-by-field compare on every sync from then on, until some other field happened to change.
+
+A stale hash now counts as sync state needing repair, alongside a tombstone or an error status: one
+write brings the stored hash back in line with what is actually being mapped, and every later sync
+skips the row cheaply again. It deliberately does not conclude the column is gone — absence in the
+data is not evidence of absence in the schema, and the column's value is left exactly as it is.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -5059,7 +5059,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             // re-establish the possibly-cleared record map and SKIP the write — leaving __mj_UpdatedAt
             // and the integration LastSynced columns untouched, exactly like the content-hash skip path.
             this.SetEntityFields(entity, record.MappedFields);
-            if (!entity.Dirty && !this.needsSyncStateRepair(entity, entityInfo)) {
+            if (!entity.Dirty && !this.needsSyncStateRepair(entity, entityInfo, record)) {
                 await this.QueueRecordMap(
                     recordMaps, companyIntegration.ID, record.ExternalRecord.ExternalID, entityMap.EntityID,
                     entity.PrimaryKey.KeyValuePairs.map(kv => String(kv.Value)).join('|'), contextUser,
@@ -5244,7 +5244,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         // Uses MJ's built-in dirty tracking (zero custom comparison logic). Critical for
         // connectors without server-side date filtering (e.g., YM) where every sync re-fetches
         // all records. Without this, 50k+ records get re-written every run.
-        if (!entity.Dirty && !this.needsSyncStateRepair(entity, entityInfo)) {
+        if (!entity.Dirty && !this.needsSyncStateRepair(entity, entityInfo, record)) {
             result.RecordsSkipped++;
             // Re-establish the record map even when the write is skipped — see the content-hash skip
             // above for the full rationale (a key-field/PK match can land here with no map row, and
@@ -5672,13 +5672,35 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
      */
     private needsSyncStateRepair(
         entity: { Get(fieldName: string): unknown },
-        entityInfo: { Fields: Array<{ Name: string }> } | undefined
+        entityInfo: { Fields: Array<{ Name: string }> } | undefined,
+        record?: MappedRecord
     ): boolean {
         if (!entityInfo) return false;
         const has = (name: string) => entityInfo.Fields.some(f => f.Name === name);
         if (has('__mj_integration_IsTombstoned') && entity.Get('__mj_integration_IsTombstoned') === true) return true;
         if (has('__mj_integration_SyncMessage') && entity.Get('__mj_integration_SyncMessage') != null) return true;
         if (has('__mj_integration_SyncStatus') && entity.Get('__mj_integration_SyncStatus') !== 'Active') return true;
+        // A STALE CONTENT HASH is repair-worthy for the same reason: skipping the write freezes it.
+        //
+        // The case that produces one is a source that stops sending a column. The mapper OMITS an
+        // absent key rather than mapping it to null (a missing value is not a null value), so the
+        // recomputed hash differs — but SetEntityFields never touches that column either, so the
+        // entity is NOT dirty and the skip above fires. The stored hash is therefore never refreshed
+        // and the mismatch is permanent: that row loses the content-hash fast path FOREVER, paying a
+        // full load and field-by-field compare on every sync until some other field happens to
+        // change. One repair write here re-converges it, and every later sync skips it cheaply.
+        //
+        // Deliberately NOT treated as "the column is gone" — absence in the data is not evidence of
+        // absence in the schema (§ the same rule the field-level deactivation follows). The value is
+        // left exactly as it is; only the hash is brought back in line with what we are actually
+        // mapping.
+        if (record && has(CONTENT_HASH_COLUMN)) {
+            const storedHash = entity.Get(CONTENT_HASH_COLUMN);
+            if (typeof storedHash === 'string' && storedHash.length > 0
+                && storedHash !== computeContentHash(record.MappedFields ?? {})) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/packages/Integration/engine/src/__tests__/StaleHashReconverges.test.ts
+++ b/packages/Integration/engine/src/__tests__/StaleHashReconverges.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { IntegrationEngine } from '../IntegrationEngine.js';
+import { CONTENT_HASH_COLUMN, computeContentHash } from '../ContentHash.js';
+
+/**
+ * A row whose stored content hash no longer matches must be repaired, not skipped forever.
+ *
+ * The case that produces one: the source stops sending a column. The mapper OMITS an absent key
+ * rather than mapping it to null — a missing value is not a null value — so the recomputed hash
+ * differs. But `SetEntityFields` never touches that column either, so the entity is NOT dirty and
+ * the unchanged-record skip fires. The stored hash is then never refreshed and the mismatch is
+ * PERMANENT: that row loses the content-hash fast path forever, paying a full load and a
+ * field-by-field compare on every sync until some other field happens to change.
+ *
+ * The repair is one write. It does NOT conclude the column is gone — absence in the data is not
+ * evidence of absence in the schema.
+ */
+type Host = {
+    needsSyncStateRepair: (
+        entity: { Get(f: string): unknown },
+        entityInfo: { Fields: Array<{ Name: string }> } | undefined,
+        record?: { MappedFields?: Record<string, unknown> },
+    ) => boolean;
+};
+
+const host = () => Object.create(IntegrationEngine.prototype) as unknown as Host;
+
+const info = (...names: string[]) => ({ Fields: names.map(Name => ({ Name })) });
+const entityWith = (values: Record<string, unknown>) => ({ Get: (f: string) => values[f] });
+
+const FULL = { id: 'ext-1', name: 'Ada', nickname: 'A' };
+const MISSING_COLUMN = { id: 'ext-1', name: 'Ada' };   // source stopped sending `nickname`
+
+describe('needsSyncStateRepair — a stale content hash re-converges', () => {
+    it('repairs a row whose stored hash no longer matches what we now map', () => {
+        const stored = computeContentHash(FULL);
+        const h = host();
+        expect(
+            h.needsSyncStateRepair(
+                entityWith({ [CONTENT_HASH_COLUMN]: stored }),
+                info(CONTENT_HASH_COLUMN),
+                { MappedFields: MISSING_COLUMN },
+            ),
+        ).toBe(true);
+    });
+
+    it('leaves a matching row alone — the skip is the whole point of hashing', () => {
+        const stored = computeContentHash(FULL);
+        const h = host();
+        expect(
+            h.needsSyncStateRepair(
+                entityWith({ [CONTENT_HASH_COLUMN]: stored }),
+                info(CONTENT_HASH_COLUMN),
+                { MappedFields: FULL },
+            ),
+        ).toBe(false);
+    });
+
+    it('does not fire on a row that has no stored hash yet', () => {
+        // Nothing to re-converge: the write path stamps one the first time it touches the row, and
+        // treating "no hash" as "stale" would rewrite every pre-hash row on every sync.
+        const h = host();
+        for (const stored of [null, undefined, '']) {
+            expect(
+                h.needsSyncStateRepair(
+                    entityWith({ [CONTENT_HASH_COLUMN]: stored }),
+                    info(CONTENT_HASH_COLUMN),
+                    { MappedFields: FULL },
+                ),
+            ).toBe(false);
+        }
+    });
+
+    it('does not fire on a table without the hash column at all', () => {
+        const h = host();
+        expect(h.needsSyncStateRepair(entityWith({}), info('id'), { MappedFields: FULL })).toBe(false);
+    });
+
+    it('is inert when no record is supplied — callers that cannot know stay unaffected', () => {
+        const h = host();
+        expect(
+            h.needsSyncStateRepair(
+                entityWith({ [CONTENT_HASH_COLUMN]: computeContentHash(FULL) }),
+                info(CONTENT_HASH_COLUMN),
+            ),
+        ).toBe(false);
+    });
+
+    it('still repairs the pre-existing sync-state cases, hash or no hash', () => {
+        // Regression guard: folding hash staleness in must not weaken tombstone / error recovery.
+        const h = host();
+        const matching = { [CONTENT_HASH_COLUMN]: computeContentHash(FULL) };
+        expect(h.needsSyncStateRepair(
+            entityWith({ ...matching, __mj_integration_IsTombstoned: true }),
+            info(CONTENT_HASH_COLUMN, '__mj_integration_IsTombstoned'), { MappedFields: FULL })).toBe(true);
+        expect(h.needsSyncStateRepair(
+            entityWith({ ...matching, __mj_integration_SyncMessage: 'boom' }),
+            info(CONTENT_HASH_COLUMN, '__mj_integration_SyncMessage'), { MappedFields: FULL })).toBe(true);
+        expect(h.needsSyncStateRepair(
+            entityWith({ ...matching, __mj_integration_SyncStatus: 'Error' }),
+            info(CONTENT_HASH_COLUMN, '__mj_integration_SyncStatus'), { MappedFields: FULL })).toBe(true);
+    });
+
+    it('the repair write is what re-converges it — the hash is recomputed from MappedFields', () => {
+        // SetStandardIntegrationFields stamps CONTENT_HASH_COLUMN from record.MappedFields, so the
+        // write this triggers stores the hash of what we now map. The NEXT sync then matches and
+        // skips: the repair happens once, not every run.
+        const afterRepair = computeContentHash(MISSING_COLUMN);
+        const h = host();
+        expect(
+            h.needsSyncStateRepair(
+                entityWith({ [CONTENT_HASH_COLUMN]: afterRepair }),
+                info(CONTENT_HASH_COLUMN),
+                { MappedFields: MISSING_COLUMN },
+            ),
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
## The defect

A source stops sending a column. The mapper **omits** the absent key rather than mapping it to null — a missing value is not a null value:

```ts
const value = this.ApplyFieldMapping(ext, fieldMap);
if (value !== undefined) { mappedFields[fieldMap.DestinationFieldName] = value; }
```

So the recomputed content hash differs from the stored one, and the hash fast path correctly declines to skip. But `SetEntityFields` never touches that column either, so the entity is **not dirty**, and the unchanged-record skip fires instead:

```ts
if (!entity.Dirty && !this.needsSyncStateRepair(entity, entityInfo)) {
    result.RecordsSkipped++;
    ...
    return;
}
```

That path never calls `SetStandardIntegrationFields`, so `__mj_integration_ContentHash` is **never refreshed**. The mismatch is permanent.

The row loses the content-hash fast path **forever** — a full `InnerLoad` and a field-by-field compare on every sync from then on, until some unrelated field happens to change. No data is wrong; it just quietly costs more every run, on every affected row, indefinitely.

## The fix

A stale hash now counts as sync state needing repair, alongside a tombstone or a non-Active status — the same reasoning those cases already use: *skipping the write freezes the state, so the state has to be part of the decision to skip.*

One write re-converges it. `SetStandardIntegrationFields` stamps the hash from `record.MappedFields`, so the repair stores the hash of what is actually being mapped and the next sync matches and skips. **The repair happens once, not every run** — pinned by a test.

Explicitly **not** a conclusion that the column is gone. Absence in the data is not evidence of absence in the schema — the same rule field-level deactivation already follows. The column's value is untouched; only the hash is brought back in line.

## Tests

Seven, including the boundaries that keep this from becoming a rewrite storm:

- a mismatched hash repairs
- a matching hash still skips (the entire point of hashing)
- **no stored hash yet → does not fire** — treating "no hash" as "stale" would rewrite every pre-hash row on every sync
- a table without the hash column is unaffected
- inert when no record is supplied
- the pre-existing tombstone / SyncMessage / SyncStatus repairs still fire with a matching hash (regression guard — folding this in must not weaken error recovery)
- after the repair, the row skips again

**Mutation-verified**: removing the check fails the first test.

Engine suite: **74 files / 970 tests** green.