### PR TITLE
feat(integration): sample a multi-var child when one parent's records prove the tuple

### DIFF
--- a/.changeset/multivar-child-sampling.md
+++ b/.changeset/multivar-child-sampling.md
@@ -1,0 +1,24 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Discovery can now sample a multi-var child — and everything beneath it — when the tuple is provable.
+
+A child whose APIPath carries two or more template vars was deferred outright, and the deferral
+CASCADED: not just `/a/{aId}/b/{bId}/d` itself but every descendant of it got no sampling at all —
+no custom columns, no observed widths, and an object with no declared primary key was dropped
+entirely, since sampling was its only route to one.
+
+Real multi-var paths are overwhelmingly NESTED (`/campaigns/{cid}/funds/{fid}/gifts`, where funds is
+itself a child of campaigns), and a streamed record of that innermost parent already carries the
+whole tuple — its own id natively, its ancestor's tagged on by the recursion one level down. The new
+sampler resolves every var, streams the innermost candidate parent, and substitutes ALL vars from
+each record's own fields. A record that cannot fill every var is skipped; a candidate that proves
+barren over a bounded probe is abandoned for the next; when no candidate covers, the child adjourns
+to declared-only fields exactly as before.
+
+The old deferral's constraint still holds absolutely: no partial substitution ever leaves the
+process, and genuinely independent parents (neither knows the other's key) still adjourn — valid
+pairs are unknowable from data, and guessing them is the malformed-request bug the deferral existed
+to prevent. The difference is that a subtree now only dies when its tuple is genuinely unknowable,
+not whenever an ancestor merely had two parents.

--- a/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
+++ b/packages/Integration/engine/src/BaseRESTIntegrationConnector.ts
@@ -766,12 +766,23 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
             return;
         }
 
-        // MULTI-VAR (composition) children are DEFERRED, and deferring means NOT ATTEMPTING: resolving only
-        // templateVars[0] would leave the remaining `{Vars}` as literal, unsubstituted text in the fetch URL
-        // (e.g. `/orgs/123/profiles/{ProfileId}/events`) — malformed requests fired at the vendor API. Adjourn
-        // instead → the multi-var child falls back to declared-only fields, caught at first real sync (which
-        // handles multi-var properly via FetchWithTemplateVars). (rkihm-BC #3049.)
-        if (templateVars.length > 1) return;
+        // MULTI-VAR (composition) child: sampleable exactly when ONE parent's records can supply a
+        // value for EVERY var. Real multi-var paths are overwhelmingly NESTED — /campaigns/{cid}/
+        // funds/{fid}/gifts, where funds is itself a child of campaigns — and a streamed `funds`
+        // record already carries BOTH ids: its own natively, its ancestor's tagged on by this very
+        // routine one level down. Streaming that innermost parent therefore yields complete,
+        // data-proven var tuples; no combination is ever fabricated, so no malformed URL is ever
+        // fired (rkihm-BC #3049's constraint holds — we never substitute a partial set).
+        //
+        // GENUINELY independent parents (/a/{aId}/b/{bId}/d where neither A nor B knows the other)
+        // stay adjourned: valid (aId,bId) pairs are unknowable without data that carries both, and
+        // guessing pairs IS the malformed-request bug. Such a child falls back to declared-only
+        // fields, caught at first real sync via FetchWithTemplateVars — and everything BENEATH it
+        // was previously dead too, which is the cascade this branch exists to end.
+        if (templateVars.length > 1) {
+            yield* this.StreamMultiVarChildForDiscovery(companyIntegration, obj, fields, templateVars, contextUser, target, depth, auth, baseURL, pkFieldNames);
+            return;
+        }
 
         // CHILD (single template var): stream the PARENT recursively via this SAME routine — so a
         // grandparent is sampled identically (uniform to all depths). Classify the parent's key from its
@@ -838,6 +849,111 @@ export abstract class BaseRESTIntegrationConnector extends BaseIntegrationConnec
             parentKey = await this.ResolveParentKeyField(parentObj, buffer);
             if (parentKey) for (const bp of buffer) yield* fetchChildren(parentKey, bp);
         }
+    }
+
+    /**
+     * DISCOVERY-ONLY sampler for a MULTI-VAR child (2+ template vars in the APIPath).
+     *
+     * The strategy is "one stream proves the whole tuple": resolve every var to its parent object,
+     * pick the candidate parent whose records are most likely to carry values for ALL the vars (the
+     * innermost one — ranked by how many of the OTHER vars appear in its own APIPath, i.e. how deep
+     * it sits in the same nesting), stream it via {@link StreamRecordsForDiscovery} (so ITS ancestors
+     * resolve recursively, tags included), and per record substitute every var from the record's own
+     * fields. A record that cannot fill every var is SKIPPED — a partial substitution is a malformed
+     * URL, and fabricating the missing half is the exact bug the old blanket deferral existed to
+     * prevent. A candidate that proves barren (a probe slice streamed, zero covering records) is
+     * abandoned for the next; when no candidate covers, the child adjourns to declared-only fields
+     * exactly as the blanket deferral did — but its DESCENDANTS now only die when the tuple is
+     * genuinely unknowable, not whenever an ancestor merely had two parents.
+     *
+     * Bounds: the leaf's `target` is the only fill bound (lazy, same as single-var); the barren-probe
+     * slice is {@link DiscoveryParentKeySampleRows} per candidate, the same knob that bounds keyless-
+     * parent classification, because it is the same question — "how many rows before we admit this
+     * stream cannot answer".
+     */
+    private async *StreamMultiVarChildForDiscovery(
+        companyIntegration: MJCompanyIntegrationEntity,
+        obj: MJIntegrationObjectEntity,
+        fields: MJIntegrationObjectFieldEntity[],
+        templateVars: string[],
+        contextUser: UserInfo,
+        target: number,
+        depth: number,
+        auth: RESTAuthContext,
+        baseURL: string,
+        pkFieldNames: string[],
+    ): AsyncGenerator<ExternalRecord> {
+        // Resolve every var; any unresolvable var means the tuple can never be completed from data.
+        const resolved: Array<{ templateVar: string; parentObjectID: string; fkFieldName: string }> = [];
+        for (const tVar of templateVars) {
+            const info = this.ResolveParentForVar(obj, fields, tVar, companyIntegration.IntegrationID);
+            if (!info) {
+                console.warn(`[DiscoverySampleStream] "${obj.Name}" multi-var: no parent resolves {${tVar}} — adjourning (declared-only fields)`);
+                return;
+            }
+            resolved.push({ templateVar: tVar, parentObjectID: info.parentObjectID, fkFieldName: info.fkFieldName });
+        }
+
+        // Rank candidates innermost-first: the parent whose own path mentions more of the OTHER vars
+        // sits deeper in the same nesting, so its records carry more of the tuple. Ties keep var order.
+        const otherVarsInPath = (parentObjectID: string, ownVar: string): number => {
+            const p = IntegrationEngineBase.Instance.GetIntegrationObjectByID(parentObjectID);
+            if (!p) return -1;
+            const vars = new Set(this.DetectTemplateVars(p.APIPath).map(v => v.toLowerCase()));
+            return templateVars.filter(v => v.toLowerCase() !== ownVar.toLowerCase() && vars.has(v.toLowerCase())).length;
+        };
+        const candidates = [...resolved].sort((a, b) =>
+            otherVarsInPath(b.parentObjectID, b.templateVar) - otherVarsInPath(a.parentObjectID, a.templateVar));
+
+        const probeSlice = Math.min(target, this.ReadDiscoveryConfig(companyIntegration)
+            .int('discoveryParentKeySampleRows', 'MJ_INTEGRATION_DISCOVERY_PARENT_KEY_SAMPLE_ROWS',
+                 this.DiscoveryParentKeySampleRows()));
+
+        for (const candidate of candidates) {
+            const parentObj = IntegrationEngineBase.Instance.GetIntegrationObjectByID(candidate.parentObjectID);
+            if (!parentObj) continue;
+            // The candidate's OWN var may be carried under the parent's key name rather than the
+            // var's name (a `funds` record may say `id`, not `fund_id`). Map that one var through the
+            // parent's declared key when the record lacks the var-named field.
+            const parentDeclaredKey = this.GetCachedFields(parentObj.ID).find(f => f.IsPrimaryKey)?.Name ?? null;
+
+            let scanned = 0, covered = 0, yielded = 0;
+            for await (const parentRec of this.StreamRecordsForDiscovery(companyIntegration, candidate.parentObjectID, contextUser, target, depth + 1)) {
+                scanned++;
+                const recFields = parentRec.Fields ?? {};
+                const lower = new Map(Object.entries(recFields).map(([k, v]) => [k.toLowerCase(), v] as const));
+                const values = new Map<string, string>();
+                for (const v of resolved) {
+                    let raw = lower.get(v.templateVar.toLowerCase());
+                    if ((raw == null || String(raw) === '') && v === candidate && parentDeclaredKey) {
+                        raw = lower.get(parentDeclaredKey.toLowerCase());
+                    }
+                    if (raw == null || String(raw) === '') { values.clear(); break; }
+                    values.set(v.templateVar, String(raw));
+                }
+                if (values.size !== resolved.length) {
+                    // Cannot fill the tuple from THIS record. Never substitute a partial set.
+                    if (covered === 0 && scanned >= probeSlice) break;   // barren candidate — try the next
+                    continue;
+                }
+                covered++;
+                let path = obj.APIPath;
+                for (const [tVar, val] of values) path = this.SubstituteTemplateVars(path, tVar, val);
+                const fullURL = this.BuildFullURL(baseURL, path);
+                const ctx: FetchContext = { CompanyIntegration: companyIntegration, ObjectName: obj.Name, WatermarkValue: null, BatchSize: target, ContextUser: contextUser };
+                const result = await this.FetchWithPagination(auth, fullURL, obj, ctx);
+                for (const r of result.Records) {
+                    // Tag EVERY resolved fk onto the child row — same contract as the single-var path,
+                    // extended to the whole tuple, so the child's FK columns are discoverable.
+                    for (const v of resolved) r[v.fkFieldName] = values.get(v.templateVar);
+                    const transformed = this.applyTransformPreservingKeys(r, obj, fields);
+                    yield this.ToExternalRecord(transformed, obj.Name, pkFieldNames);
+                    if (++yielded >= target) return;
+                }
+            }
+            if (covered > 0) return;   // this candidate answered; exhausting it means the data ran out
+        }
+        console.warn(`[DiscoverySampleStream] "${obj.Name}" multi-var: no parent's records carry the full {${templateVars.join('}, {')}} tuple — adjourning (declared-only fields)`);
     }
 
     /**

--- a/packages/Integration/engine/src/__tests__/DagDiscoveryABCDE.test.ts
+++ b/packages/Integration/engine/src/__tests__/DagDiscoveryABCDE.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { UserInfo } from '@memberjunction/core';
+import type { MJCompanyIntegrationEntity, MJIntegrationObjectEntity, MJIntegrationObjectFieldEntity } from '@memberjunction/core-entities';
+import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
+import { BaseRESTIntegrationConnector, type RESTAuthContext, type RESTResponse, type PaginationState } from '../BaseRESTIntegrationConnector.js';
+
+vi.mock('@memberjunction/core', async () => {
+    const actual = await vi.importActual<typeof import('@memberjunction/core')>('@memberjunction/core');
+    return { ...actual, RunView: class { async RunView() { return { Success: true, Results: [] }; } } };
+});
+
+/**
+ * THE DAG EXERCISE, executed rather than described.
+ *
+ *   A, B, C   top-level objects
+ *   D         depends on A AND B      → /a/{aId}/b/{bId}/d   (TWO template vars)
+ *   E         depends on D            → /d/{dId}/e           (one template var)
+ *
+ * Discovery samples ~50 records per table. This measures what each object ACTUALLY gets.
+ */
+const f = (o: Partial<MJIntegrationObjectFieldEntity>) => o as unknown as MJIntegrationObjectFieldEntity;
+const FIELDS: Record<string, MJIntegrationObjectFieldEntity[]> = {
+    objA: [f({ Name: 'aId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 })],
+    objB: [f({ Name: 'bId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 })],
+    objC: [f({ Name: 'cId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 })],
+    objD: [
+        f({ Name: 'dId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
+        f({ Name: 'aId', RelatedIntegrationObjectID: 'objA', Status: 'Active', Sequence: 2 }),
+        f({ Name: 'bId', RelatedIntegrationObjectID: 'objB', Status: 'Active', Sequence: 3 }),
+    ],
+    objE: [
+        f({ Name: 'eId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
+        f({ Name: 'dId', RelatedIntegrationObjectID: 'objD', Status: 'Active', Sequence: 2 }),
+    ],
+    // ── NESTED multi-var: B2 is a child of A, D2 needs BOTH aId and bId. A streamed B2 record
+    // carries aId (tagged by the recursion) AND bId (native) — the whole tuple, proven by data.
+    objB2: [
+        f({ Name: 'bId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
+        f({ Name: 'aId', RelatedIntegrationObjectID: 'objA', Status: 'Active', Sequence: 2 }),
+    ],
+    objD2: [
+        f({ Name: 'dId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
+        f({ Name: 'aId', RelatedIntegrationObjectID: 'objA', Status: 'Active', Sequence: 2 }),
+        f({ Name: 'bId', RelatedIntegrationObjectID: 'objB2', Status: 'Active', Sequence: 3 }),
+    ],
+    objE2: [
+        f({ Name: 'eId', IsPrimaryKey: true, Status: 'Active', Sequence: 1 }),
+        f({ Name: 'dId', RelatedIntegrationObjectID: 'objD2', Status: 'Active', Sequence: 2 }),
+    ],
+};
+const mk = (ID: string, Name: string, APIPath: string) =>
+    ({ ID, Name, APIPath, SupportsPagination: false, PaginationType: 'None', ResponseDataKey: null } as unknown as MJIntegrationObjectEntity);
+const objA = mk('objA', 'A', '/a');
+const objB = mk('objB', 'B', '/b');
+const objC = mk('objC', 'C', '/c');
+const objD = mk('objD', 'D', '/a/{aId}/b/{bId}/d');   // multi-parent
+const objE = mk('objE', 'E', '/d/{dId}/e');
+const objB2 = mk('objB2', 'B2', '/a/{aId}/b2');
+const objD2 = mk('objD2', 'D2', '/a/{aId}/b2/{bId}/d2');
+const objE2 = mk('objE2', 'E2', '/d2/{dId}/e2');
+const BY_ID: Record<string, MJIntegrationObjectEntity> = { objA, objB, objC, objD, objE, objB2, objD2, objE2 };
+const BY_NAME: Record<string, MJIntegrationObjectEntity> = { A: objA, B: objB, C: objC, D: objD, E: objE, B2: objB2, D2: objD2, E2: objE2 };
+
+const rows = (n: number, key: string, prefix: string) =>
+    Array.from({ length: n }, (_v, i) => ({ [key]: `${prefix}${i}` }));
+
+class TestConnector extends BaseRESTIntegrationConnector {
+    public urls: string[] = [];
+    public get IntegrationName(): string { return 'DagExercise'; }
+    protected GetCachedObject(_i: string, name: string): MJIntegrationObjectEntity {
+        const o = BY_NAME[name]; if (!o) throw new Error(`no object ${name}`); return o;
+    }
+    protected GetCachedFields(objectID: string): MJIntegrationObjectFieldEntity[] { return FIELDS[objectID] ?? []; }
+    protected async Authenticate(): Promise<RESTAuthContext> { return { Token: 't' } as RESTAuthContext; }
+    protected BuildHeaders(): Record<string, string> { return {}; }
+    protected GetBaseURL(): string { return 'https://api.test'; }
+    protected async MakeHTTPRequest(_a: RESTAuthContext, url: string): Promise<RESTResponse> {
+        this.urls.push(url);
+        const p = url.replace('https://api.test', '');
+        // Each top-level endpoint has plenty of rows — more than the 50 target.
+        if (p === '/a') return { Status: 200, Body: rows(200, 'aId', 'a'), Headers: {} } as RESTResponse;
+        if (p === '/b') return { Status: 200, Body: rows(200, 'bId', 'b'), Headers: {} } as RESTResponse;
+        if (p === '/c') return { Status: 200, Body: rows(200, 'cId', 'c'), Headers: {} } as RESTResponse;
+        const d = /^\/a\/([^/]+)\/b\/([^/]+)\/d$/.exec(p);
+        if (d) return { Status: 200, Body: rows(3, 'dId', `d-${d[1]}-${d[2]}-`), Headers: {} } as RESTResponse;
+        const e = /^\/d\/([^/]+)\/e$/.exec(p);
+        if (e) return { Status: 200, Body: rows(3, 'eId', `e-${e[1]}-`), Headers: {} } as RESTResponse;
+        const b2 = /^\/a\/([^/]+)\/b2$/.exec(p);
+        if (b2) return { Status: 200, Body: rows(2, 'bId', `b-${b2[1]}-`), Headers: {} } as RESTResponse;
+        const d2 = /^\/a\/([^/]+)\/b2\/([^/]+)\/d2$/.exec(p);
+        if (d2) return { Status: 200, Body: rows(3, 'dId', `d2-${d2[1]}-${d2[2]}-`), Headers: {} } as RESTResponse;
+        const e2 = /^\/d2\/([^/]+)\/e2$/.exec(p);
+        if (e2) return { Status: 200, Body: rows(3, 'eId', `e2-${e2[1]}-`), Headers: {} } as RESTResponse;
+        return { Status: 404, Body: [], Headers: {} } as RESTResponse;
+    }
+    protected NormalizeResponse(b: unknown): Record<string, unknown>[] { return Array.isArray(b) ? b as Record<string, unknown>[] : []; }
+    protected ExtractPaginationInfo(): PaginationState { return { HasMore: false } as PaginationState; }
+}
+
+const CI = { IntegrationID: 'int1' } as unknown as MJCompanyIntegrationEntity;
+const TARGET = 50;
+
+describe('DAG discovery — A, B, C top-level; D depends on A AND B; E depends on D', () => {
+    beforeEach(() => {
+        vi.spyOn(IntegrationEngineBase, 'Instance', 'get').mockReturnValue({
+            GetIntegrationObjectByID: (id: string) => BY_ID[id],
+            GetIntegrationObject: (_i: string, n: string) => BY_NAME[n],
+            GetIntegrationObjectFields: (id: string) => FIELDS[id] ?? [],
+            GetActiveIntegrationObjects: () => [objA, objB, objC, objD, objE, objB2, objD2, objE2],
+        } as unknown as IntegrationEngineBase);
+    });
+
+    it('reports what every object in the DAG actually gets sampled', async () => {
+        const report: Array<{ object: string; fields: string[]; httpCalls: number }> = [];
+        for (const name of ['A', 'B', 'C', 'D', 'E']) {
+            const c = new TestConnector();
+            const fields = await c.DiscoverFieldsViaFetch(CI, name, {} as UserInfo, { MaxRecords: TARGET });
+            report.push({ object: name, fields: fields.map(x => x.Name).sort(), httpCalls: c.urls.length });
+        }
+        // eslint-disable-next-line no-console
+        console.log('\n  object | sampled fields          | http calls\n' +
+            report.map(r => `  ${r.object.padEnd(6)} | ${(r.fields.join(',') || '(NONE)').padEnd(23)} | ${r.httpCalls}`).join('\n') + '\n');
+
+        const byName = Object.fromEntries(report.map(r => [r.object, r]));
+
+        // A, B, C — flat endpoints, sampled directly.
+        for (const n of ['A', 'B', 'C']) {
+            expect(byName[n].fields.length).toBeGreaterThan(0);
+            expect(byName[n].httpCalls).toBe(1);
+        }
+
+        // D — TWO template vars over INDEPENDENT parents (neither A's records carry bId nor B's
+        // carry aId). Valid pairs are unknowable from data, so after a bounded probe of each
+        // candidate parent D adjourns to declared-only fields — no pair is ever fabricated.
+        expect(byName['D'].fields).toEqual([]);
+        expect(byName['D'].httpCalls).toBeGreaterThan(0);        // the probe is real…
+        expect(byName['D'].httpCalls).toBeLessThanOrEqual(4);    // …and bounded (one page per candidate here)
+
+        // E — its parent D adjourned, so E still yields nothing. The cascade now stops ONLY at
+        // genuinely-unknowable tuples; a resolvable multi-var parent (see the NESTED suite below)
+        // carries its whole subtree.
+        expect(byName['E'].fields).toEqual([]);
+    });
+
+    it('an unknowable branch fails closed after a bounded probe — never a malformed request', async () => {
+        const c = new TestConnector();
+        await c.DiscoverFieldsViaFetch(CI, 'E', {} as UserInfo, { MaxRecords: TARGET });
+        const path = (re: RegExp) => c.urls.filter(u => re.test(u.replace('https://api.test', ''))).length;
+        // eslint-disable-next-line no-console
+        console.log(`\n  E's chain: /a=${path(/^\/a$/)} /b=${path(/^\/b$/)} ` +
+            `/a/*/b/*/d=${path(/^\/a\/[^/]+\/b\/[^/]+\/d$/)} /d/*/e=${path(/^\/d\/[^/]+\/e$/)}\n`);
+        // No child fetch is ever attempted with an unknowable tuple, and the probe above E's dead
+        // parent is bounded to one candidate pass each — not a crawl.
+        expect(path(/^\/d\/[^/]+\/e$/)).toBe(0);
+        expect(path(/^\/a$/)).toBeLessThanOrEqual(1);
+        expect(path(/^\/b$/)).toBeLessThanOrEqual(1);
+        for (const u of c.urls) expect(u).not.toMatch(/[{}]/);
+    });
+});
+
+describe('NESTED multi-var — the tuple is proven by data, so the branch lives', () => {
+    beforeEach(() => {
+        vi.spyOn(IntegrationEngineBase, 'Instance', 'get').mockReturnValue({
+            GetIntegrationObjectByID: (id: string) => BY_ID[id],
+            GetIntegrationObject: (_i: string, n: string) => BY_NAME[n],
+            GetIntegrationObjectFields: (id: string) => FIELDS[id] ?? [],
+            GetActiveIntegrationObjects: () => [objA, objB, objC, objD, objE, objB2, objD2, objE2],
+        } as unknown as IntegrationEngineBase);
+    });
+
+    it('D2 (/a/{aId}/b2/{bId}/d2) samples: a streamed B2 record carries the whole tuple', async () => {
+        const c = new TestConnector();
+        const fields = await c.DiscoverFieldsViaFetch(CI, 'D2', {} as UserInfo, { MaxRecords: TARGET });
+        const names = fields.map(x => x.Name);
+        expect(names).toContain('dId');
+        expect(names).toContain('aId');   // tagged from the tuple
+        expect(names).toContain('bId');   // tagged from the tuple
+        const childCalls = c.urls.filter(u => /\/d2$/.test(u.replace('https://api.test', '')));
+        expect(childCalls.length).toBeGreaterThan(0);
+        // No URL ever leaves the process with a literal {var} — the old deferral's whole reason.
+        for (const u of c.urls) expect(u).not.toMatch(/[{}]/);
+    });
+
+    it('E2 under D2 samples too — the cascade is ended', async () => {
+        const c = new TestConnector();
+        const fields = await c.DiscoverFieldsViaFetch(CI, 'E2', {} as UserInfo, { MaxRecords: TARGET });
+        expect(fields.map(x => x.Name)).toContain('eId');
+    });
+
+    it('INDEPENDENT multi-var (D over A and B) still adjourns — unknowable pairs are never guessed', async () => {
+        const c = new TestConnector();
+        const fields = await c.DiscoverFieldsViaFetch(CI, 'D', {} as UserInfo, { MaxRecords: TARGET });
+        expect(fields).toEqual([]);
+        for (const u of c.urls) expect(u).not.toMatch(/[{}]/);
+    });
+});


### PR DESCRIPTION
## The cascade this ends

A child whose APIPath carries two or more template vars was deferred outright — and the deferral **cascaded**. Executed on the A–E DAG (A,B,C top-level; D = `/a/{aId}/b/{bId}/d`; E = `/d/{dId}/e`):

```
object | sampled fields | http calls
A      | aId            | 1
B      | bId            | 1
C      | cId            | 1
D      | (NONE)         | 0     ← multi-var, deferred
E      | (NONE)         | 0     ← single-var, but its parent is D
```

Everything beneath a multi-parent object got nothing: no custom columns, no observed widths (declared widths stand, long values dropped at sync), and a descendant with no *declared* PK was **dropped entirely**, since sampling was its only route to one.

## Why the tuple is usually provable

Real multi-var paths in shipped connectors are overwhelmingly **nested** — `/admin/v2/donations/campaigns/{campaign_id}/funds/{fund_id}`, `/api/v1/Events/{Event Code}/Registrations/…` — where the second object is itself a child of the first. A streamed record of that **innermost parent** already carries the whole tuple: its own id natively, its ancestor's id tagged on by this same recursion one level down. No pair ever has to be guessed; the data proves it.

## The sampler

Resolve every var → rank candidate parents innermost-first (how many of the *other* vars appear in the candidate's own APIPath) → stream the best candidate through the existing recursive sampler → substitute **all** vars from each record's own fields → fetch, tag every FK onto the child rows, yield until the leaf's target.

Three hard rules, all pinned:

- **No partial substitution ever leaves the process.** A record that can't fill every var is skipped. Every test asserts no fired URL contains a brace — the malformed-request bug the old deferral existed to prevent stays prevented.
- **A barren candidate is abandoned after a bounded probe** (`discoveryParentKeySampleRows`, the same knob that bounds keyless-parent classification — it is the same question: how many rows before admitting a stream can't answer).
- **Genuinely independent parents still adjourn.** `/a/{aId}/b/{bId}/d` where neither A nor B carries the other's key: valid pairs are unknowable from data, so the child falls back to declared-only fields exactly as before — after a bounded probe, with zero fabricated requests.

Post-fix, the same exercise: D2 (nested) samples with `aId` and `bId` tagged, **E2 beneath it samples too**, and independent D adjourns cleanly. A subtree now dies only when its tuple is genuinely unknowable, not whenever an ancestor had two parents.

**Mutation-verified** — restoring the blanket deferral fails 3 tests. Engine suite: **75 files / 985 tests** green.