### PR TITLE
fix(integration): a deselected primary key silently degraded identity

### DIFF
--- a/.changeset/pk-always-mapped.md
+++ b/.changeset/pk-always-mapped.md
@@ -1,0 +1,16 @@
+---
+"@memberjunction/server": patch
+---
+
+A deselected primary key no longer costs an object its identity.
+
+The table build force-includes primary-key columns whatever the user selected, so the key column
+always exists in the created table. The post-restart field-map build did not apply the same rule, so
+unticking the key produced a table WITH its key column but no field map carrying `IsKeyField`. The
+sync then had no identity to match on and silently fell back to content-hash matching — nothing
+errored, records simply stopped being recognised as the same record across syncs, which is how
+duplicates and phantom orphans begin.
+
+Nothing enforces selecting the key in the UI, and nothing should: identity is not a preference. The
+rule now lives in `selectFieldsToMap` alongside the other entity-map lifecycle decisions, so both
+sides of the apply agree and it is unit-tested.

--- a/packages/MJServer/src/__tests__/PrimaryKeyAlwaysMapped.test.ts
+++ b/packages/MJServer/src/__tests__/PrimaryKeyAlwaysMapped.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { selectFieldsToMap } from '../integration/EntityMapLifecycle.js';
+
+/**
+ * Deselecting the primary key must not cost the object its identity.
+ *
+ * The table build already force-includes key columns, so the column exists in the table either way.
+ * The post-restart field-map build did NOT, so a user who unticked the key got a table WITH its key
+ * column but no field map carrying `IsKeyField` — the sync then had no identity to match on and
+ * silently fell back to content-hash matching. Nothing errored; records just stopped being
+ * recognised as the same record across syncs, which is how duplicates and orphans start.
+ *
+ * Nothing enforces selecting the key in the UI, and nothing should: identity is not a preference.
+ */
+const f = (Name: string, IsPrimaryKey = false) => ({ Name, IsPrimaryKey });
+const ALL = [f('id', true), f('name'), f('email'), f('notes')];
+const names = (out: Array<{ Name: string }>) => out.map(x => x.Name);
+
+describe('selectFieldsToMap — the primary key is never optional', () => {
+    it('includes the key even when the user did not select it', () => {
+        expect(names(selectFieldsToMap(ALL, ['name', 'email']))).toEqual(['id', 'name', 'email']);
+    });
+
+    it('includes the key when the selection is EMPTY — an empty choice is still a choice', () => {
+        // Distinct from "no selection". An empty array is unusual but real, and it still cannot
+        // produce a keyless map.
+        expect(names(selectFieldsToMap(ALL, []))).toEqual(['id']);
+    });
+
+    it('does not duplicate the key when it IS selected', () => {
+        expect(names(selectFieldsToMap(ALL, ['id', 'name']))).toEqual(['id', 'name']);
+    });
+
+    it('null or undefined selection means every field', () => {
+        expect(names(selectFieldsToMap(ALL, null))).toEqual(['id', 'name', 'email', 'notes']);
+        expect(names(selectFieldsToMap(ALL, undefined))).toEqual(['id', 'name', 'email', 'notes']);
+    });
+
+    it('keeps every part of a COMPOSITE key, selected or not', () => {
+        const composite = [f('tenant_id', true), f('row_id', true), f('label')];
+        expect(names(selectFieldsToMap(composite, ['label']))).toEqual(['tenant_id', 'row_id', 'label']);
+    });
+
+    it('matches selection names case-insensitively', () => {
+        expect(names(selectFieldsToMap(ALL, ['NAME', 'Email']))).toEqual(['id', 'name', 'email']);
+    });
+
+    it('preserves the discovered field order', () => {
+        // Field-map creation walks this list; reordering would reshuffle Priority-adjacent behaviour
+        // for no reason.
+        expect(names(selectFieldsToMap(ALL, ['notes', 'name']))).toEqual(['id', 'name', 'notes']);
+    });
+
+    it('an object with no key at all is unaffected', () => {
+        const keyless = [f('a'), f('b')];
+        expect(names(selectFieldsToMap(keyless, ['a']))).toEqual(['a']);
+    });
+});

--- a/packages/MJServer/src/index.ts
+++ b/packages/MJServer/src/index.ts
@@ -10,7 +10,7 @@ import { MJGlobal, MJEventType, UUIDsEqual, ShutdownRegistry } from '@memberjunc
 import { setupSQLServerClient, SQLServerDataProvider, SQLServerProviderConfigData } from '@memberjunction/sqlserver-dataprovider';
 import { extendConnectionPoolWithQuery } from './util.js';
 import { registerIntegrationCustomColumnPromoter, IntegrationCustomColumnPromoter } from './integration/CustomColumnPromoter.js';
-import { DisableUnselectedEntityMaps, ReenableFieldMapsForEntityMap } from './integration/EntityMapLifecycle.js';
+import { DisableUnselectedEntityMaps, ReenableFieldMapsForEntityMap, selectFieldsToMap } from './integration/EntityMapLifecycle.js';
 import { default as BodyParser } from 'body-parser';
 import compression from 'compression'; // Add compression middleware
 import cors from 'cors';
@@ -1824,9 +1824,9 @@ async function processRSUPendingWork(): Promise<void> {
           const sourceObj = schema.Objects.find(o => o.ExternalName.toLowerCase() === objName.toLowerCase());
 
           const selectedFields = sourceObjectFields[objName]; // null = all, string[] = specific
-          const fieldsToMap = selectedFields
-            ? (sourceObj?.Fields ?? []).filter(f => selectedFields.some(sf => sf.toLowerCase() === f.Name.toLowerCase()))
-            : (sourceObj?.Fields ?? []);
+          // Always maps the PRIMARY KEY, selected or not — see selectFieldsToMap for why identity
+          // cannot be left to the selection.
+          const fieldsToMap = selectFieldsToMap(sourceObj?.Fields ?? [], selectedFields);
 
           // Load existing field maps to avoid duplicates
           const existingFieldMaps = await rvPending.RunView<MJCompanyIntegrationFieldMapEntity>({

--- a/packages/MJServer/src/integration/EntityMapLifecycle.ts
+++ b/packages/MJServer/src/integration/EntityMapLifecycle.ts
@@ -219,3 +219,34 @@ export async function ResetPullWatermarks(
     }
     return reset;
 }
+
+/** One discovered source field, reduced to what the selection decision needs. */
+export interface SelectableSourceField {
+    Name: string;
+    IsPrimaryKey?: boolean;
+}
+
+/**
+ * Which discovered fields get a field map, given the user's column selection.
+ *
+ * A PRIMARY KEY field is ALWAYS mapped, selected or not. The table build already applies this rule
+ * (`buildTargetConfigs`: `|| f.IsPrimaryKey`), so the key column exists in the table either way —
+ * and without the same rule here, deselecting the key produced a table WITH its key column but no
+ * field map carrying `IsKeyField`. The sync then had no identity to match on and silently fell back
+ * to content-hash matching: nothing errored, records just stopped being recognised as the same
+ * record across syncs.
+ *
+ * Nothing enforces selecting the key in the UI, and nothing should — identity is not a preference,
+ * so the invariant belongs here rather than in a validation message.
+ *
+ * `null`/`undefined` selection means "all fields", which is not the same as an EMPTY selection —
+ * an empty array is a real (if unusual) choice, and still yields the keys.
+ */
+export function selectFieldsToMap<T extends SelectableSourceField>(
+    allFields: readonly T[],
+    selectedFieldNames: readonly string[] | null | undefined,
+): T[] {
+    if (!selectedFieldNames) return [...allFields];
+    const selected = new Set(selectedFieldNames.map(n => n.toLowerCase()));
+    return allFields.filter(f => selected.has(f.Name.toLowerCase()) || f.IsPrimaryKey === true);
+}


### PR DESCRIPTION
## The asymmetry

The table build force-includes primary-key columns whatever the user selected:

```ts
const sourceFields = sourceObj.Fields.filter(f =>
    !selectedFieldSet || selectedFieldSet.has(f.Name.toLowerCase()) || f.IsPrimaryKey
);
```

The post-restart field-map build did not:

```ts
const fieldsToMap = selectedFields
    ? (sourceObj?.Fields ?? []).filter(f => selectedFields.some(sf => sf.toLowerCase() === f.Name.toLowerCase()))
    : (sourceObj?.Fields ?? []);
```

So unticking the key produced a table **with** its key column but **no field map carrying `IsKeyField`**.

## Why that is worse than it looks

`IsKeyField` is what the sync matches records on. Without it there is no identity, and matching silently degrades to content-hash comparison. Nothing errors. Nothing warns. Records simply stop being recognised as the same record across syncs — which is how duplicates and phantom orphans begin, on an object whose table looks perfectly correct.

Nothing enforces selecting the key in the UI, and nothing should. Identity is not a preference, so the invariant belongs in the apply rather than in a validation message the user can dismiss.

## The change

The rule moves into `selectFieldsToMap` in `integration/EntityMapLifecycle`, so both sides of the apply share one definition instead of two filters that drifted apart. `index.ts` cannot be imported in a unit test, so a rule written inline there is a rule nothing can check — the same reason the two sides diverged unnoticed.

It also distinguishes a **null** selection ("all fields") from an **empty** one — an empty array is unusual but a real choice, and it still cannot produce a keyless map.

**The initial-apply path was checked and is unaffected**: `createEntityAndFieldMaps` maps every field `DiscoverFields` returns, with no selection filter, so its keys were never at risk.

## Tests

Eight: key included when unselected, when the selection is empty, not duplicated when selected, all fields on null/undefined, **every part of a composite key**, case-insensitive matching, discovered order preserved, and a keyless object unaffected.

**Mutation-verified** — dropping `|| f.IsPrimaryKey` fails five of them.

MJServer suite: **953 passed, 0 failed**. The 12 file-level load failures are pre-existing unbuilt-peer resolution, identical on `origin/next`.