### PR TITLE
feat(integration): report per-object progress during discovery sampling

### DIFF
--- a/.changeset/tame-pandas-attack.md
+++ b/.changeset/tame-pandas-attack.md
@@ -1,0 +1,30 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+Report per-object progress during discovery sampling
+
+Sampling is the expensive half of discovery — one read-path fetch per object — and it emitted
+nothing between the stage's start and its completion. A 23-object source looked exactly like a
+5-object one: a stage that had started, for an unbounded stretch, with no way to tell slow
+progress from a wedged run.
+
+`StageIntrospect` now emits a heartbeat per object it samples, carrying `processed` / `totalKnown`
+/ `skipped` and a message that stands on its own (`Sampling "Invoice" (3 of 23)`), so a consumer
+that renders only the text still reads correctly.
+
+Two details that make the number trustworthy rather than merely present:
+
+- The denominator is the union both sampling passes will walk — in-scope runtime objects plus
+  in-scope declared ones — computed before the first sample. Counting per-loop would show
+  "1 of 2" and then restart when the declared-only pass began, revising the total upward under a
+  user who is watching it.
+- Announcements are keyed by object name, so a connector that surfaces the same object twice
+  cannot walk the count past its own denominator ("3 of 2").
+
+An exhausted sampling budget still walks the count to the end and reports the passed-over objects
+as `skipped`; freezing the count where sampling stopped would leave a completing stage looking
+identical to a wedged one.
+
+No new event type — `heartbeat` and its counts already exist, and readers already derive the
+latest counts from the stream.

--- a/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
+++ b/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
@@ -518,9 +518,37 @@ export class IntegrationConnectorCreationPipeline {
             const sampledDeclared = new Set<string>();
             let runtimeAdded = 0;
             let unsampledForTime = 0;
+
+            // Per-object progress. Everything below this point is the expensive half of discovery —
+            // one read-path sample per object — and it emitted nothing, so a consumer watching a
+            // 23-object source saw the same silence as a 5-object one for however long it ran.
+            // The denominator is the union BOTH passes will sample (in-scope runtime objects plus
+            // in-scope declared ones) rather than either loop's own length, so the total is fixed
+            // before the first sample instead of revising upward when the second pass starts.
+            const sampleUniverse = new Set<string>();
+            for (const d of runtimeObjects) if (inScope(d.Name)) sampleUniverse.add(d.Name.toLowerCase());
+            for (const n of declaredNames) if (inScope(n)) sampleUniverse.add(n.toLowerCase());
+            const sampleTotal = sampleUniverse.size;
+            // Keyed, not counted: a name the connector surfaces twice is sampled twice by the loop
+            // below, and a bare counter would then report "24 of 23".
+            const announced = new Set<string>();
+            const announceSample = (name: string): void => {
+                const k = name.toLowerCase();
+                if (announced.has(k)) return;
+                announced.add(k);
+                emitter.heartbeat('Introspect', `Sampling "${name}" (${announced.size} of ${sampleTotal})`, {
+                    processed: announced.size,
+                    totalKnown: sampleTotal,
+                    skipped: unsampledForTime,
+                });
+            };
+
             for (const d of runtimeObjects) {
                 const key = d.Name.toLowerCase();
                 if (!inScope(d.Name)) continue;
+                // Announced BEFORE the budget check so an exhausted budget reads as a run that
+                // reached the end of its object list, not one that stalled partway through it.
+                announceSample(d.Name);
                 if (outOfTime()) { unsampledForTime++; continue; }
                 if (seen.has(key)) {
                     // §case-3 (data-only-discoverable): a DECLARED object the connector ALSO surfaces at
@@ -589,6 +617,7 @@ export class IntegrationConnectorCreationPipeline {
             for (const name of declaredNames) {
                 const key = name.toLowerCase();
                 if (sampledDeclared.has(key) || !inScope(name)) continue;
+                announceSample(name);
                 if (outOfTime()) { unsampledForTime++; continue; }
                 const existing = schema.Objects.find(o => o.ExternalName.toLowerCase() === key);
                 if (!existing) continue;

--- a/packages/Integration/engine/src/__tests__/IntrospectPerObjectProgress.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntrospectPerObjectProgress.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Discovery reports which object it is on, out of how many.
+ *
+ * Sampling is the expensive half of discovery — one read-path fetch per object — and it used to
+ * emit nothing between the stage's start and its completion. A consumer watching a 23-object
+ * source therefore saw exactly what a 5-object source looked like: a stage that had started, for
+ * an unbounded stretch of time, with no way to tell slow progress from a wedged run.
+ *
+ * These tests pin the CONTRACT the consumer reads, not the loop that produces it: every in-scope
+ * object is announced exactly once, and the denominator is fixed before the first sample so the
+ * number a user is watching never revises upward mid-run.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { IntegrationConnectorCreationPipeline } from '../IntegrationConnectorCreationPipeline.js';
+import type { ConnectorCreationPipelineOptions } from '../IntegrationConnectorCreationPipeline.js';
+import type { SourceObjectInfo } from '../types.js';
+
+type IntrospectHost = {
+    StageIntrospect: (
+        emitter: unknown,
+        opts: ConnectorCreationPipelineOptions
+    ) => Promise<{ Objects: SourceObjectInfo[] }>;
+};
+
+type Beat = { message: string; counts: { processed?: number; totalKnown?: number; skipped?: number } };
+
+function makeEmitter() {
+    const beats: Beat[] = [];
+    const errors: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+    return {
+        beats,
+        errors,
+        /** Only the per-object announcements; IntrospectSchema's own scan progress is a separate beat. */
+        samples: () => beats.filter((b) => b.message.startsWith('Sampling ')),
+        stageStart: () => undefined,
+        stageComplete: () => undefined,
+        heartbeat: (_stage: string, message: string, counts: Beat['counts']) => { beats.push({ message, counts }); },
+        checkpoint: () => undefined,
+        stageError: (_stage: string, message: string, meta?: Record<string, unknown>) => { errors.push({ message, meta }); },
+    };
+}
+
+const declaredObject = (ExternalName: string): SourceObjectInfo => ({
+    ExternalName,
+    ExternalLabel: ExternalName,
+    Description: '',
+    Fields: [
+        { Name: 'id', Label: 'id', SourceType: 'string', MaxLength: 50, IsPrimaryKey: true } as SourceObjectInfo['Fields'][number],
+    ],
+    PrimaryKeyFields: ['id'],
+    Relationships: [],
+} as unknown as SourceObjectInfo);
+
+const sampledField = (Name: string, MaxLength: number | null, IsPrimaryKey = false) => ({
+    Name, Label: Name, Description: '', DataType: 'string',
+    IsRequired: false, AllowsNull: true, MaxLength,
+    IsPrimaryKey, IsUniqueKey: false, IsReadOnly: false, IsForeignKey: false,
+});
+
+function makeOpts(over: {
+    declared: SourceObjectInfo[];
+    discoverObjects?: () => Promise<Array<{ Name: string; Label: string; Description: string }>>;
+    discoverFieldsViaFetch?: ReturnType<typeof vi.fn>;
+    objectNames?: string[];
+    runDeadlineMs?: number;
+}): ConnectorCreationPipelineOptions {
+    const discoverFieldsViaFetch = over.discoverFieldsViaFetch
+        ?? vi.fn(async () => [sampledField('id', 50, true)]);
+    return {
+        Connector: {
+            IntrospectSchema: async () => ({ Objects: over.declared }),
+            DiscoverObjects: over.discoverObjects ?? (async () => []),
+            DiscoverFieldsViaFetch: discoverFieldsViaFetch,
+        },
+        CompanyIntegration: { ID: 'CI-1', IntegrationID: 'INT-1' },
+        ContextUser: { ID: 'U-1' },
+        IntrospectOptions: over.objectNames ? { ObjectNames: over.objectNames } : undefined,
+        RunDeadlineMs: over.runDeadlineMs,
+    } as unknown as ConnectorCreationPipelineOptions;
+}
+
+const host = () => Object.create(IntegrationConnectorCreationPipeline.prototype) as unknown as IntrospectHost;
+
+describe('StageIntrospect — per-object progress', () => {
+    it('announces every object it samples, counting up to the catalog size', async () => {
+        const declared = Array.from({ length: 5 }, (_v, i) => declaredObject(`Obj${i}`));
+        const emitter = makeEmitter();
+
+        await host().StageIntrospect(emitter, makeOpts({ declared }));
+
+        const beats = emitter.samples();
+        expect(beats).toHaveLength(5);
+        expect(beats.map((b) => b.counts.processed)).toEqual([1, 2, 3, 4, 5]);
+        expect(beats.every((b) => b.counts.totalKnown === 5)).toBe(true);
+        // The message stands on its own, so a consumer that renders only the text still reads right.
+        expect(beats[2].message).toBe('Sampling "Obj2" (3 of 5)');
+    });
+
+    it('fixes the denominator across BOTH passes before the first sample', async () => {
+        // The runtime pass and the declared-only pass sample disjoint halves of the union. Counting
+        // per-loop would show "1 of 2" and then restart, so the number a user is watching would
+        // revise upward the moment the second pass began.
+        const emitter = makeEmitter();
+        const opts = makeOpts({
+            declared: [declaredObject('Invoice'), declaredObject('Customer')],
+            discoverObjects: async () => [
+                { Name: 'Vendor', Label: 'Vendor', Description: '' },
+                { Name: 'Payment', Label: 'Payment', Description: '' },
+            ],
+        });
+
+        await host().StageIntrospect(emitter, opts);
+
+        const beats = emitter.samples();
+        expect(beats).toHaveLength(4);                                        // 2 runtime + 2 declared
+        expect(beats.every((b) => b.counts.totalKnown === 4)).toBe(true);     // never 2, never revised
+        expect(beats.map((b) => b.counts.processed)).toEqual([1, 2, 3, 4]);   // one continuous count
+    });
+
+    it('counts an object declared AND surfaced at runtime once, not twice', async () => {
+        // It is sampled once, so it must be announced once — and the total must not double-count it.
+        const emitter = makeEmitter();
+        const opts = makeOpts({
+            declared: [declaredObject('Invoice')],
+            discoverObjects: async () => [{ Name: 'Invoice', Label: 'Invoice', Description: '' }],
+        });
+
+        await host().StageIntrospect(emitter, opts);
+
+        expect(emitter.samples()).toHaveLength(1);
+        expect(emitter.samples()[0].counts.totalKnown).toBe(1);
+    });
+
+    it('never reports more processed than the total when the runtime catalog repeats a name', async () => {
+        // A connector that lists the same object twice would walk a bare counter past its own
+        // denominator — "3 of 2" — which reads as a bug in the progress, not in the vendor.
+        const emitter = makeEmitter();
+        const opts = makeOpts({
+            declared: [],
+            discoverObjects: async () => [
+                { Name: 'Vendor', Label: 'Vendor', Description: '' },
+                { Name: 'Vendor', Label: 'Vendor', Description: '' },
+                { Name: 'Payment', Label: 'Payment', Description: '' },
+            ],
+        });
+
+        await host().StageIntrospect(emitter, opts);
+
+        const beats = emitter.samples();
+        expect(beats.every((b) => (b.counts.processed ?? 0) <= (b.counts.totalKnown ?? 0))).toBe(true);
+        expect(beats.map((b) => b.counts.processed)).toEqual([1, 2]);
+    });
+
+    it('narrows the denominator to a scoped introspection', async () => {
+        // A run asked about one object must not count itself against the whole catalog.
+        const emitter = makeEmitter();
+        const opts = makeOpts({
+            declared: [declaredObject('Invoice'), declaredObject('Customer')],
+            discoverObjects: async () => [{ Name: 'Vendor', Label: 'Vendor', Description: '' }],
+            objectNames: ['Invoice'],
+        });
+
+        await host().StageIntrospect(emitter, opts);
+
+        const beats = emitter.samples();
+        expect(beats).toHaveLength(1);
+        expect(beats[0].counts.totalKnown).toBe(1);
+    });
+
+    it('walks the count to the end when the budget is spent, and says how many were passed over', async () => {
+        // An exhausted budget must read as a run that reached the end of its object list. Stopping
+        // the count where sampling stopped leaves the progress frozen at "2 of 12" while the stage
+        // races to completion — the exact shape of a wedged run.
+        const fetchFields = vi.fn(async () => {
+            await new Promise((r) => setTimeout(r, 30));
+            return [sampledField('id', 50, true)];
+        });
+        const declared = Array.from({ length: 12 }, (_v, i) => declaredObject(`Obj${i}`));
+        const emitter = makeEmitter();
+
+        await host().StageIntrospect(emitter, makeOpts({ declared, discoverFieldsViaFetch: fetchFields, runDeadlineMs: 60 }));
+
+        const beats = emitter.samples();
+        expect(fetchFields.mock.calls.length).toBeLessThan(12);   // sampling really did stop early
+        expect(beats).toHaveLength(12);                           // the count still reached the end
+        expect(beats[11].counts.processed).toBe(12);
+        expect(beats[11].counts.skipped ?? 0).toBeGreaterThan(0); // and said the tail was passed over
+    });
+
+    it('says nothing per-object when every object is out of scope', async () => {
+        const emitter = makeEmitter();
+        const opts = makeOpts({ declared: [declaredObject('Invoice')], objectNames: ['NotHere'] });
+
+        await host().StageIntrospect(emitter, opts);
+
+        expect(emitter.samples()).toHaveLength(0);
+    });
+});


### PR DESCRIPTION


The message stands on its own, so a consumer that renders only the text still reads correctly; the counts are there for one that wants to draw a bar.

## Two details that make the number trustworthy

**The denominator spans both passes and is fixed before the first sample.** Introspect samples in two loops — the runtime objects `DiscoverObjects` surfaced, then the declared objects that pass never reached. Counting per-loop would show "1 of 2", finish, and then restart at "1 of 2" when the declared-only pass began, revising the total upward under a user who is watching it. The total is the union of both, in scope, computed up front.

**Announcements are keyed by object name.** A connector that surfaces the same object twice is sampled twice by the existing loop; a bare counter would then report "3 of 2", which reads as a bug in the progress rather than in the vendor.

**An exhausted sampling budget still walks the count to the end**, reporting the passed-over objects as `skipped`. Freezing the count where sampling stopped would leave a stage that is racing to completion looking identical to one that has wedged — the precise confusion this change exists to remove.

A scoped introspection (`ObjectNames`) narrows the denominator to the scope rather than counting one object against the whole catalog.

## Not a new event type

`IntegrationProgressEmitter.heartbeat(stage, message, counts)` already exists and `counts` already carries `processed` / `succeeded` / `failed` / `skipped` / `totalKnown`; readers already derive the latest counts from the stream. This is purely additive to an existing channel — nothing downstream needs to learn a new shape.

## Tests

`IntrospectPerObjectProgress.test.ts`, 7 behavior tests over the existing `StageIntrospect` harness. **Mutation-verified**: 6 of the 7 fail on the pre-change source. The seventh ("says nothing per-object when every object is out of scope") passes both ways by design — it guards the inverse direction, that a future change does not start announcing objects it never samples.

Engine suite: 76 files / 993 tests green. `tsc && tsc-alias` clean.