### PR TITLE
perf(migrations): covering index for the recycle-bin chip's RecordChange read

### DIFF
--- a/migrations/v6/V202609011930__v6.1.x__RecordChange_RecycleBin_Covering_Index.sql
+++ b/migrations/v6/V202609011930__v6.1.x__RecordChange_RecycleBin_Covering_Index.sql
@@ -1,0 +1,31 @@
+-- The recycle-bin chip resolves every entity's deleted-record count by
+-- (EntityID, Type='Delete') ordered by ChangedAt DESC, taking the top 500 and reading back
+-- RecordID to count distinct deletions. It is embedded in both standard surfaces —
+-- entity-viewer.component and entity-data-grid.component — so this query runs on every
+-- record open and every grid render, once per entity. RecordChange has only the
+-- single-column auto-FK index on EntityID plus IX_RecordChange_RecordID, so the read seeks
+-- EntityID, then sorts every change ever recorded for that entity to satisfy the ORDER BY,
+-- and looks up Type and RecordID per row. On an audit table that grows one row per record
+-- mutation forever, that sort is paid on every page load.
+--
+-- Measured on SQL Server at 3.9M RecordChange rows: 47,363 ms. The record page issues its
+-- related-entity panels as one batched RunViews call, so a read of that length exceeds the
+-- request timeout and fails the entire batch — every tab on the record returns 504, not
+-- just the recycle-bin chip. The chip's own catch is empty (recycle-bin-chip.component.ts),
+-- so nothing attributes the failure to it and the symptom presents as unrelated panels
+-- breaking. With this index the same query returns in 687 ms.
+--
+-- One composite serves the filter and the sort together and covers RecordID, so there is no
+-- key lookup and no sort. Key stays far under the 1700-byte nonclustered cap:
+-- 16 + nvarchar(20) + datetimeoffset = 66 bytes.
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes
+    WHERE name = 'IDX_RecordChange_Entity_Type_ChangedAt'
+      AND object_id = OBJECT_ID('[${flyway:defaultSchema}].[RecordChange]')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IDX_RecordChange_Entity_Type_ChangedAt]
+        ON [${flyway:defaultSchema}].[RecordChange]
+            ([EntityID], [Type], [ChangedAt] DESC)
+        INCLUDE ([RecordID]);
+END


### PR DESCRIPTION
## The problem

`recycle-bin-chip.component` resolves each entity's deleted-record count with:

```ts
rv.RunView({
  EntityName: 'MJ: Record Changes',
  Fields: ['ID','RecordID'],
  ExtraFilter: `EntityID='${entityInfo.ID}' AND Type='Delete'`,
  OrderBy: 'ChangedAt DESC',
  MaxRows: 500,
})
```

The chip is embedded in **both standard surfaces** — `entity-viewer.component` and `entity-data-grid.component` — so this runs on **every record open and every grid render**, once per entity.

`RecordChange` carries only the single-column auto-FK index on `EntityID` plus `IX_RecordChange_RecordID`. Nothing supports `EntityID + Type` filtered and sorted by `ChangedAt`, so the read seeks `EntityID`, then sorts every change ever recorded for that entity to satisfy the `ORDER BY`, with a lookup per row for `Type` and `RecordID`. On an audit table that grows one row per record mutation forever, that sort is paid on every page load.

## Impact

Measured on SQL Server at **3.9M** `RecordChange` rows: **47,363 ms**. (The same environment is now at 7.1M rows, so that figure is conservative.)

The record page issues its related-entity panels as one batched `RunViews` call, so a read of that length exceeds the request timeout and **fails the entire batch — every tab on the record returns 504**, not just the recycle-bin chip.

Worse for diagnosis: the chip's own `catch` is empty, so nothing attributes the failure to it. It presents as unrelated panels breaking. In our case that cost hours of investigation across the wrong layers before we found the caller.

## The fix

```sql
CREATE NONCLUSTERED INDEX [IDX_RecordChange_Entity_Type_ChangedAt]
    ON [${flyway:defaultSchema}].[RecordChange]
        ([EntityID], [Type], [ChangedAt] DESC)
    INCLUDE ([RecordID]);
```

One composite serves the filter and the sort together and covers `RecordID`, so there is no key lookup and no sort. **Measured after: 687 ms.**

Key is 66 bytes (`16 + nvarchar(20) + datetimeoffset`), far under the 1700-byte nonclustered cap.

Follows the pattern and guard style of `V202608260700__v6.1.x__RecordMap_Upsert_Covering_Index.sql`, and is numbered above the current high-water mark.

## Suggested follow-up (not in this PR)

The empty `catch` in `recycle-bin-chip.component.ts` should log. A swallowed failure there is indistinguishable from unrelated breakage, which is what made this expensive to trace.
