### PR TITLE
fix(integration): a provable key must have no observed duplicate; a capped scan is a prefix

### DIFF
--- a/.changeset/sample-trustworthy.md
+++ b/.changeset/sample-trustworthy.md
@@ -1,0 +1,32 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Three fixes to make a discovery sample trustworthy: a provable key now requires no observed
+duplicate, a capped scan admits it only saw a prefix, and the per-table sample target returns to 500.
+
+**A duplicate in the sample disproves keyness.** `subsetKeyness` decided keyness purely by Chao1
+domain saturation and never checked the sampled tuples were distinct. Chao1 estimates how large the
+value domain is — evidence about future collisions, not about ones already in the sample — and its
+bias-corrected branch grows quadratically in the singleton count. A column with nine copies of one
+value among 100 rows scored D̂ ≈ 4187 and was reported as a *provable* primary key. Two source
+records sharing that value then collapse onto one row: silent data loss, the mirror image of a
+duplicate record. Keyness now requires `d === n` first, with Chao1 retained to separate an identifier
+from a small category that merely has not collided yet. Genuine composite keys whose individual
+columns repeat are unaffected.
+
+**A record-capped scan is a prefix, not an exhausted source.** The cap is enforced by the generator
+feeding the scan, which simply returns, so the stream ended indistinguishably from a table that ran
+out of rows and the scan reported `exhausted`. That unlocked the lenient near-unique (0.9) soft-key
+rule instead of the strict 1.0 reserved for partial corpora. `StoppedReason` gains `record-cap`, the
+producer's target is passed in so the scan can recognise its own truncation, and completeness now
+means `exhausted` rather than "not time-budget".
+
+**The sample target returns to 500.** It was lowered to the primary-key significance floor on the
+reasoning that 50 rows answer the other questions well enough. They do not: several connectors
+declare no widths at all — YourMembership states `MaxLength: null` and unions in the sampler's result
+— so the sample is the only source of column width, and a value too wide for its column is skipped at
+sync time rather than truncated. A sparse custom column present on ~1% of records is also near-certain
+in 500 rows and a coin flip in 50. A floor is a minimum, not a target to sample down to. Streaming
+rows from one object is one paged read; what costs requests is descending into parents, which is
+bounded separately by the child's own demand.

--- a/packages/Integration/engine/src/BaseIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseIntegrationConnector.ts
@@ -378,15 +378,27 @@ export interface RateLimitPolicy {
 }
 
 /**
- * Records sampled per table during discovery, by default.
+ * Records STREAMED per table during discovery, by default.
  *
- * Deliberately equal to the classifier's significance floor
- * ({@link PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE}): sampling exists to answer three questions, and 50 rows
- * fully answers two of them. Raising it only sharpens the third (largest observed string), which has
- * its own safety nets, so the extra rows are paid on every object of every connection to improve one
- * answer in three. Per-connection `discoveryMaxRecords` raises it where that trade is worth making.
+ * This is a STATISTICS budget, not a fetch-fan-out budget, and the distinction is the whole reason
+ * it is large. Streaming N rows from one object is paging one endpoint; it does not multiply into
+ * per-parent requests. What costs requests is DESCENDING into parents to build a child's sample, and
+ * that is bounded separately by the child's own demand — see StreamRecordsForDiscovery, which pulls
+ * exactly as many parents as it takes to fill the child, however many rows each parent's own scan
+ * happens to read.
+ *
+ * It was briefly lowered to {@link PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE} on the reasoning that 50 rows
+ * answer the primary-key question and the other two answers have safety nets. Both halves were
+ * wrong:
+ *   - Several connectors declare NO widths at all (YourMembership states `MaxLength: null` in its
+ *     own catalog and unions in the sampler's result), so the sample is the ONLY source of column
+ *     width. Ten times fewer observed values means narrower columns, and a value too wide for its
+ *     column is SKIPPED at sync time, not truncated — records silently lost.
+ *   - A sparse custom column present on ~1% of records is near-certain in 500 rows and a coin flip
+ *     in 50.
+ * The primary-key floor is a MINIMUM for significance, never a target to sample down to.
  */
-const DEFAULT_DISCOVERY_SAMPLE_TARGET = PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE;
+const DEFAULT_DISCOVERY_SAMPLE_TARGET = 500;
 
 export abstract class BaseIntegrationConnector {
 
@@ -685,7 +697,11 @@ export abstract class BaseIntegrationConnector {
             // objects still get no PK (content-hash identity handles dedup).
             // #A4 — tell the PK picker whether the scan saw the WHOLE stream; a time-budget-truncated scan
             // must not yield a confident soft key from a partial prefix.
-            const soft = pickPrimaryKeyFromStats(scan.Columns, { ...opts.Pk, ScanComplete: scan.StoppedReason !== 'time-budget' });
+            // A scan is COMPLETE only when the source ran out of rows. A time budget and a record cap
+            // both leave a PREFIX, and a prefix must not earn a confident soft key: over a short one
+            // an ordinary foreign key is very likely to look near-unique, and a wrong soft key does
+            // not error — it silently merges two source records onto one row.
+            const soft = pickPrimaryKeyFromStats(scan.Columns, { ...opts.Pk, ScanComplete: scan.StoppedReason === 'exhausted' });
             if (soft.Field) { pkFieldNames = [soft.Field]; pkReason = `[soft-fallback] ${soft.Reason}`; }
         }
         const pkFields = new Set<string>(pkFieldNames);
@@ -793,19 +809,8 @@ export abstract class BaseIntegrationConnector {
         // discovery budget an operator actually wants to lower for a slow source the ONLY one that needed
         // an app setting and a process restart. Same precedence as the others now:
         // explicit opts > per-connection Configuration > operator env > default.
-        // The DEFAULT is the per-table sample target: ~50 records, the same figure the value-statistic
-        // classifier treats as significant (PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE). It was 500, which is
-        // 10x what any of the three questions sampling answers actually needs:
-        //   - a significant primary key — 50 rows IS the significance floor; more changes no verdict,
-        //   - custom-discoverable columns — a column present in the data shows up almost immediately,
-        //   - the largest string — the only one that genuinely benefits from more rows.
-        // That last one is why this is a KNOB and not a constant. Width has real safety nets (the
-        // bucket pads to 2x the observed max, the overlay only ever GROWS a width, and a value that
-        // overflows at sync time is recorded as a widening candidate rather than lost), so paying 10x
-        // the discovery time on every object by default to sharpen one of three answers is the wrong
-        // trade. A connection that needs deeper width fidelity raises `discoveryMaxRecords`.
-        //
-        // Precedence unchanged: explicit opts > per-connection Configuration > operator env > default.
+        // The DEFAULT is a STATISTICS budget — see DEFAULT_DISCOVERY_SAMPLE_TARGET for why it is large
+        // and why lowering it costs width fidelity and custom-column coverage rather than buying speed.
         const maxRecords = opts.MaxRecords ?? cfgInt(cfg.discoveryMaxRecords) ?? envInt('MJ_INTEGRATION_DISCOVERY_MAX_RECORDS', DEFAULT_DISCOVERY_SAMPLE_TARGET);
         // Announce intent AND cost. Until now only the FAILURE branch below said anything, so a
         // healthy-but-slow object, an object grinding out its whole time budget, and one that will
@@ -827,7 +832,10 @@ export abstract class BaseIntegrationConnector {
                     deadlineMs,
                     watchKey,
                 ),
-                { Discovery: { TimeBudgetMs: timeBudgetMs }, ReadOnly: true },
+                // RecordCap is the producer's target, handed to the scan so it can tell "the source ran
+                // out" from "we stopped it at the target". Without it a capped prefix reports as a
+                // complete scan and earns the lenient near-unique soft-key rule it has not earned.
+                { Discovery: { TimeBudgetMs: timeBudgetMs, RecordCap: maxRecords }, ReadOnly: true },
             );
             const tookMs = Date.now() - startedMs;
             const seen = watchdog.Peek(watchKey);

--- a/packages/Integration/engine/src/StreamingDiscovery.ts
+++ b/packages/Integration/engine/src/StreamingDiscovery.ts
@@ -32,6 +32,15 @@ export interface StreamDiscoveryOptions {
      * (cap × columns) — never the raw values. Default 2000: enough for significance, cheap on CPU/RAM.
      */
     CompositeSampleRowCap?: number;
+    /**
+     * The record target the PRODUCER of this stream is enforcing, if any.
+     *
+     * Supplied so the scan can distinguish "the source ran out of rows" from "we stopped it" — the
+     * generator enforces the cap by returning, which the scan would otherwise read as exhaustion.
+     * Only affects {@link StreamDiscoveryResult.StoppedReason}; the scan never stops early on its
+     * own account because of it.
+     */
+    RecordCap?: number;
     /** Injectable clock (for tests). Defaults to Date.now. */
     Now?: () => number;
 }
@@ -62,8 +71,16 @@ export interface DiscoveredColumnStat {
 export interface StreamDiscoveryResult {
     Columns: DiscoveredColumnStat[];
     RowsScanned: number;
-    /** Why the scan ended — surfaced so a time-capped (partial) corpus is never silently treated as complete. */
-    StoppedReason: 'exhausted' | 'time-budget';
+    /**
+     * Why the scan ended, so a PARTIAL corpus is never silently treated as complete.
+     *
+     * `record-cap` is not a variant of `exhausted`. Hitting the sample target means the stream had
+     * more to give — the corpus is a PREFIX of the table, exactly like a time-capped one, and the
+     * key pickers must judge it with the same suspicion. Reporting it as `exhausted` let a 50-row
+     * prefix of a ten-million-row table qualify for the lenient near-unique soft-key rule, where an
+     * ordinary foreign key is very likely to look unique.
+     */
+    StoppedReason: 'exhausted' | 'time-budget' | 'record-cap';
     /**
      * Bounded per-row cell-hash sample (column → stable value-hash for the row's non-null cells),
      * capped at {@link StreamDiscoveryOptions.CompositeSampleRowCap}. Feeds composite-key discovery
@@ -114,7 +131,11 @@ export async function discoverFromStream(
     const acc = new Map<string, ColumnAcc>();
     const rowSamples: Array<Record<string, string>> = [];
     let totalRows = 0;
-    let stoppedReason: 'exhausted' | 'time-budget' = 'exhausted';
+    let stoppedReason: 'exhausted' | 'time-budget' | 'record-cap' = 'exhausted';
+    // The record cap fires in the GENERATOR feeding this scan (it simply returns), so the stream
+    // ends indistinguishably from a table that ran out of rows. Told the cap, the scan can tell the
+    // two apart: reaching it exactly means the producer stopped us, not that the source was done.
+    const recordCap = opts.RecordCap;
 
     for await (const record of toAsyncIterable(records)) {
         totalRows++;
@@ -130,6 +151,10 @@ export async function discoverFromStream(
         }
         if (now() - start > timeBudgetMs) {
             stoppedReason = 'time-budget';
+            break;
+        }
+        if (recordCap != null && totalRows >= recordCap) {
+            stoppedReason = 'record-cap';
             break;
         }
     }
@@ -363,11 +388,22 @@ function* combinations<T>(items: T[], k: number): Generator<T[]> {
 }
 
 /**
- * Key-ness of a column SUBSET over the cached row-hash sample, via the Chao1 nonparametric
- * cardinality estimator. A subset is a PROVABLE key iff its estimated value-domain provably EXCEEDS
- * the sample (D̂ > n) — i.e. the domain has NOT saturated: we keep seeing brand-new tuples, the
- * signature of an identifier, not a category. Robust to skew (it reads the singleton/doubleton
- * structure of the repeats, not a raw distinct ratio) and CPU-cheap (one pass over the row-hashes).
+ * Key-ness of a column SUBSET over the cached row-hash sample.
+ *
+ * TWO conditions, and the first is the one that makes it PROVABLE:
+ *
+ *  1. **No observed duplicate.** Every tuple in the sample occurs exactly once (`d === n`). A
+ *     repeated tuple is direct, positive disproof — the column cannot be a key, and no amount of
+ *     domain estimation can argue otherwise.
+ *  2. **The domain has not saturated** (Chao1 `D̂ > n`). Given all-distinct values, this separates an
+ *     identifier from a small category that merely happens not to have collided yet in `n` rows.
+ *
+ * Condition 1 used to be missing, and Chao1 alone is not a uniqueness test — it estimates how large
+ * the value domain is, which is evidence about FUTURE collisions, not about observed ones. Worse,
+ * its bias-corrected branch (`f2 === 0`) grows QUADRATICALLY in the singleton count, so a column with
+ * 92 distinct values over 100 rows — nine of them the same value — scored D̂ ≈ 4187 and was declared
+ * a provable primary key. That does not error: the sync silently merges two source records onto one
+ * row, which is data loss, and the mirror image of the duplicate-record failure.
  */
 function subsetKeyness(rowSamples: Array<Record<string, string>>, cols: string[], minRows: number): { Dhat: number; isKey: boolean } {
     const n = rowSamples.length;
@@ -383,7 +419,8 @@ function subsetKeyness(rowSamples: Array<Record<string, string>>, cols: string[]
     // Chao1 (bias-corrected when no doubletons): D̂ blows up when values are mostly singletons
     // (domain ≫ sample → unsaturated → key); collapses toward `d` when repeats dominate (saturated).
     const Dhat = f2 > 0 ? d + (f1 * f1) / (2 * f2) : d + (f1 * (f1 - 1)) / 2;
-    return { Dhat, isKey: n >= minRows && Dhat > n };
+    // `d === n` FIRST: an observed duplicate disproves keyness outright, whatever the estimator says.
+    return { Dhat, isKey: n >= minRows && d === n && Dhat > n };
 }
 
 /**

--- a/packages/Integration/engine/src/__tests__/DagDiscoveryABCDE.test.ts
+++ b/packages/Integration/engine/src/__tests__/DagDiscoveryABCDE.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { UserInfo } from '@memberjunction/core';
+import type { MJCompanyIntegrationEntity, MJIntegrationObjectEntity, MJIntegrationObjectFieldEntity } from '@memberjunction/core-entities';
+import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
+import { BaseRESTIntegrationConnector, type RESTAuthContext, type RESTResponse, type PaginationState } from '../BaseRESTIntegrationConnector.js';
+
+vi.mock('@memberjunction/core', async () => {
+    const actual = await vi.importActual<typeof import('@memberjunction/core')>('@memberjunction/core');
+    return { ...actual, RunView: class { async RunView() { return { Success: true, Results: [] }; } } };
+});
+
+/**
+ * THE DAG EXERCISE, executed rather than described.
+ *
+ *   A, B, C   top-level objects
+ *   D         depends on A AND B      → /a/{aId}/b/{bId}/d   (TWO template vars)
+ *   E         depends on D            → /d/{dId}/e           (one template var)
+ *
+ * Discovery samples ~50 records per table. This measures what each object ACTUALLY gets.
+ */
+const f = (o: Partial<MJIntegrationObjectFieldEntity>) => o as unknown as MJIntegrationObjectFieldEntity;
+const FIELDS: Record<string, MJIntegrationObjectFieldEntity[]> = {
+    objA: [f({ Name: 'aId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 })],
+    objB: [f({ Name: 'bId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 })],
+    objC: [f({ Name: 'cId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 })],
+    objD: [
+        f({ Name: 'dId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
+        f({ Name: 'aId', RelatedIntegrationObjectID: 'objA', Status: 'Active', Sequence: 2 }),
+        f({ Name: 'bId', RelatedIntegrationObjectID: 'objB', Status: 'Active', Sequence: 3 }),
+    ],
+    objE: [
+        f({ Name: 'eId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
+        f({ Name: 'dId', RelatedIntegrationObjectID: 'objD', Status: 'Active', Sequence: 2 }),
+    ],
+};
+const mk = (ID: string, Name: string, APIPath: string) =>
+    ({ ID, Name, APIPath, SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity);
+const objA = mk('objA', 'A', '/a');
+const objB = mk('objB', 'B', '/b');
+const objC = mk('objC', 'C', '/c');
+const objD = mk('objD', 'D', '/a/{aId}/b/{bId}/d');   // multi-parent
+const objE = mk('objE', 'E', '/d/{dId}/e');
+const BY_ID: Record<string, MJIntegrationObjectEntity> = { objA, objB, objC, objD, objE };
+const BY_NAME: Record<string, MJIntegrationObjectEntity> = { A: objA, B: objB, C: objC, D: objD, E: objE };
+
+const rows = (n: number, key: string, prefix: string) =>
+    Array.from({ length: n }, (_v, i) => ({ [key]: `${prefix}${i}` }));
+
+class TestConnector extends BaseRESTIntegrationConnector {
+    public urls: string[] = [];
+    public get IntegrationName(): string { return 'DagExercise'; }
+    protected GetCachedObject(_i: string, name: string): MJIntegrationObjectEntity {
+        const o = BY_NAME[name]; if (!o) throw new Error(`no object ${name}`); return o;
+    }
+    protected GetCachedFields(objectID: string): MJIntegrationObjectFieldEntity[] { return FIELDS[objectID] ?? []; }
+    protected async Authenticate(): Promise<RESTAuthContext> { return { Token: 't' } as RESTAuthContext; }
+    protected BuildHeaders(): Record<string, string> { return {}; }
+    protected GetBaseURL(): string { return 'https://api.test'; }
+    protected async MakeHTTPRequest(_a: RESTAuthContext, url: string): Promise<RESTResponse> {
+        this.urls.push(url);
+        const p = url.replace('https://api.test', '');
+        // Each top-level endpoint has plenty of rows — more than the 50 target.
+        if (p === '/a') return { Status: 200, Body: rows(200, 'aId', 'a'), Headers: {} } as RESTResponse;
+        if (p === '/b') return { Status: 200, Body: rows(200, 'bId', 'b'), Headers: {} } as RESTResponse;
+        if (p === '/c') return { Status: 200, Body: rows(200, 'cId', 'c'), Headers: {} } as RESTResponse;
+        const d = /^\/a\/([^/]+)\/b\/([^/]+)\/d$/.exec(p);
+        if (d) return { Status: 200, Body: rows(3, 'dId', `d-${d[1]}-${d[2]}-`), Headers: {} } as RESTResponse;
+        const e = /^\/d\/([^/]+)\/e$/.exec(p);
+        if (e) return { Status: 200, Body: rows(3, 'eId', `e-${e[1]}-`), Headers: {} } as RESTResponse;
+        return { Status: 404, Body: [], Headers: {} } as RESTResponse;
+    }
+    protected NormalizeResponse(b: unknown): Record<string, unknown>[] { return Array.isArray(b) ? b as Record<string, unknown>[] : []; }
+    protected ExtractPaginationInfo(): PaginationState { return { HasMore: false } as PaginationState; }
+}
+
+const CI = { IntegrationID: 'int1' } as unknown as MJCompanyIntegrationEntity;
+const TARGET = 50;
+
+describe('DAG discovery — A, B, C top-level; D depends on A AND B; E depends on D', () => {
+    beforeEach(() => {
+        vi.spyOn(IntegrationEngineBase, 'Instance', 'get').mockReturnValue({
+            GetIntegrationObjectByID: (id: string) => BY_ID[id],
+            GetIntegrationObject: (_i: string, n: string) => BY_NAME[n],
+            GetIntegrationObjectFields: (id: string) => FIELDS[id] ?? [],
+            GetActiveIntegrationObjects: () => [objA, objB, objC, objD, objE],
+        } as unknown as IntegrationEngineBase);
+    });
+
+    it('reports what every object in the DAG actually gets sampled', async () => {
+        const report: Array<{ object: string; fields: string[]; httpCalls: number }> = [];
+        for (const name of ['A', 'B', 'C', 'D', 'E']) {
+            const c = new TestConnector();
+            const fields = await c.DiscoverFieldsViaFetch(CI, name, {} as UserInfo, { MaxRecords: TARGET });
+            report.push({ object: name, fields: fields.map(x => x.Name).sort(), httpCalls: c.urls.length });
+        }
+        // eslint-disable-next-line no-console
+        console.log('\n  object | sampled fields          | http calls\n' +
+            report.map(r => `  ${r.object.padEnd(6)} | ${(r.fields.join(',') || '(NONE)').padEnd(23)} | ${r.httpCalls}`).join('\n') + '\n');
+
+        const byName = Object.fromEntries(report.map(r => [r.object, r]));
+
+        // A, B, C — flat endpoints, sampled directly.
+        for (const n of ['A', 'B', 'C']) {
+            expect(byName[n].fields.length).toBeGreaterThan(0);
+            expect(byName[n].httpCalls).toBe(1);
+        }
+
+        // D — TWO template vars. Deliberate deferral: resolving only the first var would leave a
+        // literal `{bId}` in the URL and fire malformed requests at the vendor. D is not sampled at
+        // all and makes ZERO http calls.
+        expect(byName['D'].fields).toEqual([]);
+        expect(byName['D'].httpCalls).toBe(0);
+
+        // E — ONE template var, so E itself is sampleable in principle. But its parent is D, and the
+        // recursion cannot walk D, so E yields nothing either.
+        //
+        // THE DEFERRAL CASCADES. It is not "multi-parent objects go unsampled" — it is "multi-parent
+        // objects AND EVERYTHING BENEATH THEM go unsampled", however deep. Every such object falls
+        // back to its declared metadata alone: no custom columns discovered, no observed widths (so
+        // declared widths stand and long values are dropped at sync time), and an object with no
+        // DECLARED primary key is dropped entirely, because sampling was its only route to one.
+        expect(byName['E'].fields).toEqual([]);
+        expect(byName['E'].httpCalls).toBe(0);
+    });
+
+    it('the dead branch costs nothing at runtime — it fails closed, not expensively', async () => {
+        const c = new TestConnector();
+        await c.DiscoverFieldsViaFetch(CI, 'E', {} as UserInfo, { MaxRecords: TARGET });
+        const path = (re: RegExp) => c.urls.filter(u => re.test(u.replace('https://api.test', ''))).length;
+        // eslint-disable-next-line no-console
+        console.log(`\n  E's chain: /a=${path(/^\/a$/)} /b=${path(/^\/b$/)} ` +
+            `/a/*/b/*/d=${path(/^\/a\/[^/]+\/b\/[^/]+\/d$/)} /d/*/e=${path(/^\/d\/[^/]+\/e$/)}\n`);
+        // Nothing above E is touched either: the walk stops at the multi-var boundary rather than
+        // pulling ancestors it can never use. Wrong result, but not a wasteful one.
+        expect(path(/^\/d\/[^/]+\/e$/)).toBe(0);
+        expect(path(/^\/a$/)).toBe(0);
+        expect(path(/^\/b$/)).toBe(0);
+    });
+});

--- a/packages/Integration/engine/src/__tests__/DiscoveryBudgetPrecedence.test.ts
+++ b/packages/Integration/engine/src/__tests__/DiscoveryBudgetPrecedence.test.ts
@@ -27,7 +27,6 @@ import type {
     FetchBatchResult,
 } from '../BaseIntegrationConnector.js';
 import type { StreamDiscoveryOptions, PkPickOptions } from '../StreamingDiscovery.js';
-import { PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE } from '../StreamingDiscovery.js';
 
 /** The three budgets as `DiscoverFieldsViaFetch` resolved them for a given call. */
 type ResolvedBudgets = { BatchSize: number; MaxRecords: number; TimeBudgetMs: number | undefined };
@@ -85,17 +84,13 @@ const NO_USER = {} as unknown as UserInfo;   // passed straight through to the o
 /**
  * Engine defaults, asserted here so a silent change to one shows up as a test failure.
  *
- * MaxRecords is the per-table sample TARGET and is deliberately the classifier's significance floor,
- * not a round number: 50 rows fully answers two of the three questions sampling asks (significant
- * primary key, custom-discoverable columns) and only the third (largest observed string) benefits
- * from more — and that one has its own safety nets. Sourced from the constant rather than restated,
- * so the two cannot drift apart.
+ * MaxRecords is a STATISTICS budget, deliberately far above the primary-key significance FLOOR
+ * (PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE). It was briefly lowered to that floor, which cost width
+ * fidelity on every connector whose catalog declares no lengths — for those the sample is the only
+ * width source, and a column sized too narrow SKIPS records at sync time. A floor is a minimum, not
+ * a target to sample down to; this assertion exists to stop that conflation recurring.
  */
-const DEFAULTS = {
-    BatchSize: 500,
-    MaxRecords: PK_STAT_MIN_ROWS_FOR_SIGNIFICANCE,
-    TimeBudgetMs: 5 * 60 * 1000,
-} as const;
+const DEFAULTS = { BatchSize: 500, MaxRecords: 500, TimeBudgetMs: 5 * 60 * 1000 } as const;
 
 const ENV_KEYS = [
     'MJ_INTEGRATION_DISCOVERY_TIME_BUDGET_MS',

--- a/packages/Integration/engine/src/__tests__/ProvableKeyRejectsDuplicates.test.ts
+++ b/packages/Integration/engine/src/__tests__/ProvableKeyRejectsDuplicates.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { discoverFromStream, pickKeyFromStats } from '../StreamingDiscovery.js';
+
+/**
+ * An observed duplicate disproves keyness. Full stop.
+ *
+ * `subsetKeyness` decided keyness purely by Chao1 domain saturation (D̂ > n) and never checked that
+ * the sampled tuples were actually distinct. Chao1 estimates how LARGE the value domain is — evidence
+ * about future collisions — which says nothing about collisions already sitting in the sample. Its
+ * bias-corrected branch (no doubletons) also grows quadratically in the singleton count, so a column
+ * with nine copies of one value among 100 rows scored D̂ ≈ 4187 and was reported as a
+ * "Provable 1-column key".
+ *
+ * Consequence: two source records sharing that value collapse onto one MJ row. It does not error —
+ * it silently loses a record, the mirror image of the duplicate-record failure.
+ */
+const rows = (n: number, fn: (i: number) => Record<string, unknown>) =>
+    Array.from({ length: n }, (_v, i) => fn(i));
+
+const verdict = async (data: Array<Record<string, unknown>>) => {
+    const scan = await discoverFromStream(data);
+    return pickKeyFromStats(scan.Columns, scan.RowSamples, {});
+};
+
+describe('pickKeyFromStats — a duplicate in the sample is disproof', () => {
+    it('refuses a near-unique column: 92 distinct of 100 rows is NOT a key', async () => {
+        // The exact shape that scored D̂ ≈ 4187 and was declared provable.
+        const v = await verdict(rows(100, i => ({ customer_id: `c${i < 92 ? i : 0}` })));
+        expect(v.Fields).toBeNull();
+    });
+
+    it('refuses even ONE duplicate among 500 rows', async () => {
+        // No ratio threshold to hide behind: a single repeat is still a repeat.
+        const v = await verdict(rows(500, i => ({ id: `k${i === 499 ? 0 : i}` })));
+        expect(v.Fields).toBeNull();
+    });
+
+    it('still accepts a genuinely unique column', async () => {
+        const v = await verdict(rows(100, i => ({ id: `k${i}` })));
+        expect(v.Fields).toEqual(['id']);
+    });
+
+    it('still accepts a genuine COMPOSITE key whose parts are individually duplicated', async () => {
+        // 10 tenants x 10 rows: neither column alone is unique, the pair is. This is the case the
+        // duplicate check must not break.
+        const v = await verdict(rows(100, i => ({ tenant_id: `t${i % 10}`, row_id: `r${Math.floor(i / 10)}` })));
+        expect(v.Fields).not.toBeNull();
+        expect([...(v.Fields ?? [])].sort()).toEqual(['row_id', 'tenant_id']);
+    });
+
+    it('refuses a composite whose combined tuple still repeats', async () => {
+        // Every pair appears twice — a saturated domain wearing a composite disguise.
+        const v = await verdict(rows(100, i => ({ a: `a${Math.floor(i / 2) % 10}`, b: `b${Math.floor(i / 20)}` })));
+        expect(v.Fields).toBeNull();
+    });
+
+    it('a low-cardinality category is refused, as it always was', async () => {
+        const v = await verdict(rows(100, i => ({ status_id: `s${i % 3}` })));
+        expect(v.Fields).toBeNull();
+    });
+});

--- a/packages/Integration/engine/src/__tests__/ScanCompletenessHonesty.test.ts
+++ b/packages/Integration/engine/src/__tests__/ScanCompletenessHonesty.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { RegisterClass } from '@memberjunction/global';
+import { discoverFromStream, pickPrimaryKeyFromStats } from '../StreamingDiscovery.js';
+import { BaseIntegrationConnector } from '../BaseIntegrationConnector.js';
+import type {
+    ConnectionTestResult, ExternalObjectSchema, ExternalFieldSchema, FetchContext, FetchBatchResult,
+} from '../BaseIntegrationConnector.js';
+import type { StreamDiscoveryOptions, PkPickOptions } from '../StreamingDiscovery.js';
+
+/** Exposes the protected bridge so the CONNECTOR's own ScanComplete decision is what gets tested. */
+@RegisterClass(BaseIntegrationConnector, 'ScanCompletenessTestConnector')
+class ScanCompletenessTestConnector extends BaseIntegrationConnector {
+    public async TestConnection(): Promise<ConnectionTestResult> { return { Success: true, Message: 'OK' }; }
+    public async DiscoverObjects(): Promise<ExternalObjectSchema[]> { return []; }
+    public async DiscoverFields(): Promise<ExternalFieldSchema[]> { return []; }
+    public async FetchChanges(_ctx: FetchContext): Promise<FetchBatchResult> { return { Records: [], HasMore: false }; }
+    public Run(
+        records: Iterable<Record<string, unknown>>,
+        opts?: { Discovery?: StreamDiscoveryOptions; Pk?: PkPickOptions; ReadOnly?: boolean },
+    ): Promise<ExternalFieldSchema[]> { return this.DiscoverFieldsViaStream(records, opts); }
+}
+
+/**
+ * A capped scan saw a PREFIX, and must say so.
+ *
+ * The record cap is enforced by the GENERATOR feeding the scan — it simply returns — so the stream
+ * ends indistinguishably from a table that ran out of rows, and the scan reported `'exhausted'`.
+ * That mattered because `ScanComplete` unlocks the LENIENT near-unique (0.9) soft-key rule instead
+ * of the strict 1.0 reserved for partial corpora. A 50-row prefix of a ten-million-row table was
+ * therefore judged complete, and over 50 rows an ordinary foreign key is very likely to look ≥90%
+ * distinct. A wrong soft key does not error — it silently merges two source records onto one row.
+ */
+const rows = (n: number, fn: (i: number) => Record<string, unknown>) =>
+    Array.from({ length: n }, (_v, i) => fn(i));
+
+describe('discoverFromStream — StoppedReason distinguishes a prefix from an exhausted source', () => {
+    it('reports record-cap when the producer stopped it at the target', async () => {
+        const out = await discoverFromStream(rows(60, i => ({ id: `r${i}` })), { RecordCap: 50 });
+        expect(out.StoppedReason).toBe('record-cap');
+        expect(out.RowsScanned).toBe(50);
+    });
+
+    it('reports exhausted when the source genuinely ran out first', async () => {
+        const out = await discoverFromStream(rows(20, i => ({ id: `r${i}` })), { RecordCap: 50 });
+        expect(out.StoppedReason).toBe('exhausted');
+        expect(out.RowsScanned).toBe(20);
+    });
+
+    it('reports exhausted when no cap is in play at all', async () => {
+        const out = await discoverFromStream(rows(20, i => ({ id: `r${i}` })));
+        expect(out.StoppedReason).toBe('exhausted');
+    });
+
+    it('a source that ends exactly AT the cap is a prefix as far as we know', async () => {
+        // We cannot tell "exactly 50 rows exist" from "row 51 was never offered", and the safe
+        // reading is the suspicious one.
+        const out = await discoverFromStream(rows(50, i => ({ id: `r${i}` })), { RecordCap: 50 });
+        expect(out.StoppedReason).toBe('record-cap');
+    });
+});
+
+describe('the soft-key rule a capped scan is now held to', () => {
+    // 100 rows where `customer_id` is 92% distinct — the shape of an ordinary foreign key over a
+    // short prefix. Convention-named, non-null on every row, so it clears every gate except the
+    // uniqueness ratio.
+    const nearUnique = () => {
+        const cols = rows(100, i => ({ customer_id: `c${i < 92 ? i : 0}` }));
+        return cols;
+    };
+
+    it('an EXHAUSTED scan may take the lenient near-unique soft key', async () => {
+        const scan = await discoverFromStream(nearUnique());
+        expect(scan.StoppedReason).toBe('exhausted');
+        const soft = pickPrimaryKeyFromStats(scan.Columns, { ScanComplete: true });
+        expect(soft.Field).toBe('customer_id');
+    });
+
+    it('a CAPPED scan of the same data must NOT — it only saw a prefix', async () => {
+        const scan = await discoverFromStream(nearUnique(), { RecordCap: 100 });
+        expect(scan.StoppedReason).toBe('record-cap');
+        // This is the decision the connector now makes: ScanComplete === 'exhausted', not
+        // "!== time-budget". Under the strict 1.0 rule a 92%-distinct column is not a key.
+        const soft = pickPrimaryKeyFromStats(scan.Columns, { ScanComplete: scan.StoppedReason === 'exhausted' });
+        expect(soft.Field).toBeNull();
+    });
+
+    it('a genuinely unique column still wins on a capped scan — strictness is not refusal', async () => {
+        const scan = await discoverFromStream(rows(100, i => ({ customer_id: `c${i}` })), { RecordCap: 100 });
+        const soft = pickPrimaryKeyFromStats(scan.Columns, { ScanComplete: scan.StoppedReason === 'exhausted' });
+        expect(soft.Field).toBe('customer_id');
+    });
+});
+
+describe('the CONNECTOR\'s own decision, not a re-implementation of it', () => {
+    // The tests above compute ScanComplete themselves, so they cannot catch the connector passing
+    // the wrong thing — which is exactly the defect being fixed. These drive
+    // DiscoverFieldsViaStream and read the verdict off the fields it returns.
+    const nearUnique = () => Array.from({ length: 100 }, (_v, i) => ({ customer_id: `c${i < 92 ? i : 0}` }));
+    const pkOf = (fields: ExternalFieldSchema[]) => fields.filter(f => f.IsPrimaryKey).map(f => f.Name);
+
+    it('does NOT nominate a near-unique column as the key when the scan was capped', async () => {
+        const c = new ScanCompletenessTestConnector();
+        const fields = await c.Run(nearUnique(), { Discovery: { RecordCap: 100 }, ReadOnly: true });
+        expect(pkOf(fields)).toEqual([]);
+    });
+
+    it('DOES nominate it when the source genuinely ran out first', async () => {
+        const c = new ScanCompletenessTestConnector();
+        const fields = await c.Run(nearUnique(), { Discovery: { RecordCap: 500 }, ReadOnly: true });
+        expect(pkOf(fields)).toEqual(['customer_id']);
+    });
+
+    it('a provably unique column is still nominated on a capped scan', async () => {
+        const c = new ScanCompletenessTestConnector();
+        const rows = Array.from({ length: 100 }, (_v, i) => ({ customer_id: `c${i}` }));
+        const fields = await c.Run(rows, { Discovery: { RecordCap: 100 }, ReadOnly: true });
+        expect(pkOf(fields)).toEqual(['customer_id']);
+    });
+});


### PR DESCRIPTION
Three defects that together let discovery trust a sample it shouldn't. The first is the serious one.

## 1. A column with duplicates was declared a *provable* primary key

`subsetKeyness` decided keyness purely by Chao1 domain saturation:

```ts
const Dhat = f2 > 0 ? d + (f1*f1)/(2*f2) : d + (f1*(f1-1))/2;
return { Dhat, isKey: n >= minRows && Dhat > n };
```

It never checked the sampled tuples were distinct. Chao1 estimates how large the value **domain** is — evidence about *future* collisions — which says nothing about collisions already sitting in the sample. And its bias-corrected branch (no doubletons) grows **quadratically** in the singleton count.

Measured, on 100 rows where nine share one value:

```
stats    = 92 distinct of 100 rows
verdict  = "Provable 1-column key {customer_id} — Chao1 domain D̂≈4187 ≫ n=100"
```

Nine duplicates, reported as provable. That does not error — the sync **silently merges two source records onto one row**. Data loss, and the mirror image of the duplicate-record failure.

Keyness now requires `d === n` first; Chao1 is kept for what it is actually good at — separating an identifier from a small category that merely hasn't collided yet in `n` rows. Genuine composite keys whose individual columns repeat are unaffected, and pinned by a test.

## 2. A record-capped scan reported itself as an exhausted source

The cap is enforced by the **generator** feeding the scan — it simply `return`s — so the stream ends indistinguishably from a table that ran out of rows, and the scan reported `'exhausted'`.

That matters because `ScanComplete` unlocks the lenient near-unique (0.9) soft-key rule instead of the strict 1.0 reserved for partial corpora. So a 50-row prefix of a ten-million-row table was judged complete, and over a short prefix an ordinary foreign key like `customer_id` is very likely to look ≥90% distinct.

`StoppedReason` gains `'record-cap'`, the producer's target is passed to the scan so it can recognise its own truncation, and completeness now means `=== 'exhausted'` rather than `!== 'time-budget'`.

## 3. The sample target returns to 500

It was lowered to the primary-key significance floor on the reasoning that 50 rows answer the other two questions well enough. Both halves of that were wrong:

- **Width.** Several connectors declare no widths at all — YourMembership's own code states `MaxLength: null` and unions in the sampler's result, so **the sample is the only source of width**. Ten times fewer observed values means narrower columns, and a value too wide for its column is *skipped* at sync time, not truncated. Records silently lost.
- **Custom columns.** A field populated on ~1% of records is near-certain in 500 rows and a coin flip in 50.

A floor is a minimum, not a target to sample down to. And the speed argument doesn't hold either: streaming rows from one object is one paged read — what costs requests is *descending into parents*, which is bounded separately by the child's own demand.

## Tests

`ProvableKeyRejectsDuplicates` (6) — the exact 92-of-100 shape, a single duplicate among 500, a genuine unique column still accepted, a genuine composite whose parts individually repeat still accepted, a composite whose combined tuple repeats refused, a low-cardinality category refused.

`ScanCompletenessHonesty` (10) — `record-cap` vs `exhausted` vs no cap, a source ending exactly at the cap treated as a prefix, and three that drive the **connector's own decision** rather than recomputing it (an earlier draft recomputed `ScanComplete` in the test and consequently survived the mutation).

All three fixes **mutation-verified**. Engine suite: **77 files / 998 tests** green.