### PR TITLE
fix(integration): the absence-proof prefetch must be unbounded

### DIFF
--- a/.changeset/prefetch-unbounded.md
+++ b/.changeset/prefetch-unbounded.md
@@ -1,0 +1,13 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+The absence-proof prefetch now passes `IgnoreMaxRows`, so a row-limit default can never truncate it.
+
+A plain `RunView` is not unbounded — it falls back to the entity's `UserViewMaxRows`, which defaults
+to 1000. The prefetch's result is what `CoversWholeBatch` absence proofs are judged against, and
+coverage is computed from the request side, never reconciled with the response length: a silently
+truncated response would mark every existing row beyond the cap "provably absent" and re-INSERT each
+as a duplicate on every sync. Today the apply batch (500) happens to sit under the default cap, so
+nothing fires — a 2× margin defended by nothing. This engine already documents the identical trap on
+its push side and fixes it the same way.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -5352,6 +5352,15 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 Fields: [...pkNames, CONTENT_HASH_COLUMN],
                 ExtraFilter: extraFilter,
                 ResultType: 'simple',
+                // A plain RunView is NOT unbounded — it falls back to the entity's UserViewMaxRows
+                // (default 1000). This result is what `CoversWholeBatch` absence proofs are judged
+                // against, and coverage is computed from the REQUEST side, never reconciled with
+                // res.Results.length: a silently truncated response would mark every existing row
+                // beyond the cap "provably absent" and re-INSERT it as a duplicate on every sync.
+                // Today the apply batch (500) sits under the default cap, so nothing fires — but a
+                // 2x margin defended by nothing is not a guard. Same reasoning as baseEngine's own
+                // IgnoreMaxRows use, and this file documents the identical trap on the push side.
+                IgnoreMaxRows: true,
             }, contextUser);
             if (!res.Success) return undefined;
             const Hashes = new Map<string, string>();

--- a/packages/Integration/engine/src/__tests__/PrefetchProvesAbsence.test.ts
+++ b/packages/Integration/engine/src/__tests__/PrefetchProvesAbsence.test.ts
@@ -4,13 +4,14 @@ import { join } from 'node:path';
 
 // Scripted by each test before it drives the prefetch.
 const runViewResult = vi.hoisted(() => ({ current: { Success: true, Results: [] as Array<Record<string, unknown>> } }));
+const lastRunViewParams = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
 
 vi.mock('@memberjunction/core', async () => {
     const actual = await vi.importActual<typeof import('@memberjunction/core')>('@memberjunction/core');
     return {
         ...actual,
         RunView: class MockRunView {
-            async RunView() { return runViewResult.current; }
+            async RunView(params: Record<string, unknown>) { lastRunViewParams.current = params; return runViewResult.current; }
         },
     };
 });
@@ -164,5 +165,18 @@ describe('the key SHAPES agree end to end (the regression that shipped)', () => 
         expect(host.isProvablyAbsent('k', undefined)).toBe(false);
         expect(host.isProvablyAbsent('k', { Hashes: new Map(), Present: new Set(), CoversWholeBatch: false })).toBe(false);
         expect(host.isProvablyAbsent(null, { Hashes: new Map(), Present: new Set(), CoversWholeBatch: true })).toBe(false);
+    });
+});
+
+describe('the prefetch is unbounded — its result is what absence proofs are judged against', () => {
+    it('passes IgnoreMaxRows so a row-limit default can never truncate the proof', async () => {
+        // A plain RunView falls back to the entity's UserViewMaxRows (default 1000). CoversWholeBatch
+        // is computed from the REQUEST side and never reconciled against res.Results.length, so a
+        // silently truncated response marks every existing row beyond the cap "provably absent" —
+        // and each one is re-INSERTed as a duplicate on every sync. The batch size happening to sit
+        // under the default cap is a margin, not a guard.
+        const host = makeHost([]);
+        await host.PrefetchContentHashes([created('x')], {});
+        expect(lastRunViewParams.current?.['IgnoreMaxRows']).toBe(true);
     });
 });


### PR DESCRIPTION
One line plus its pin.

A plain `RunView` is not unbounded — it falls back to the entity's `UserViewMaxRows` (default 1000). The prefetch's result is what `CoversWholeBatch` **absence proofs** are judged against, and coverage is computed from the request side, never reconciled with `res.Results.length` — so a silently truncated response marks every existing row beyond the cap *provably absent*, and each one is re-INSERTed as a **duplicate on every sync**.

Today `APPLY_BATCH_SIZE` (500) sits under the default cap, so nothing fires. That is a 2× margin defended by nothing: lower `UserViewMaxRows` on one integration entity, or raise the batch size, and it starts silently at full batch throughput. This engine already documents the identical trap on its push side (and `baseEngine` passes `IgnoreMaxRows` for exactly this reason).

Pinned by a test that captures the RunView params. Engine suite: **981 tests** green.