### PR TITLE
fix(markdown-core): keep HTML blocks intact across blank lines so SVG charts render

### DIFF
--- a/.changeset/markdown-html-block-blank-lines.md
+++ b/.changeset/markdown-html-block-blank-lines.md
@@ -1,0 +1,24 @@
+---
+"@memberjunction/markdown-core": patch
+---
+
+Keep embedded HTML blocks intact across blank lines so SVG charts render.
+
+A blank line ends an HTML block in CommonMark, and the markup after it is
+re-tokenized by indentation: 4+ spaces becomes an indented code block, which
+`html-block-repair` already rescues, while 0-3 spaces becomes a paragraph
+rendered as `<p>…<br>…</p>`. Because `normalizeHtmlBlockIndentation` strips
+indentation, the paragraph case is the one that arises whenever `enableHtml` is
+on — and `<p>` and `<br>` are on the HTML5 foreign-content breakout list, so
+inside an `<svg>` the browser leaves the SVG namespace and auto-closes the
+chart. Every shape after the blank line then renders as an unknown HTML
+element: `<text>` as bare document text, `<path>`/`<circle>`/`<rect>` as
+nothing. The visible result is a chart whose top renders and whose middle is
+blank, which is how this was reported.
+
+`normalizeHtmlBlockIndentation` now drops blank lines while an element is still
+open, guarded so it stays narrow: only when `tagStack` is non-empty, so blank
+lines between sibling top-level blocks are not swallowed and unrelated blocks
+cannot merge; and never inside `<pre>`, where a blank line is content rather
+than layout. Whitespace between tags is insignificant, so no rendered output
+changes apart from the repair.

--- a/packages/MarkdownCore/src/__tests__/html-block-blank-lines.test.ts
+++ b/packages/MarkdownCore/src/__tests__/html-block-blank-lines.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { MarkdownEngine } from '../engine/markdown-engine.js';
+
+/**
+ * `normalizeHtmlBlockIndentation` (the `enableHtml` string pass) drops blank
+ * lines while an HTML element is still open.
+ *
+ * Why: a blank line ends an HTML block in CommonMark, and the markup after it is
+ * re-tokenized according to its indentation — 4+ spaces becomes an indented code
+ * block (which html-block-repair rescues), 0-3 spaces becomes a paragraph
+ * rendered as `<p>…<br>…</p>`. Because this pass strips indentation, the
+ * paragraph case is what arises. `<p>` and `<br>` sit on the HTML5
+ * foreign-content breakout list, so inside an `<svg>` the browser leaves the SVG
+ * namespace and auto-closes the chart: every later `<text>` renders as bare
+ * document text and every `<path>`/`<circle>`/`<rect>` renders as nothing.
+ *
+ * Regression fixture: Skip PRD "## Mockup" sections, whose SVG charts separate
+ * gridlines, axis labels and the plot with blank lines for readability.
+ */
+
+/** Engine with the `enableHtml` normalization pass active. */
+function htmlEngine(): MarkdownEngine {
+  const engine = new MarkdownEngine();
+  engine.configureMarked({ enableHtml: true });
+  return engine;
+}
+
+/** True when a `<p>`/`<br>` lands between an `<svg>` and its close — the breakout signature. */
+function svgIsBrokenBy(html: string): boolean {
+  const open = html.indexOf('<svg');
+  if (open < 0) return false;
+  const close = html.indexOf('</svg>', open);
+  return /<p>|<br>/.test(html.slice(open, close > open ? close : html.length));
+}
+
+/** A mockup-shaped SVG whose children are split by a blank line, at a given indent. */
+function svgMockup(indent: string): string {
+  return [
+    '<div style="border:3px solid #4a90d9">',
+    `${indent}<svg width="100%" height="180" viewBox="0 0 700 180">`,
+    `${indent}<line x1="50" y1="20" x2="670" y2="20" stroke="#f1f5f9" />`,
+    '',
+    `${indent}<text x="35" y="24" font-size="10" fill="#94a3b8">600</text>`,
+    `${indent}</svg>`,
+    '</div>',
+    ''
+  ].join('\n');
+}
+
+describe('normalizeHtmlBlockIndentation — blank lines inside an open HTML block', () => {
+  for (const [label, indent] of [
+    ['unindented', ''],
+    ['2-space indented', '  '],
+    ['4-space indented', '    '],
+    ['8-space indented', '        ']
+  ] as const) {
+    it(`keeps an ${label} SVG intact across a blank line`, () => {
+      const html = htmlEngine().parseToHtml(svgMockup(indent));
+
+      expect(svgIsBrokenBy(html)).toBe(false);
+      // The shapes after the blank line must still be inside the SVG, not escaped
+      // and not stranded in a paragraph.
+      expect(html).toContain('<text x="35" y="24" font-size="10" fill="#94a3b8">600</text>');
+      expect(html).not.toContain('&lt;text');
+      expect(html).not.toMatch(/<\/svg>\s*<p>/);
+    });
+  }
+
+  it('does not merge sibling top-level blocks separated by a blank line', () => {
+    // The blank line here sits between two *closed* blocks. Swallowing it would
+    // fuse them into a single HTML block.
+    const html = htmlEngine().parseToHtml('<div>a</div>\n\n<div>b</div>\n');
+
+    expect(html.match(/<div>/g)).toHaveLength(2);
+  });
+
+  it('does not swallow a blank line inside a nested <pre>, where whitespace is content', () => {
+    const html = htmlEngine().parseToHtml('<div>\n<pre>\nline1\n\nline2\n</pre>\n</div>\n');
+
+    // The blank line survives the normalization pass. How marked then renders a
+    // blank line inside an HTML block is its own long-standing behaviour and is
+    // deliberately left alone here — the point is that this pass must not delete
+    // the line, because inside <pre> it is content rather than layout.
+    expect(html).toMatch(/line1\n\s*\n/);
+  });
+
+  it('still renders markdown in a paragraph that follows a closed HTML block', () => {
+    // Guards against over-reach: this paragraph is not inside an open element, so
+    // it must keep being parsed as markdown rather than emitted as raw HTML.
+    const html = htmlEngine().parseToHtml('<div>x</div>\n\n<span>has **bold** inside</span>\n');
+
+    expect(html).toContain('<strong>bold</strong>');
+  });
+
+  it('leaves a fenced html example escaped', () => {
+    const html = htmlEngine().parseToHtml('<div>x</div>\n\n```html\n<div>example</div>\n```\n');
+
+    expect(html).toContain('&lt;div&gt;example&lt;/div&gt;');
+  });
+
+  it('is inert when enableHtml is false (normalization does not run)', () => {
+    // The pass is gated on enableHtml; with it off the markdown is untouched by
+    // this transform and the token-level repair extension is the only defence.
+    const engine = new MarkdownEngine();
+    const html = engine.parseToHtml('<div>a</div>\n\n<div>b</div>\n');
+
+    expect(html.match(/<div>/g)).toHaveLength(2);
+  });
+});

--- a/packages/MarkdownCore/src/engine/markdown-engine.ts
+++ b/packages/MarkdownCore/src/engine/markdown-engine.ts
@@ -266,6 +266,7 @@ export class MarkdownEngine {
     const lines = markdown.split('\n');
     const result: string[] = [];
     let inHtmlBlock = false;
+    let preDepth = 0;
     const tagStack: string[] = [];
 
     for (const line of lines) {
@@ -289,6 +290,37 @@ export class MarkdownEngine {
         }
         result.push(line);
       } else {
+        // A blank line ends an HTML block in CommonMark, so the markup that
+        // follows is re-tokenized. Which token it becomes depends purely on its
+        // indentation: 4+ spaces makes an indented code block (rescued later by
+        // the html-block-repair extension), while 0-3 spaces makes a paragraph,
+        // rendered as `<p>…<br>…</p>`. Because this pass strips indentation, the
+        // paragraph case is the one that arises here — and `<p>` and `<br>` are
+        // on the HTML5 foreign-content breakout list, so inside an `<svg>` the
+        // browser leaves the SVG namespace and auto-closes the chart. Every
+        // shape after the blank line then becomes an unknown HTML element:
+        // `<text>` renders as bare document text and `<path>`/`<circle>`/`<rect>`
+        // render as nothing.
+        //
+        // Dropping the blank line keeps the block intact. Whitespace between
+        // tags is insignificant, so this cannot change the rendered result.
+        //
+        // Two guards keep it narrow:
+        //   - `tagStack.length > 0` — only while an element is genuinely open.
+        //     Without it, blank lines separating sibling top-level blocks would
+        //     be swallowed and unrelated blocks would merge into one.
+        //   - `preDepth === 0` — never inside `<pre>`, where a blank line is
+        //     meaningful content rather than insignificant whitespace.
+        if (trimmedLine === '' && tagStack.length > 0 && preDepth === 0) {
+          continue;
+        }
+
+        // Track <pre> separately from tagStack: it is not in htmlBlockTags (it
+        // never starts a block here) but its content must be left untouched.
+        const preOpens = (trimmedLine.match(/<pre\b/gi) || []).length;
+        const preCloses = (trimmedLine.match(/<\/pre>/gi) || []).length;
+        preDepth = Math.max(0, preDepth + preOpens - preCloses);
+
         // We're inside an HTML block - remove ALL leading whitespace
         // to prevent any nested content from being treated as code blocks.
         this.updateTagStack(trimmedLine, tagStack, htmlBlockTags);
@@ -298,6 +330,7 @@ export class MarkdownEngine {
         // Check if we've closed all HTML blocks
         if (tagStack.length === 0) {
           inHtmlBlock = false;
+          preDepth = 0;
         }
       }
     }


### PR DESCRIPTION
## Summary
- `normalizeHtmlBlockIndentation` now drops blank lines while an HTML element is still open, so an embedded block is not split mid-element. A blank line ends an HTML block in CommonMark, and because this pass strips indentation the markup after it always re-tokenizes as a *paragraph* (`<p>…<br>…</p>`) rather than an indented code block — which is the one shape `html-block-repair` cannot rescue, since it only reclassifies `code` tokens.
- The visible symptom was SVG charts rendering with their top intact and their middle blank. `<p>` and `<br>` are on the HTML5 foreign-content breakout list, so the browser leaves the SVG namespace and auto-closes the chart; every later `<text>` renders as bare document text and `<path>`/`<circle>`/`<rect>` render as nothing. Reproduced on Skip PRD "## Mockup" sections, whose charts separate gridlines, axis labels and the plot with blank lines for readability.
- Two guards keep the change narrow: `tagStack.length > 0` so blank lines between sibling top-level blocks are not swallowed (without it unrelated blocks merge), and `preDepth === 0` so blank lines inside `<pre>` are untouched, where they are content rather than layout. Whitespace between tags is insignificant, so nothing else about rendered output changes.
- Adds 9 tests and a patch changeset.

## Test plan
- [ ] `cd packages/MarkdownCore && npm run build && npx vitest run` — 106/106 pass, including the 19 existing `html-block-repair` tests
- [ ] Confirm an SVG split by a blank line renders intact at 0/2/4/8-space indentation
- [ ] Confirm `<div>a</div>` / blank line / `<div>b</div>` still produces two separate blocks
- [ ] Confirm a blank line inside a nested `<pre>` survives
- [ ] Confirm a paragraph following a *closed* HTML block is still parsed as markdown (`<span>has **bold**</span>` keeps `<strong>`)
- [ ] Open a Skip PRD artifact's Functional tab and confirm the mockup chart renders end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)