### PR TITLE
fix(integration): Type and AllowsNull overlays ignored a silent source

### DIFF
--- a/.changeset/overlay-respects-silence.md
+++ b/.changeset/overlay-respects-silence.md
@@ -1,0 +1,22 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Type and nullability overlays now respect a silent source, like every other attribute already does.
+
+The per-attribute rule in this file is that discovered metadata wins where the source states
+something and the declaration fills the silence. Descriptions, booleans and lengths all follow it.
+`Type` and `AllowsNull` did not:
+
+- `MapSourceType` answers every input, including `''` and `undefined`, because its fallback has to
+  produce something for a genuinely unknown column. The caller used that answer either way, so a
+  describe with no type opinion rewrote a curated `datetimeoffset` or `bit` to `nvarchar` — and a
+  declared `nvarchar(MAX)` to a bounded `nvarchar`, which drops records at sync time.
+- `AllowsNull ?? !IsRequired` computed `true` when the source stated neither, because `!undefined` is
+  `true` — so a describe with no opinion silently turned a declared NOT NULL column optional.
+
+Types are hard constraints backed by real DDL, so a wrong one is a migration rather than a cosmetic
+drift. `decideTypeOverlay` and `decideNullabilityOverlay` now make both decisions explicitly, in the
+same shape as `decideBooleanOverlay`. A source that states something still wins; `IsRequired` still
+derives nullability, since that is a statement made indirectly; and a field with no declaration still
+takes the mapped value, fallback included, because there is nothing curated to protect.

--- a/packages/Integration/engine/src/IntegrationSchemaSync.ts
+++ b/packages/Integration/engine/src/IntegrationSchemaSync.ts
@@ -341,6 +341,72 @@ export interface PersistSchemaResult {
 }
 
 /**
+ * Does the source actually STATE a type, or is this silence?
+ *
+ * {@link MapSourceType} answers every input, including `''` and `undefined`, because its fallback
+ * has to produce something for a genuinely unknown column. That makes it unable to tell "the source
+ * says this is text" from "the source said nothing" — and the caller used its answer either way.
+ */
+function SourceStatedAType(sourceType: string | null | undefined): boolean {
+  return typeof sourceType === 'string' && sourceType.trim().length > 0;
+}
+
+/**
+ * Type overlay, silence-respecting — the same rule {@link decideBooleanOverlay} applies to booleans.
+ *
+ * A source that states a type wins; a source that says NOTHING leaves the declaration alone. Without
+ * the silence check, `MapSourceType('')` fell through to its `'nvarchar'` default and a describe with
+ * no type opinion quietly rewrote a curated `datetimeoffset` or `bit` to `nvarchar` — the exact
+ * "never fabricate values the source didn't give you" rule this file already enforces everywhere
+ * else. Types are hard constraints (real DDL), so a wrong one is a migration, not a cosmetic drift.
+ *
+ * A declaration that states nothing still takes the mapped value, fallback included: something has
+ * to be written, and there is no curated value to protect.
+ */
+export function decideTypeOverlay(
+  declaredType: string | null | undefined,
+  sourceType: string | null | undefined,
+): { value: string; winner: 'Declared' | 'Discovered' } {
+  const declared = (declaredType ?? '').trim();
+  if (!SourceStatedAType(sourceType)) {
+    return declared.length > 0
+      ? { value: declared, winner: 'Declared' }
+      : { value: MapSourceType(''), winner: 'Discovered' };
+  }
+  const mapped = MapSourceType(sourceType as string);
+  if (declared.length === 0 || declared === mapped) {
+    return { value: mapped, winner: declared === mapped ? 'Declared' : 'Discovered' };
+  }
+  return { value: mapped, winner: 'Discovered' };
+}
+
+/**
+ * Nullability overlay, silence-respecting.
+ *
+ * `AllowsNull ?? !IsRequired` computed `true` when the source stated NEITHER — because `!undefined`
+ * is `true` — so a describe with no opinion on either attribute unconditionally overwrote a declared
+ * `AllowsNull: false`. A required column silently became optional, and the DDL followed.
+ *
+ * The derivation from `IsRequired` is kept: a source that says a column is required HAS stated its
+ * nullability, just indirectly. Only the both-silent case defers to the declaration.
+ */
+export function decideNullabilityOverlay(
+  declaredAllowsNull: boolean | null | undefined,
+  sourceAllowsNull: boolean | undefined,
+  sourceIsRequired: boolean | undefined,
+): { value: boolean; winner: 'Declared' | 'Discovered' } {
+  if (sourceAllowsNull === undefined && sourceIsRequired === undefined) {
+    // Nothing said. Keep the declaration; default to permissive only when there is none.
+    return { value: declaredAllowsNull ?? true, winner: 'Declared' };
+  }
+  const described = sourceAllowsNull ?? !sourceIsRequired;
+  return {
+    value: described,
+    winner: declaredAllowsNull === described ? 'Declared' : 'Discovered',
+  };
+}
+
+/**
  * Maps generic source types (from connectors) to MJ EntityField-compatible type strings.
  */
 function MapSourceType(sourceType: string): string {
@@ -784,16 +850,16 @@ export class IntegrationSchemaSync {
           dirty = true;
         }
       }
-      const mappedType = MapSourceType(srcField.SourceType);
-      const describedAllowsNull = srcField.AllowsNull ?? !srcField.IsRequired;
+      const typeOverlay = decideTypeOverlay(existing.Type, srcField.SourceType);
+      const nullabilityOverlay = decideNullabilityOverlay(
+        existing.AllowsNull, srcField.AllowsNull, srcField.IsRequired);
+      const describedAllowsNull = nullabilityOverlay.value;
 
-      if (existing.Type !== mappedType) {
-        existing.Type = mappedType;
+      if (existing.Type !== typeOverlay.value) {
+        existing.Type = typeOverlay.value;
         dirty = true;
-        winners.Type = 'Discovered';
-      } else {
-        winners.Type = 'Declared';
       }
+      winners.Type = typeOverlay.winner;
       // Length is DDL-affecting (describe wins): seed it so the column is sized
       // nvarchar(N) instead of defaulting to NVARCHAR(MAX) downstream. (Large-text types carry
       // their MAX in the Type itself — 'nvarchar(MAX)' — via MapSourceType, so no length here.)
@@ -806,10 +872,8 @@ export class IntegrationSchemaSync {
       if (existing.AllowsNull !== describedAllowsNull) {
         existing.AllowsNull = describedAllowsNull;
         dirty = true;
-        winners.AllowsNull = 'Discovered';
-      } else {
-        winners.AllowsNull = 'Declared';
       }
+      winners.AllowsNull = nullabilityOverlay.winner;
       // No-fabrication overlay rule for boolean attributes — see
       // `decideBooleanOverlay`.  Discovered values only override when
       // the source actually has an opinion (defined boolean).  Undefined

--- a/packages/Integration/engine/src/__tests__/IntegrationSchemaSync.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntegrationSchemaSync.test.ts
@@ -20,7 +20,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { decideBooleanOverlay, decidePKPromotion, decideAbsentDeactivations, decideSchemaLimitViolations, decideLengthOverlay, decideSemanticOverlay, type AbsentDeactivationInput } from '../IntegrationSchemaSync';
+import { decideTypeOverlay, decideNullabilityOverlay, decideBooleanOverlay, decidePKPromotion, decideAbsentDeactivations, decideSchemaLimitViolations, decideLengthOverlay, decideSemanticOverlay, type AbsentDeactivationInput } from '../IntegrationSchemaSync';
 
 describe('decideLengthOverlay (U2 — width overlay grows, never shrinks)', () => {
     it('GROWS a persisted width when the rediscovered sample is wider', () => {
@@ -418,5 +418,74 @@ describe('the persist call site passes the CONNECTOR\'s authority, not a constan
     it('gates object and field deactivation on the same claim', () => {
         // If these ever diverge again, one level retires on evidence the other rejects.
         expect(source).toMatch(/FieldsAreAuthoritative \?\? SourceSchema\.IsAuthoritative === true/);
+    });
+});
+
+describe('decideTypeOverlay — silence keeps the declaration (§ no fabrication)', () => {
+    // MapSourceType answers EVERY input, including '' and undefined, because its fallback has to
+    // produce something for a genuinely unknown column. That made it unable to distinguish "the
+    // source says text" from "the source said nothing" — and the caller used its answer either way,
+    // so a describe with no type opinion rewrote a curated datetimeoffset to nvarchar. Types are
+    // hard constraints (real DDL), so a wrong one is a migration, not a cosmetic drift.
+
+    it('a SILENT source leaves a declared type alone', () => {
+        for (const silent of ['', '   ', undefined, null]) {
+            const out = decideTypeOverlay('datetimeoffset', silent);
+            expect(out.value).toBe('datetimeoffset');
+            expect(out.winner).toBe('Declared');
+        }
+    });
+
+    it('a source that STATES a type wins over the declaration', () => {
+        const out = decideTypeOverlay('nvarchar', 'datetime');
+        expect(out.value).toBe('datetimeoffset');
+        expect(out.winner).toBe('Discovered');
+    });
+
+    it('agreement is credited to the declaration, not the describe', () => {
+        expect(decideTypeOverlay('bit', 'boolean')).toEqual({ value: 'bit', winner: 'Declared' });
+    });
+
+    it('an UNDECLARED field still takes the mapped value, fallback included', () => {
+        // Nothing curated to protect, and something has to be written.
+        expect(decideTypeOverlay(null, 'string').value).toBe('nvarchar');
+        expect(decideTypeOverlay('', undefined).value).toBe('nvarchar');
+    });
+
+    it('does not silently downgrade a declared large-text column', () => {
+        // The nvarchar(MAX) → nvarchar direction is the one that drops records at sync time.
+        expect(decideTypeOverlay('nvarchar(MAX)', undefined).value).toBe('nvarchar(MAX)');
+        expect(decideTypeOverlay('nvarchar(MAX)', '').value).toBe('nvarchar(MAX)');
+    });
+});
+
+describe('decideNullabilityOverlay — both-silent keeps the declaration', () => {
+    // `AllowsNull ?? !IsRequired` computed TRUE when the source stated neither, because !undefined
+    // is true. A describe with no opinion on either attribute unconditionally overwrote a declared
+    // AllowsNull:false — a required column silently became optional, and the DDL followed.
+
+    it('keeps a declared NOT NULL when the source states neither attribute', () => {
+        const out = decideNullabilityOverlay(false, undefined, undefined);
+        expect(out.value).toBe(false);
+        expect(out.winner).toBe('Declared');
+    });
+
+    it('an explicit AllowsNull from the source wins', () => {
+        expect(decideNullabilityOverlay(false, true, undefined)).toEqual({ value: true, winner: 'Discovered' });
+        expect(decideNullabilityOverlay(true, false, undefined)).toEqual({ value: false, winner: 'Discovered' });
+    });
+
+    it('IsRequired still derives nullability — that is a statement, just an indirect one', () => {
+        expect(decideNullabilityOverlay(true, undefined, true)).toEqual({ value: false, winner: 'Discovered' });
+        expect(decideNullabilityOverlay(false, undefined, false)).toEqual({ value: true, winner: 'Discovered' });
+    });
+
+    it('agreement is credited to the declaration', () => {
+        expect(decideNullabilityOverlay(false, false, undefined).winner).toBe('Declared');
+    });
+
+    it('defaults to permissive only when there is no declaration to keep', () => {
+        expect(decideNullabilityOverlay(null, undefined, undefined)).toEqual({ value: true, winner: 'Declared' });
+        expect(decideNullabilityOverlay(undefined, undefined, undefined).value).toBe(true);
     });
 });


### PR DESCRIPTION
## The rule this restores

The per-attribute overlay rule in `IntegrationSchemaSync` is: **discovered metadata wins where the source states something; the declaration fills the silence.** Descriptions (`decideSemanticOverlay`), booleans (`decideBooleanOverlay`) and lengths (`decideLengthOverlay`) all implement it explicitly.

`Type` and `AllowsNull` were the two that didn't.

## Type

```ts
const mappedType = MapSourceType(srcField.SourceType);
if (existing.Type !== mappedType) { existing.Type = mappedType; ... }
```

`MapSourceType` answers **every** input — `''` and `undefined` fall through to `return 'nvarchar'` — because its fallback has to produce something for a genuinely unknown column. That makes it unable to distinguish *"the source says this is text"* from *"the source said nothing"*, and the caller used its answer either way.

So a describe with no type opinion rewrote a curated `datetimeoffset` or `bit` to `nvarchar`. Worse, it rewrote a declared **`nvarchar(MAX)` to a bounded `nvarchar`** — which is the shape that drops records at sync time once a value exceeds the width.

Types are hard constraints backed by real DDL. A wrong one is a migration, not a cosmetic drift.

## AllowsNull

```ts
const describedAllowsNull = srcField.AllowsNull ?? !srcField.IsRequired;
```

With both undefined this is `!undefined` → **`true`**. A describe stating nothing about either attribute unconditionally overwrote a declared `AllowsNull: false`, silently making a required column optional, and the DDL followed.

## The fix

`decideTypeOverlay` and `decideNullabilityOverlay`, in the same shape as `decideBooleanOverlay`:

- a source that **states** something still wins
- `IsRequired` still derives nullability — an indirect statement is still a statement, so only the both-silent case defers
- a field with **no declaration** still takes the mapped value, fallback included: nothing curated to protect, and something must be written
- agreement is credited to the declaration, keeping the `winners` provenance honest

## Tests

Eleven, including the two that matter most in practice: silence never downgrades a declared `nvarchar(MAX)`, and silence never flips a declared NOT NULL.

**Both mutation-verified** — removing each silence check fails two tests apiece.

Engine suite: **74 files / 980 tests** green.