### PR TITLE
perf(integration): sample ~50 records per table by default, not 500

### DIFF
--- a/.changeset/sample-target-fifty.md
+++ b/.changeset/sample-target-fifty.md
@@ -1,0 +1,22 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Discovery samples ~50 records per table by default, not 500.
+
+Sampling exists to answer three questions, and 50 rows fully answers two of them: a statistically
+significant primary key (50 IS the classifier's significance floor — more rows change no verdict) and
+which custom columns exist in the data. Only the third, the largest observed string, benefits from
+more rows, and it has its own safety nets: the width bucket pads to twice the observed maximum, the
+overlay only ever grows a width, and a value that overflows at sync time is recorded as a widening
+candidate rather than lost.
+
+Paying ten times the discovery time on every object of every connection to sharpen one answer in
+three is the wrong default. On a large catalog that difference is the difference between a discovery
+a person will wait for and one they won't.
+
+The default is now sourced from `PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE` rather than restated, so the
+sample target and the floor it is chosen to match cannot drift apart. The precedence chain is
+unchanged — explicit options, then per-connection `discoveryMaxRecords`, then
+`MJ_INTEGRATION_DISCOVERY_MAX_RECORDS`, then this default — so a connection that wants deeper width
+fidelity raises it.

--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -26,6 +26,7 @@ import {
     discoverFromStream,
     pickKeyFromStats,
     pickPrimaryKeyFromStats,
+    PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE,
     type StreamDiscoveryOptions,
     type PkPickOptions,
 } from './StreamingDiscovery.js';
@@ -375,6 +376,17 @@ export interface RateLimitPolicy {
      */
     MinTokensPerSec?: number;
 }
+
+/**
+ * Records sampled per table during discovery, by default.
+ *
+ * Deliberately equal to the classifier's significance floor
+ * ({@link PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE}): sampling exists to answer three questions, and 50 rows
+ * fully answers two of them. Raising it only sharpens the third (largest observed string), which has
+ * its own safety nets, so the extra rows are paid on every object of every connection to improve one
+ * answer in three. Per-connection `discoveryMaxRecords` raises it where that trade is worth making.
+ */
+const DEFAULT_DISCOVERY_SAMPLE_TARGET = PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE;
 
 export abstract class BaseIntegrationConnector {
 
@@ -781,7 +793,20 @@ export abstract class BaseIntegrationConnector {
         // discovery budget an operator actually wants to lower for a slow source the ONLY one that needed
         // an app setting and a process restart. Same precedence as the others now:
         // explicit opts > per-connection Configuration > operator env > default.
-        const maxRecords = opts.MaxRecords ?? cfgInt(cfg.discoveryMaxRecords) ?? envInt('MJ_INTEGRATION_DISCOVERY_MAX_RECORDS', 500);
+        // The DEFAULT is the per-table sample target: ~50 records, the same figure the value-statistic
+        // classifier treats as significant (PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE). It was 500, which is
+        // 10x what any of the three questions sampling answers actually needs:
+        //   - a significant primary key — 50 rows IS the significance floor; more changes no verdict,
+        //   - custom-discoverable columns — a column present in the data shows up almost immediately,
+        //   - the largest string — the only one that genuinely benefits from more rows.
+        // That last one is why this is a KNOB and not a constant. Width has real safety nets (the
+        // bucket pads to 2x the observed max, the overlay only ever GROWS a width, and a value that
+        // overflows at sync time is recorded as a widening candidate rather than lost), so paying 10x
+        // the discovery time on every object by default to sharpen one of three answers is the wrong
+        // trade. A connection that needs deeper width fidelity raises `discoveryMaxRecords`.
+        //
+        // Precedence unchanged: explicit opts > per-connection Configuration > operator env > default.
+        const maxRecords = opts.MaxRecords ?? cfgInt(cfg.discoveryMaxRecords) ?? envInt('MJ_INTEGRATION_DISCOVERY_MAX_RECORDS', DEFAULT_DISCOVERY_SAMPLE_TARGET);
         // Announce intent AND cost. Until now only the FAILURE branch below said anything, so a
         // healthy-but-slow object, an object grinding out its whole time budget, and one that will
         // never return were indistinguishable from outside the process. The watchdog names whatever

--- a/packages/Integration/engine/src/__tests__/DiscoveryBudgetPrecedence.test.ts
+++ b/packages/Integration/engine/src/__tests__/DiscoveryBudgetPrecedence.test.ts
@@ -27,6 +27,7 @@ import type {
     FetchBatchResult,
 } from '../BaseIntegrationConnector.js';
 import type { StreamDiscoveryOptions, PkPickOptions } from '../StreamingDiscovery.js';
+import { PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE } from '../StreamingDiscovery.js';
 
 /** The three budgets as `DiscoverFieldsViaFetch` resolved them for a given call. */
 type ResolvedBudgets = { BatchSize: number; MaxRecords: number; TimeBudgetMs: number | undefined };
@@ -81,8 +82,20 @@ function connectionWithConfiguration(configuration: string | null): MJCompanyInt
 
 const NO_USER = {} as unknown as UserInfo;   // passed straight through to the overridden stream
 
-/** Engine defaults, asserted here so a silent change to one shows up as a test failure. */
-const DEFAULTS = { BatchSize: 500, MaxRecords: 500, TimeBudgetMs: 5 * 60 * 1000 } as const;
+/**
+ * Engine defaults, asserted here so a silent change to one shows up as a test failure.
+ *
+ * MaxRecords is the per-table sample TARGET and is deliberately the classifier's significance floor,
+ * not a round number: 50 rows fully answers two of the three questions sampling asks (significant
+ * primary key, custom-discoverable columns) and only the third (largest observed string) benefits
+ * from more — and that one has its own safety nets. Sourced from the constant rather than restated,
+ * so the two cannot drift apart.
+ */
+const DEFAULTS = {
+    BatchSize: 500,
+    MaxRecords: PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE,
+    TimeBudgetMs: 5 * 60 * 1000,
+} as const;
 
 const ENV_KEYS = [
     'MJ_INTEGRATION_DISCOVERY_TIME_BUDGET_MS',
@@ -120,7 +133,7 @@ describe('BaseIntegrationConnector.DiscoverFieldsViaFetch — discovery budget p
     });
 
     it('reads ALL THREE budgets from per-connection Configuration', async () => {
-        // maxRecords is the one that was missing its read: before the fix this came back as 500.
+        // maxRecords is the one that was missing its read: before that fix it ignored Configuration entirely.
         const budgets = await resolve(JSON.stringify({
             discoveryTimeBudgetMs: 90_000,
             discoveryBatchSize: 25,


### PR DESCRIPTION
## The trade

Discovery samples records to answer exactly three questions. **50 rows fully answers two of them:**

| Question | Does 500 beat 50? |
|---|---|
| Is there a statistically significant primary key? | **No** — 50 *is* the classifier's significance floor. Below it the classifier abstains; above it, more rows change no verdict. |
| Which custom columns exist in the data? | **No** — a column present in the data appears almost immediately. |
| What is the largest string value? | **Yes** — this is the only one more rows genuinely sharpen. |

So the old default paid **10× the discovery time on every object of every connection** to improve one answer in three.

## Why the third question can afford it

Width is not left unprotected if a wide value falls outside the sample:

- the width bucket pads to **twice** the observed maximum, so the sampled max is not the ceiling
- the overlay **only ever grows** a width, never shrinks one — a later refresh that sees a wider value widens the column
- a value that overflows at sync time is recorded as a **widening candidate**, not silently lost

And it stays a knob precisely because that trade isn't universal: a connection that needs deeper width fidelity raises `discoveryMaxRecords`.

## The change

```ts
envInt('MJ_INTEGRATION_DISCOVERY_MAX_RECORDS', DEFAULT_DISCOVERY_SAMPLE_TARGET)
```

where `DEFAULT_DISCOVERY_SAMPLE_TARGET = PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE`.

**Sourced, not restated.** The sample target is deliberately equal to the classifier's floor, so writing `50` a second time invites exactly the drift that made a fourth copy of that number a problem in the parent-key sampler. If the floor moves, this moves with it.

Precedence is untouched: explicit options → per-connection `discoveryMaxRecords` → `MJ_INTEGRATION_DISCOVERY_MAX_RECORDS` → default.

## Tests

`DiscoveryBudgetPrecedence` asserted the literal `500`, which is the correct thing to fail here. Its `DEFAULTS` now reads the constant for the same anti-drift reason, and its precedence coverage (explicit > Configuration > env > default, non-positive and malformed values ignored) is unchanged and still green.

Engine suite: **74 files / 980 tests** green.