### PR TITLE
fix(entity-viewer): make the grid's Delete affordance reachable

### DIFF
--- a/.changeset/olive-moons-shake.md
+++ b/.changeset/olive-moons-shake.md
@@ -1,0 +1,23 @@
+---
+"@memberjunction/ng-entity-viewer": patch
+---
+
+Make the grid's Delete affordance reachable
+
+The grid wrapper has always deleted correctly: `onDeleteConfirmed()` walks every
+selected record, reports per-record failures and reloads the page. But the template
+renders the Delete button only when `ToolbarConfig.showDelete && AllowDelete`, both
+of which default to `false`, and the wrapper set neither — so the entire path was
+unreachable. In practice there was no multi-record delete anywhere the grid is used:
+removing ten rows meant opening ten records, one at a time.
+
+`showDelete` now defaults to whether the user may actually delete this entity, and
+`AllowDelete` is bound to the same permission. Defaulting to the permission rather
+than to `true` keeps the button off exactly where the delete would have been refused
+anyway, and an explicit `showDelete` in a view's config still wins in both directions
+— though it can never grant the permission itself, since `AllowDelete` is bound to
+the check, not to the config.
+
+The permission check mirrors `recycle-bin.component.ts`, the package's other delete
+surface, so both agree on what "can delete" means. A metadata provider that cannot
+answer is treated as "no", never as permission.

--- a/packages/Angular/Generic/entity-viewer/src/__tests__/grid-delete-affordance.test.ts
+++ b/packages/Angular/Generic/entity-viewer/src/__tests__/grid-delete-affordance.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import type { EntityInfo, UserInfo } from '@memberjunction/core';
+import { GridViewRendererComponent } from '../lib/view-types/renderers/grid-view-renderer.component';
+import type { GridViewConfig } from '../lib/view-types/renderers/grid-view-renderer.component';
+
+/**
+ * The grid's Delete affordance must actually be reachable.
+ *
+ * The wrapper has always deleted correctly — `onDeleteConfirmed()` walks every
+ * selected record, reports per-record failures and reloads the page. But the
+ * template renders the button only when `ToolbarConfig.showDelete && AllowDelete`,
+ * both of which default to false, and the wrapper set NEITHER. So the whole path
+ * was unreachable: in Explorer there was no way to remove ten rows except to open
+ * ten records, one at a time.
+ *
+ * These pin the gate rather than the button: shown exactly when the user could
+ * delete anyway, and an explicit view config still wins in both directions.
+ */
+
+type Host = {
+  entity: EntityInfo | null;
+  config: GridViewConfig;
+  canDelete: boolean;
+  effectiveToolbarConfig: { showDelete?: boolean };
+};
+
+const USER = { ID: 'U-1' } as unknown as UserInfo;
+
+/** An EntityInfo whose permission check answers `canDelete`, or throws. */
+function mockEntity(canDelete: boolean | 'throws'): EntityInfo {
+  return {
+    Name: 'Companies',
+    GetUserPermisions: () => {
+      if (canDelete === 'throws') {
+        throw new Error('metadata unavailable');
+      }
+      return { CanDelete: canDelete };
+    }
+  } as unknown as EntityInfo;
+}
+
+/** The component without Angular DI, with a stubbed provider. */
+function host(entity: EntityInfo | null, config: GridViewConfig = {}, user: UserInfo | null = USER): Host {
+  const c = Object.create(GridViewRendererComponent.prototype) as Host;
+  c.entity = entity;
+  c.config = config;
+  Object.defineProperty(c, 'ProviderToUse', { get: () => ({ CurrentUser: user }) });
+  return c;
+}
+
+describe('grid Delete affordance', () => {
+  it('is offered when the user may delete this entity', () => {
+    const c = host(mockEntity(true));
+    expect(c.canDelete).toBe(true);
+    expect(c.effectiveToolbarConfig.showDelete).toBe(true);
+  });
+
+  it('is withheld when the user may not', () => {
+    // Defaulting to the permission, not to `true`, keeps the button off exactly
+    // where the delete would have been refused anyway.
+    const c = host(mockEntity(false));
+    expect(c.canDelete).toBe(false);
+    expect(c.effectiveToolbarConfig.showDelete).toBe(false);
+  });
+
+  it('an explicit view config wins in both directions', () => {
+    expect(host(mockEntity(true), { toolbarConfig: { showDelete: false } }).effectiveToolbarConfig.showDelete).toBe(false);
+    expect(host(mockEntity(false), { toolbarConfig: { showDelete: true } }).effectiveToolbarConfig.showDelete).toBe(true);
+  });
+
+  it('an explicit showDelete never grants the permission itself', () => {
+    // The template needs AllowDelete too, and that is bound to canDelete — so a
+    // view config cannot talk the grid into offering a delete the user can't do.
+    const c = host(mockEntity(false), { toolbarConfig: { showDelete: true } });
+    expect(c.canDelete).toBe(false);
+  });
+
+  it('preserves the rest of the toolbar config', () => {
+    const c = host(mockEntity(true), { toolbarConfig: { showDelete: undefined, showExport: false } as never });
+    expect((c.effectiveToolbarConfig as { showExport?: boolean }).showExport).toBe(false);
+  });
+
+  it('withholds it when there is no entity yet', () => {
+    expect(host(null).canDelete).toBe(false);
+  });
+
+  it('withholds it when there is no current user', () => {
+    expect(host(mockEntity(true), {}, null).canDelete).toBe(false);
+  });
+
+  it('treats a provider that cannot answer as "no", not as permission', () => {
+    expect(host(mockEntity('throws')).canDelete).toBe(false);
+  });
+});

--- a/packages/Angular/Generic/entity-viewer/src/lib/view-types/renderers/grid-view-renderer.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/view-types/renderers/grid-view-renderer.component.ts
@@ -121,7 +121,8 @@ export interface GridViewConfig {
       [AllowLoad]="false"
       [AutoLoadEntityActions]="AutoLoadEntityActions"
       [ShowToolbar]="effectiveShowToolbar"
-      [ToolbarConfig]="config.toolbarConfig ?? {}"
+      [ToolbarConfig]="effectiveToolbarConfig"
+      [AllowDelete]="canDelete"
       [SelectionMode]="effectiveSelectionMode"
       [ShowAddToListButton]="effectiveShowAddToListButton"
       [ShowPager]="effectiveShowPager"
@@ -311,6 +312,46 @@ export class GridViewRendererComponent extends BaseAngularComponent implements I
   /** Effective toolbar visibility — defaults to `true` when not set in config. */
   get effectiveShowToolbar(): boolean {
     return this.config.showToolbar ?? true;
+  }
+
+  /**
+   * Whether this user may delete records of this entity.
+   *
+   * Mirrors `recycle-bin.component.ts`, the other delete surface in this package, so
+   * both agree on what "can delete" means rather than each inventing a rule.
+   */
+  get canDelete(): boolean {
+    const entity = this.entity;
+    if (!entity) {
+      return false;
+    }
+    try {
+      const user = this.ProviderToUse.CurrentUser;
+      return user ? (entity.GetUserPermisions(user)?.CanDelete ?? false) : false;
+    } catch {
+      // A metadata provider that cannot answer is not permission to delete.
+      return false;
+    }
+  }
+
+  /**
+   * Effective toolbar config — Delete defaults to whether the user CAN delete.
+   *
+   * The grid's Delete affordance was unreachable: the template shows it only when
+   * `ToolbarConfig.showDelete && AllowDelete`, both of which default to false, and
+   * this wrapper set neither. So `onDeleteConfirmed()` below — which already deletes
+   * every selected record, reports per-record failures and reloads the page — could
+   * only ever be reached by a view whose saved config happened to set the flag. In
+   * practice that meant no multi-record delete anywhere in Explorer: the only way to
+   * remove ten rows was to open ten records.
+   *
+   * Defaulting to the permission (rather than to `true`) keeps the button off exactly
+   * where the delete would have been refused anyway. An explicit `showDelete` in a
+   * view's config still wins in both directions.
+   */
+  get effectiveToolbarConfig(): GridToolbarConfig {
+    const cfg = this.config.toolbarConfig ?? {};
+    return { ...cfg, showDelete: cfg.showDelete ?? this.canDelete };
   }
 
   /** Effective selection mode — defaults to `'checkbox'` when not set in config. */


### PR DESCRIPTION
## The bug

The grid wrapper deletes correctly and always has — `onDeleteConfirmed()` walks every selected record, calls `Delete()` on each, logs per-record failures without aborting the rest, and re-requests the page.

None of it was reachable. The template renders the Delete button only when:

```
ToolbarConfig.showDelete && AllowDelete && HasSelection && !ShowDeleteButton
```

`_showDeleteButton`, `_allowDelete` and `ToolbarConfig.showDelete` all default to `false`, and `grid-view-renderer.component.ts` passed `[ToolbarConfig]="config.toolbarConfig ?? {}"` while never binding `AllowDelete` at all. So unless a view's *saved config* happened to set the flag, the button could not appear.

The user-visible consequence is that there is no multi-record delete anywhere the grid is used. Removing ten rows means opening ten records, one at a time. This was reported from a live environment as "there is no way to select and then delete".

## The fix

`showDelete` now defaults to whether the user may actually delete this entity, and `AllowDelete` is bound to the same permission:

```ts
get canDelete(): boolean { /* entity.GetUserPermisions(user)?.CanDelete ?? false */ }

get effectiveToolbarConfig(): GridToolbarConfig {
  const cfg = this.config.toolbarConfig ?? {};
  return { ...cfg, showDelete: cfg.showDelete ?? this.canDelete };
}
```

Defaulting to the **permission** rather than to `true` matters: it keeps the button off exactly where the delete would have been refused anyway, so nobody is offered an action that will fail. An explicit `showDelete` in a view's config still wins in both directions — but it can never grant the permission itself, because `AllowDelete` is bound to the check rather than to the config.

The permission check mirrors `recycle-bin.component.ts`, this package's other delete surface, so the two agree on what "can delete" means instead of each inventing a rule. A metadata provider that cannot answer is treated as "no", never as permission.

## Tests

`grid-delete-affordance.test.ts`, 8 tests, **mutation-verified** — all 8 fail on the pre-change source. They pin the gate rather than the button: offered when the user may delete, withheld when they may not, explicit config wins both ways, explicit config cannot grant permission, the rest of the toolbar config survives, and no-entity / no-user / provider-throws all resolve to "no".

Package suite goes from 14 failed files to 13. The 13 remaining are pre-existing module-resolution failures in unbuilt workspace siblings (`ng-pagination`, `ng-list-management`) — verified identical on a clean tree, unrelated to this change.