### PR TITLE
fix(docker): port the regression images to pnpm

### DIFF
--- a/docker/regression/Dockerfile.api
+++ b/docker/regression/Dockerfile.api
@@ -11,7 +11,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 
 WORKDIR /app
 
-COPY package.json package-lock.json turbo.json tsconfig.angular.json tsconfig.server.json ./
+# corepack activates the pnpm version pinned by package.json's `packageManager`, matching
+# docker/MJAPI/Dockerfile. This repo moved off npm in the 6.x era: there is no
+# package-lock.json, so the previous `COPY … package-lock.json` failed the build outright.
+RUN corepack enable
+
+# pnpm-workspace.yaml is LOAD-BEARING here, not incidental metadata:
+#   * linkWorkspacePackages: true — pnpm 10 defaults this to false, which makes internal deps
+#     pinned at an exact version resolve from the REGISTRY instead of linking to the local
+#     package. For an unpublished package that fails loudly; for a published one it silently
+#     builds against the wrong code.
+#   * onlyBuiltDependencies — pnpm 10 blocks postinstall scripts by default, so without this
+#     isolated-vm / sharp / esbuild / lmdb would install unbuilt and fail at runtime.
+#   * packages: — the workspace globs themselves (pnpm ignores package.json's `workspaces`).
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.angular.json tsconfig.server.json ./
 COPY packages/ ./packages/
 COPY metadata/ ./metadata/
 COPY migrations/ ./migrations/
@@ -26,11 +39,16 @@ COPY migrations/ ./migrations/
 COPY docker/regression/.docker-generated/GeneratedEntities/ ./packages/GeneratedEntities/src/generated/
 COPY docker/regression/.docker-generated/MJAPI-generated/ ./packages/MJAPI/src/generated/
 
-RUN npm install
+RUN pnpm install --frozen-lockfile
 
-RUN npm run build:api
+RUN pnpm run build:api
 
 # ─── Runtime ───────────────────────────────────────────────────────────────
+# Copying the whole /app is what makes pnpm work across stages: its node_modules is a symlink
+# farm pointing into node_modules/.pnpm, and those links are RELATIVE and entirely contained
+# under /app — so `COPY --from=builder /app ./` preserves a self-consistent tree. Copying only
+# packages/*/dist would leave every dependency dangling. No pnpm is needed at runtime; the
+# CMD is plain `node`.
 FROM node:24-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl \

--- a/docker/regression/Dockerfile.db-setup
+++ b/docker/regression/Dockerfile.db-setup
@@ -40,15 +40,20 @@ ENV PATH="/opt/mssql-tools18/bin:$PATH"
 WORKDIR /app
 
 # Copy package manifests and source
-COPY package.json package-lock.json turbo.json tsconfig.angular.json tsconfig.server.json ./
+# See Dockerfile.api for why corepack + pnpm-workspace.yaml are required rather than optional:
+# there is no package-lock.json in the 6.x era, and pnpm-workspace.yaml carries
+# linkWorkspacePackages / onlyBuiltDependencies, both of which change what actually installs.
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.angular.json tsconfig.server.json ./
 COPY packages/ ./packages/
 COPY metadata/ ./metadata/
 COPY migrations/ ./migrations/
 COPY Demos/AssociationDB/ ./Demos/AssociationDB/
 
-RUN npm install
+RUN pnpm install --frozen-lockfile
 
-RUN npm run build:api
+RUN pnpm run build:api
 
 # Copy MJ config (same one MJAPI uses)
 COPY docker/MJAPI/docker.config.cjs ./mj.config.cjs

--- a/docker/regression/docker-compose.cross-server.yml
+++ b/docker/regression/docker-compose.cross-server.yml
@@ -14,7 +14,14 @@
 #   RUN_CROSS_SERVER=1 \
 #   MJAPI_A_URL=http://localhost:14000/ MJAPI_B_URL=http://localhost:14001/ \
 #   MJ_API_KEY=<system-api-key> \
-#   npx tsx packages/MJServer/integration-test-scripts/cross-server-invalidation-tests.ts
+#   npx tsx packages/TestingFramework/integration-test-suite/rigs/cross-server-invalidation-tests.ts
+#
+# NOTE: bringing this stack up also needs `docker/regression/.docker-generated/` to exist —
+# Dockerfile.api COPYs the codegen overlay from it, and Docker has no conditional COPY, so a
+# fresh clone fails there. Produce it first with `docker/regression/gen-forms.sh` (see
+# LIMITATIONS.md). The CI lane in .github/workflows/integration.yml ("Cross-server
+# invalidation rig (nightly)") sidesteps all of this: it provisions SQL Server + a Redis
+# service and boots two host MJAPI processes directly, using no images from this directory.
 #
 # REDIS_KEY_PREFIX defaults to "mj" on both processes, so they share one keyspace.
 


### PR DESCRIPTION
`docker/regression/Dockerfile.api` and `Dockerfile.db-setup` were never ported when the repo moved to pnpm. Both do `COPY … package-lock.json`, which no longer exists, so the build fails at that line before anything else runs:

```
docker compose -f docker/regression/docker-compose.test.yml \
               -f docker/regression/docker-compose.cross-server.yml build
→ fails at COPY (package-lock.json not found)
```

`docker/MJAPI/Dockerfile` was already ported, and is the template followed here.

## The change

```dockerfile
RUN corepack enable                                    # pnpm version pinned by packageManager
COPY package.json pnpm-lock.yaml pnpm-workspace.yaml \ # was: package-lock.json
     turbo.json tsconfig.angular.json tsconfig.server.json ./
RUN pnpm install --frozen-lockfile                     # was: npm install
```

**`pnpm-workspace.yaml` is load-bearing, not incidental metadata** — this is the easy one to omit and the expensive one to get wrong:

- **`linkWorkspacePackages: true`** — pnpm 10 defaults this to **false**, which makes internal deps pinned at an exact version resolve from the **registry** instead of linking to the local package. Unpublished packages fail loudly; published ones silently build against the wrong code.
- **`onlyBuiltDependencies`** — pnpm 10 blocks postinstall scripts by default, so without it `isolated-vm` / `sharp` / `esbuild` / `lmdb` install unbuilt and fail at runtime.
- **`packages:`** — the workspace globs themselves (pnpm ignores `package.json`'s `workspaces`).

The multi-stage `COPY --from=builder /app ./` is **unchanged**, and now documented inline, because it is the part that usually breaks when porting to pnpm: `node_modules` is a symlink farm into `node_modules/.pnpm`, and those links are relative and entirely contained under `/app`. Copying only `packages/*/dist` would leave every dependency dangling.

## What is verified, and what is not

**Verified** — built the exact layer that previously failed. Inside the resulting image:

```
pnpm: 10.33.0
package.json  pnpm-lock.yaml  pnpm-workspace.yaml
turbo.json    tsconfig.angular.json  tsconfig.server.json   all present
linkWorkspacePackages carried over: yes
```

**Not verified end-to-end.** `Dockerfile.api` also COPYs `docker/regression/.docker-generated/`, which does not exist on a fresh clone — an existing limitation (`LIMITATIONS.md:231`), unchanged by this PR. A full build still needs `gen-forms.sh` run first. I have stated that prerequisite in the compose header, replacing the stale claim that `npm run regression:build` produces it — there is no such script in `package.json`.

So this PR takes the stack from *"cannot build at all"* to *"builds once the pre-existing codegen prerequisite is met"*. Resolving that prerequisite properly (committing placeholder dirs so fresh clones work, per LIMITATIONS.md's own suggestion) is a separate decision — an empty overlay may break the AssociationDemo resolvers those images exist to serve, and I did not want to guess at that on behalf of the regression suite's actual users.

## Also

Corrects the compose header's rig path — the script moved to `packages/TestingFramework/integration-test-suite/rigs/`.

## Context

Found while trying to reproduce a cross-server Redis defect locally. Worth noting the nightly cross-server CI lane does **not** use these images — it provisions SQL Server plus a Redis service and boots two host MJAPI processes directly — so this is a local-development fix and does not affect that gate. The rig work itself is in a separate PR.
