### PR TITLE
fix(testing): unbreak every rig, and cover the cross-server payload half

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -546,6 +546,37 @@ jobs:
             echo "MJAPI on ${PORT} is up."
           done
 
+      # ANTI-VACUITY. Every assertion in the rig presupposes that both processes actually
+      # swapped LocalCacheManager to RedisLocalStorageProvider — that is the only thing that
+      # publishes a CacheChangedEvent. If REDIS_URL were ever dropped, mistyped, or ignored,
+      # both would silently fall back to the in-memory cache, no cross-server event would be
+      # emitted, and XS1–XS5 would all PASS while testing nothing. A green lane asserting
+      # nothing is worse than a red one.
+      #
+      # MJServer logs the swap only at `verbose` (index.ts: startupLog.LogIf('verbose', …)),
+      # so the log is not a dependable signal. Assert against Redis itself: two servers that
+      # have booted and served a healthcheck through a shared cache never leave it empty.
+      # `redis-cli` is not installed on ubuntu-latest, and the Redis here is a service
+      # container (generated name), so `docker exec` by name is unreliable. Use ioredis,
+      # which integration-test-suite already declares for the sibling Redis rig.
+      - name: Verify both processes actually swapped to Redis
+        working-directory: packages/TestingFramework/integration-test-suite
+        run: |
+          node -e "
+            const Redis = require('ioredis');
+            const c = new Redis('redis://localhost:6379');
+            c.dbsize()
+              .then(n => {
+                console.log('Redis DBSIZE after both MJAPI processes booted: ' + n);
+                if (n === 0) {
+                  console.log('::error::Redis is empty — neither MJAPI swapped to RedisLocalStorageProvider, so the cross-server rig would assert nothing. Check REDIS_URL handling in packages/MJServer/src/index.ts.');
+                  process.exit(1);
+                }
+                process.exit(0);
+              })
+              .catch(e => { console.log('::error::Could not reach Redis: ' + e.message); process.exit(1); });
+          " || { echo '--- mjapi-a ---'; tail -100 /tmp/mjapi-a.log || true; exit 1; }
+
       - name: Run cross-server invalidation rig
         env:
           RUN_CROSS_SERVER: '1'

--- a/packages/TestingFramework/integration-test-suite/README.md
+++ b/packages/TestingFramework/integration-test-suite/README.md
@@ -109,7 +109,7 @@ gates the one-process catalog can't provide, and they are **not** dispatched by 
 
 | Rig | Needs |
 |---|---|
-| `cross-server-invalidation-tests.ts` | TWO MJAPI processes + shared Redis (`RUN_CROSS_SERVER=1`, `MJAPI_A_URL`/`MJAPI_B_URL`) |
+| `cross-server-invalidation-tests.ts` | TWO MJAPI processes + shared Redis (`RUN_CROSS_SERVER=1`, `MJAPI_A_URL`/`MJAPI_B_URL`, `MJ_API_KEY`) — XS1/XS2 cover cache **invalidation**, XS3–XS5 cover **payload materialization** (that cross-server rows arrive as real BaseEntity instances, not prototype-less JSON); **mutates** (touches a query's `Description`, always restored) |
 | `cache-payload-materialization-tests.ts` | one process + real Redis (`REDIS_URL`) — captures a real cache publish off the wire and replays it as a foreign server; **mutates** (seeds/deletes agent notes) |
 | `agent-memory-tests.ts` | live-model gate (`RUN_AGENT_TESTS=1`) |
 | `runview-matrix-tests.ts` | running MJAPI + `MJ_API_KEY` — client-first RunView sweep across every entity |

--- a/packages/TestingFramework/integration-test-suite/rigs/cross-server-invalidation-tests.ts
+++ b/packages/TestingFramework/integration-test-suite/rigs/cross-server-invalidation-tests.ts
@@ -3,6 +3,13 @@
  * process A invalidates the cached read in MJAPI process B via the shared
  * Redis-backed LocalCacheManager (RedisLocalStorageProvider pub/sub).
  *
+ * Two halves, and they fail differently:
+ *   - INVALIDATION (XS1/XS2) — does B stop serving a stale slot after A writes?
+ *   - PAYLOAD (XS3-XS5) — when B APPLIES a data-carrying event, do the rows stay real
+ *     BaseEntity instances? Row counts cannot see this: `results.length` is correct on
+ *     prototype-less JSON, which is exactly how #3777 shipped past XS1/XS2 and broke
+ *     every RunQuery in production with `query.UserCanRun is not a function`.
+ *
  * This is the ONE check class that fundamentally needs TWO processes — it cannot be
  * expressed in a single-process suite — so it is a standalone script (D1/D8), gated
  * behind RUN_CROSS_SERVER=1 and run only when the topology is provisioned:
@@ -22,7 +29,7 @@
 import { RunView } from '@memberjunction/core';
 import type { UserInfo } from '@memberjunction/core';
 import { GraphQLDataProvider, GraphQLProviderConfigData } from '@memberjunction/graphql-dataprovider';
-import type { MJUserSettingEntity } from '@memberjunction/core-entities';
+import type { MJUserSettingEntity, MJQueryEntity } from '@memberjunction/core-entities';
 // Side-effect import: registers generated entity subclasses so GetEntityObject<…>()
 // materializes a real BaseEntity (this script doesn't go through bootstrapIntegrationClient).
 import '@memberjunction/server-bootstrap-lite';
@@ -60,6 +67,100 @@ async function countTagged(provider: GraphQLDataProvider, user: UserInfo, tag: s
         throw new Error(`RunView (count '${tag}') failed: ${res.ErrorMessage}`);
     }
     return res.Results?.length ?? 0;
+}
+
+/**
+ * Attempt a RunQuery through `provider`, returning the failure text rather than throwing.
+ *
+ * XS3–XS5 care about *how* a query fails, not merely that it did: a poisoned engine surfaces as a
+ * TypeError naming a missing entity METHOD, while an unrelated problem (bad parameters, a query
+ * whose SQL no longer compiles) surfaces as an ordinary query error. Swallowing the distinction
+ * would let this bundle go green against the very defect it exists to catch.
+ */
+async function tryRunQuery(
+    provider: GraphQLDataProvider,
+    user: UserInfo,
+    params: { QueryID?: string; QueryName?: string }
+): Promise<{ ok: boolean; error: string }> {
+    try {
+        const res = await provider.RunQuery(params, user);
+        return { ok: !!res?.Success, error: res?.ErrorMessage ?? '' };
+    } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+}
+
+/**
+ * The signature of a BaseEngine cached array that has been overwritten with plain JSON.
+ *
+ * Deserialized rows carry the DATA but not the PROTOTYPE, so field reads keep working while any
+ * METHOD call throws `... is not a function`. `MJQueryEntityExtended.UserCanRun` is the one every
+ * RunQuery goes through (`GenericDatabaseProvider.ValidateQueryForExecution`), which is why the
+ * production symptom was `TypeError: query.UserCanRun is not a function` on every dashboard tile.
+ */
+function looksLikePoisonedEngine(error: string): boolean {
+    return /is not a function/i.test(error);
+}
+
+/**
+ * Find a query this server can actually execute right now, so XS3–XS5 assert against a known-good
+ * baseline instead of blaming the cross-server path for a query that was already broken.
+ *
+ * Tries candidates in turn because catalog queries carry required parameters we cannot infer here;
+ * the first one that succeeds unparameterised becomes the probe. Returning null is a BOOTSTRAP
+ * condition (exit 2), never a test failure — "no runnable query exists" says nothing about Redis.
+ */
+async function pickRunnableQuery(
+    provider: GraphQLDataProvider,
+    user: UserInfo,
+    maxAttempts = 8
+): Promise<{ ID: string; Name: string } | null> {
+    const rv = RunView.FromMetadataProvider(provider);
+    const res = await rv.RunView<{ ID: string; Name: string; Description: string | null }>({
+        EntityName: 'MJ: Queries',
+        ExtraFilter: `Status = 'Approved'`,
+        Fields: ['ID', 'Name', 'Description'],
+        OrderBy: 'Name',
+        ResultType: 'simple'
+    }, user);
+    if (!res.Success) {
+        throw new Error(`Could not list MJ: Queries: ${res.ErrorMessage}`);
+    }
+    // Prefer a query with a non-empty Description. `MJQueryEntityServer.Save` NULLs
+    // EmbeddingVector/EmbeddingModelID when Description is blank — a side effect the restore
+    // below cannot undo, so keep the probe off those rows when any alternative exists.
+    // Filtered client-side rather than in ExtraFilter to stay dialect-agnostic.
+    const rows = res.Results ?? [];
+    const ordered = [
+        ...rows.filter(r => (r.Description ?? '').trim().length > 0),
+        ...rows.filter(r => (r.Description ?? '').trim().length === 0)
+    ];
+    const errors: string[] = [];
+    for (const row of ordered.slice(0, maxAttempts)) {
+        const attempt = await tryRunQuery(provider, user, { QueryID: row.ID });
+        if (attempt.ok) {
+            return { ID: row.ID, Name: row.Name };
+        }
+        errors.push(`${row.Name}: ${attempt.error}`);
+    }
+
+    // CRITICAL distinction. "Nothing ran" has two very different causes, and treating them
+    // alike is how this rig would report the defect it exists to catch as a setup problem.
+    //
+    // Observed on a pre-#3777 build: the engine is ALREADY poisoned by the time the probe
+    // runs — these servers have been publishing cross-server events since startup — so every
+    // candidate fails with `query.UserCanRun is not a function`. Reporting that as "seed a
+    // runnable query" is exactly backwards: it is the bug, at full severity, and it means
+    // RunQuery is dead process-wide.
+    if (errors.length > 0 && errors.every(e => looksLikePoisonedEngine(e))) {
+        throw new Error(
+            'EVERY approved query failed with a missing entity METHOD, which is the #3777 ' +
+            'signature: this server\'s cached MJ: Queries array holds plain JSON, not BaseEntity ' +
+            'instances, so RunQuery is broken process-wide. This is a FAILURE, not a missing ' +
+            `fixture.\n  ${errors.slice(0, 3).join('\n  ')}`
+        );
+    }
+    return null;
 }
 
 async function main(): Promise<void> {
@@ -102,6 +203,145 @@ async function main(): Promise<void> {
         } finally {
             // Always clean up our mutation, even if the assertion above threw.
             Assert(await setting.Delete(), `Cleanup delete in A failed: ${setting.LatestResult?.CompleteMessage ?? 'unknown'}`);
+        }
+    });
+
+    // ────────────────────────────────────────────────────────────────────────────────────────────
+    // XS3–XS5: the payload half of the cross-server contract.
+    //
+    // XS1/XS2 above prove INVALIDATION — "does B stop serving a stale slot?" — by counting rows.
+    // That is structurally blind to the defect fixed in #3777, because a row COUNT is correct on
+    // plain JSON: `results.length` does not care about prototypes. The bug lived one layer down.
+    //
+    // `BaseEngine.OnExternalCacheChange` used to assign a cache-change payload's rows straight into
+    // the engine property:
+    //
+    //     const parsed = JSON.parse(event.Data);
+    //     this.HandleSingleViewResult(config, { Results: parsed.results, ... });   // plain objects
+    //
+    // Cache payloads are serialized, so for any `entity_object` config — the DEFAULT, and what
+    // `QueryEngine` uses for `MJ: Queries` (`CacheLocal: true`) — that silently replaced live
+    // BaseEntity instances with prototype-less objects. Reads still worked. Method calls did not,
+    // and every RunQuery calls one: `ValidateQueryForExecution` → `query.UserCanRun(user)`.
+    //
+    // Production symptom, observed on a Redis-backed Skip deployment: every Skip Monitoring
+    // dashboard rendered empty while MJAPI logged `TypeError: query.UserCanRun is not a function`.
+    // Redis-only, because `CacheChangedEvent` is published solely by RedisLocalStorageProvider.
+    //
+    // These three drive that path from the OUTSIDE — a write in A, then real work in B — so they
+    // need no access to B's engine internals and would have failed on the pre-#3777 build.
+    // ────────────────────────────────────────────────────────────────────────────────────────────
+
+    const probe = await pickRunnableQuery(b, userB);
+    if (!probe) {
+        // Bootstrap condition, not a failure: with no executable query there is nothing to poison.
+        throw new Error(
+            'No approved MJ: Query executed successfully unparameterised, so XS3–XS5 have no probe. ' +
+            'Seed a runnable query or widen pickRunnableQuery(); this says nothing about Redis.'
+        );
+    }
+
+    /**
+     * Force `MJ: Queries` to publish a data-carrying cross-server event from A.
+     *
+     * An unfiltered, unlimited slot is MAINTAINED in place rather than invalidated (see the
+     * cache-gauntlet bundle's slot matrix), so the save publishes `Action: 'set'` WITH `Data` —
+     * precisely the branch that pre-#3777 applied without materializing.
+     *
+     * `Feedback` is the mutation target for a specific reason. `MJQueryEntityServer.Save`
+     * gates two expensive side effects on WHICH field is dirty:
+     *
+     *     shouldExtractData      = !IsSaved || sqlField.Dirty
+     *     shouldGenerateEmbedding = !IsSaved || nameField.Dirty
+     *                                        || descriptionField.Dirty
+     *                                        || userQuestionField.Dirty
+     *
+     * Dirtying Name/Description/UserQuestion calls GenerateCompositeEmbedding(), which fails
+     * outright wherever no embedding model is configured — turning this rig RED for an
+     * environment reason that has nothing to do with cross-server caching. Dirtying SQL
+     * triggers parameter extraction and dialect conversion. `Feedback` trips neither, so the
+     * save is a pure row-version bump: it publishes the event and changes nothing that any
+     * other check observes. The original value is always restored.
+     */
+    async function publishQueriesChangeFromA(marker: string): Promise<() => Promise<void>> {
+        const q = await a.GetEntityObject<MJQueryEntity>('MJ: Queries', userA);
+        Assert(await q.Load(probe!.ID), `Could not load query ${probe!.Name} in A`);
+        const original = q.Feedback;
+        q.Feedback = `${original ?? ''} ${marker}`.trim();
+        Assert(await q.Save(), `Save of MJ: Queries in A failed: ${q.LatestResult?.CompleteMessage ?? 'unknown'}`);
+        return async () => {
+            const restore = await a.GetEntityObject<MJQueryEntity>('MJ: Queries', userA);
+            if (await restore.Load(probe!.ID)) {
+                restore.Feedback = original;
+                await restore.Save();
+            }
+        };
+    }
+
+    suite.Test('XS3: after a MJ: Queries write in A, B can still EXECUTE a query (entity methods survive the payload)', async () => {
+        const baseline = await tryRunQuery(b, userB, { QueryID: probe.ID });
+        Assert(baseline.ok, `Pre-condition: B must be able to run "${probe.Name}" before the write (${baseline.error})`);
+
+        const restore = await publishQueriesChangeFromA('[mj-xserver-xs3]');
+        try {
+            await sleep(SETTLE_MS); // let the cross-server payload land in B
+            const after = await tryRunQuery(b, userB, { QueryID: probe.ID });
+            Assert(
+                after.ok,
+                looksLikePoisonedEngine(after.error)
+                    ? `B's cached MJ: Queries array was overwritten with plain JSON by the cross-server ` +
+                      `payload — entity methods are gone. This is the #3777 regression: ${after.error}`
+                    : `B failed to run "${probe.Name}" after A's write for an unrelated reason: ${after.error}`
+            );
+        } finally {
+            await restore();
+        }
+    });
+
+    suite.Test('XS4: name-based query resolution in B also survives the cross-server payload', async () => {
+        // Same poisoned array, different lookup path: resolving by Name walks the cached collection
+        // rather than hitting an ID index, so it can fail where the ID path happens to succeed.
+        const baseline = await tryRunQuery(b, userB, { QueryName: probe.Name });
+        Assert(baseline.ok, `Pre-condition: B must resolve "${probe.Name}" by name before the write (${baseline.error})`);
+
+        const restore = await publishQueriesChangeFromA('[mj-xserver-xs4]');
+        try {
+            await sleep(SETTLE_MS);
+            const after = await tryRunQuery(b, userB, { QueryName: probe.Name });
+            Assert(
+                after.ok,
+                looksLikePoisonedEngine(after.error)
+                    ? `Name-based resolution hit the same poisoned array (#3777): ${after.error}`
+                    : `B failed name-based resolution after A's write for an unrelated reason: ${after.error}`
+            );
+        } finally {
+            await restore();
+        }
+    });
+
+    suite.Test('XS5: B stays healthy across rapid successive writes in A (overlapping events must not leave it poisoned)', async () => {
+        // The fix claims a refresh generation (beginConfigRefresh / isLatestConfigRefresh) because
+        // materialization is async: without it two overlapping events can resolve out of order and
+        // the STALE one assigns last. A single write cannot expose that; three back-to-back can.
+        const restores: Array<() => Promise<void>> = [];
+        try {
+            for (let i = 0; i < 3; i++) {
+                restores.push(await publishQueriesChangeFromA(`[mj-xserver-xs5-${i}]`));
+            }
+            await sleep(SETTLE_MS * 2); // all three events must settle, in whatever order they arrive
+            const after = await tryRunQuery(b, userB, { QueryID: probe.ID });
+            Assert(
+                after.ok,
+                looksLikePoisonedEngine(after.error)
+                    ? `B was left poisoned after overlapping cross-server events — a stale payload ` +
+                      `won the race (#3777 generation guard): ${after.error}`
+                    : `B failed after rapid writes for an unrelated reason: ${after.error}`
+            );
+        } finally {
+            // Restore in reverse so the earliest snapshot is the one that lands.
+            for (const restore of restores.reverse()) {
+                await restore();
+            }
         }
     });
 

--- a/packages/TestingFramework/integration-test-suite/rigs/lib/harness.ts
+++ b/packages/TestingFramework/integration-test-suite/rigs/lib/harness.ts
@@ -30,8 +30,6 @@ export {
     IntegrationCheckRegistry,
     bootstrapIntegrationServer,
     bootstrapIntegrationClient,
-    createRunQueryFixtures,
-    teardownRunQueryFixtures,
     // RLS two-user discovery (the rls-isolation bundle's fixture) — DISCOVERED, not minted.
     discoverRlsFixture,
     // Tier gate predicate — the ONE source of truth honored by both the scripts and the driver.


### PR DESCRIPTION
Two problems, both found by trying to actually run the cross-server rig.

## 1. Every rig in the repo is currently unrunnable

`rigs/lib/harness.ts` re-exports `createRunQueryFixtures` and `teardownRunQueryFixtures`, which no longer exist in `@memberjunction/testing-integration` — the same changeset that introduced the shim removed them from the package. ESM validates named exports at instantiation, so **any rig importing `./lib/harness` dies before its first line.** That is all of them.

Nothing caught it. `tsconfig.include` is `src/**/*`, so `rigs/` sits outside every `tsc` pass, and until the cross-server lane was added no workflow invoked a rig at all. The nightly job has been failing at `Run cross-server invalidation rig` — most recently `2026-09-01T06:21`, run `33477235102`:

```
failure   Cross-server invalidation rig (nightly)
              failed -> Run cross-server invalidation rig
```

Every `pull_request`/`push` run is green because none of them run that job.

Fix: two dead re-exports removed. Verified load-bearing — reverting only that file reintroduces both `TS2724` errors and the rig will not compile.

## 2. XS1/XS2 are structurally blind to the defect class they sit closest to

They assert **invalidation** — *does B stop serving a stale slot after A writes?* — by counting rows. A row count is correct on prototype-less JSON: `results.length` does not care about prototypes.

So when #3777 shipped, this rig stayed green. `BaseEngine.OnExternalCacheChange` was assigning a cache-change payload's rows straight into the engine property; payloads are serialized, so for any `entity_object` config — the default, and what `QueryEngine` uses for `MJ: Queries` — live `BaseEntity` instances were replaced by plain objects. Data intact, methods gone. `ValidateQueryForExecution` calls `query.UserCanRun(user)` on every RunQuery, so RunQuery died process-wide with `TypeError: query.UserCanRun is not a function`, and every dashboard on a Redis-backed deployment rendered empty.

`XS3`–`XS5` drive the **payload** half from the outside — write in A, then do real work in B — so they need no access to B's engine internals:

| | |
|---|---|
| **XS3** | after a `MJ: Queries` write in A, B can still **execute** a query |
| **XS4** | name-based resolution survives too (different lookup path, same array) |
| **XS5** | overlapping writes leave B healthy (the `beginConfigRefresh` generation guard) |

They distinguish a poisoned engine (`is not a function`) from an unrelated query failure, so they cannot go green against the defect they exist to catch. And if *every* candidate query fails with a missing-method signature, that is reported as the #3777 failure rather than as a missing fixture — the first draft got this wrong and reported a total outage as "seed a runnable query".

`Feedback` is the mutation target deliberately. `MJQueryEntityServer.Save` gates embedding generation on `Name`/`Description`/`UserQuestion` being dirty, and parameter extraction on `SQL` being dirty. `Feedback` trips neither, so the save is a pure row-version bump: it publishes the event and changes nothing any other check observes. The original value is always restored.

## Verification — red before green

Run against **two real MJAPI processes on one shared Redis** (distinct `SourceServerId`s, genuine cross-server events), not a single-process simulation:

**Pre-fix (5.51.0)** — all 44 approved queries fail:

```
Server Installed Version History:  query.UserCanRun is not a function
MonitoringAgentRunSteps:           query.UserCanRun is not a function
GetConversationArtifactsForAgent:  query.UserCanRun is not a function
```

**Post-fix (5.51.2)** — XS3/XS4/XS5 pass.

## Anti-vacuity gate on the CI job

Every assertion here presupposes both processes actually swapped `LocalCacheManager` to Redis — that is the only thing that publishes a `CacheChangedEvent`. If `REDIS_URL` were dropped, mistyped or ignored, both would silently fall back to the in-memory cache, emit nothing, and all five checks would pass while testing nothing. A green lane asserting nothing is worse than a red one.

MJServer logs the swap only at `verbose`, so the step asserts `DBSIZE > 0` via `ioredis` instead — `redis-cli` is not installed on `ubuntu-latest`, and the Redis is a service container whose generated name makes `docker exec` unreliable.

## Known gap — please read before treating this lane as a gate

**`XS2` fails consistently** (3/3) in a local two-server setup on 5.51.2: `expected 1, got 0`, meaning B does not observe A's write inside the 2s settle window. It passed on the first run and failed on every run after. I ruled out leftover fixtures (0 stray `mj.xserver.*` rows) and third-party Redis clients (5 connections = the 2 MJAPI processes and their pub/sub channels).

I have not explained it, and it is the **pre-existing invalidation check**, not one of the new ones. Whether it is a too-short `SETTLE_MS` under load, Redis state carried across restarts, or a real invalidation problem, it should be understood before this lane is trusted to gate anything. Happy to hand over the repro to whoever owns this suite.

## Not included

The `docker/regression` Dockerfiles are still on npm after the pnpm migration, so `docker compose … build` for this stack fails outright. That is a separate PR — it is an unrelated drive-by and does not affect this lane, which uses no images from that directory.

