### PR TITLE
fix(conversations,code-editor): restore the agent-completion toast and template syntax highlighting

### DIFF
--- a/.changeset/fix-completion-toast-and-editor-language.md
+++ b/.changeset/fix-completion-toast-and-editor-language.md
@@ -1,0 +1,10 @@
+---
+"@memberjunction/ng-conversations": patch
+"@memberjunction/ng-code-editor": patch
+---
+
+Two fixes for defects found while tracing console noise in the conversation UI.
+
+**The agent-completion toast never fired.** `markMessageComplete` looked up the active task by the AI reply's conversation detail ID, but every `activeTasks.add()` call in `message-input` registers the task against the message that STARTED the turn — the user message, the Sage delegation message, or the status message. Those IDs are never equal, so the lookup missed on every completion and the "&lt;agent&gt; completed in &lt;conversation&gt;" notification never reached a user who had navigated away. The task still disappeared, because `conversation-chat-area` separately sweeps tasks whose message has left `In-Progress`, so this surfaced only as a missing notification plus `⚠️ No task found for completed message …` on every single turn. Every path already links the reply to its starter through `ParentID`, so the lookup now falls back to it.
+
+**Template editors lost syntax highlighting entirely.** `_findLanguage` matched only `name` and `alias`. Several names in common use are registered by CodeMirror as extensions instead — `jinja2` is one of Jinja's (`["j2", "jinja", "jinja2"]`) while its only matchable name is `"Jinja"`. The template editors in core-entity-forms ask for `jinja2`, so every prompt and template opened with `Language not found: jinja2` and no highlighting. Resolution now falls back to extensions, but only when nothing matched by name or alias — so it can turn a miss into a hit and can never change a match that already resolved, which matters because short extensions (`r`, `md`, `ts`) could otherwise outrank another language's real name.

--- a/packages/Angular/Generic/code-editor/src/lib/ng-code-editor.component.ts
+++ b/packages/Angular/Generic/code-editor/src/lib/ng-code-editor.component.ts
@@ -716,13 +716,30 @@ export class CodeEditorComponent extends BaseAngularComponent implements OnInit,
 
   /** Find the language's extension by its name. Case insensitive. */
   private _findLanguage(name: string) {
+    const wanted = name.toLowerCase();
     for (const lang of this.languages) {
       for (const alias of [lang.name, ...lang.alias]) {
-        if (name.toLowerCase() === alias.toLowerCase()) {
+        if (wanted === alias.toLowerCase()) {
           return lang;
         }
       }
     }
+
+    // Fall back to the file extensions CodeMirror lists for each language. Several names in common
+    // use are registered there rather than as an alias — 'jinja2', for instance, is one of Jinja's
+    // extensions (["j2", "jinja", "jinja2"]) while its only matchable name is "Jinja", so asking for
+    // the name everyone writes returned null and the editor silently lost syntax highlighting.
+    //
+    // Deliberately a FALLBACK and not part of the loop above: it runs only when nothing matched by
+    // name or alias, so it can turn a miss into a hit but can never change a match that already
+    // resolved. That matters because short extensions ('r', 'md', 'ts') would otherwise be able to
+    // outrank another language's real name.
+    for (const lang of this.languages) {
+      if (lang.extensions.some((ext) => wanted === ext.toLowerCase())) {
+        return lang;
+      }
+    }
+
     console.error('Language not found:', name);
     console.info('Supported language names:', this.languages.map((lang) => lang.name).join(', '));
     return null;

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
@@ -2877,8 +2877,22 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
       console.log(`[MarkComplete] Unregistered streaming callback for completed message ${conversationDetail.ID}`);
     }
 
-    // Remove task from active tasks if it exists
-    const task = this.activeTasks.getByConversationDetailId(conversationDetail.ID);
+    // Remove task from active tasks if it exists.
+    //
+    // Tasks are registered against the message that STARTED the turn — every activeTasks.add() call
+    // in this component passes the user message, the Sage delegation message or the status message
+    // as its conversationDetailId. This method, by contrast, is called with the AI REPLY. Those ids
+    // are never equal, so a direct lookup missed on every completion: the task was never removed
+    // here, and the "<agent> completed in <conversation>" toast below never fired for a user who had
+    // navigated away. (The task itself still disappeared, because conversation-chat-area separately
+    // sweeps tasks whose message has left 'In-Progress' — which is why this surfaced only as a
+    // missing notification plus a warning on every turn.)
+    //
+    // Every path already links the reply to its starter through ParentID, so fall back to that.
+    const task = this.activeTasks.getByConversationDetailId(conversationDetail.ID)
+      ?? (conversationDetail.ParentID
+            ? this.activeTasks.getByConversationDetailId(conversationDetail.ParentID)
+            : undefined);
     if (task) {
       console.log(`✅ Task found for message ${conversationDetail.ID} - removing from active tasks:`, {
         taskId: task.id,


### PR DESCRIPTION
## Summary

Two independent defects in the conversation UI, both found while tracing why the browser console prints a warning on every single agent turn. Neither is a big change — 11 lines of code between them — but each disables a feature that currently looks like it works.

## Changes

### The agent-completion notification has never fired

`MessageInputComponent.markMessageComplete()` looks up the active task by the AI reply's conversation detail ID:

```ts
const task = this.activeTasks.getByConversationDetailId(conversationDetail.ID);
```

But every `activeTasks.add()` call in that component registers the task against the message that **started** the turn — the user message, the Sage delegation message, or the status message — never the reply. Those IDs can't be equal, so the lookup misses on every completion, and the block it guards never runs:

```ts
MJNotificationService.Instance?.CreateSimpleNotification(
  `${task.agentName} completed in ${task.conversationName || 'conversation'}`, ...
```

That notification exists for the user who asks something and navigates away, which is exactly the case it never covers.

It didn't leak tasks, which is why this went unnoticed: `ConversationChatAreaComponent` separately sweeps tasks whose message has left `In-Progress`. So the only symptoms were the missing toast and `⚠️ No task found for completed message …` on every turn — a warning whose text ("task may have been removed prematurely or not added") sent me looking for a lifecycle race that isn't there.

Every path already links the reply to its starter through `ParentID`, so the lookup now falls back to it.

### Template editors have no syntax highlighting at all

`CodeEditorComponent._findLanguage()` matches only `name` and `alias`. Several names in common use are registered by CodeMirror as **extensions** instead — `jinja2` is one of Jinja's (`["j2", "jinja", "jinja2"]`) while its only matchable name is `"Jinja"`.

`template-editor.component` and `templates-form.component` both ask for `jinja2` (six call sites), so every prompt and template opened with `Language not found: jinja2` and fell back to no highlighting — on content that is Nunjucks, where `{{ }}` and `{% %}` are most of what you're reading.

Fixed in the editor rather than the six call sites, so it holds for any caller. Deliberately a **fallback** rather than part of the main loop: it runs only when nothing matched by name or alias, so it can turn a miss into a hit but can never change a match that already resolves. That matters because short extensions (`r`, `md`, `ts`) could otherwise outrank another language's real name.

## Testing

- `turbo build --filter=@memberjunction/ng-conversations --filter=@memberjunction/ng-code-editor` — 68/68 tasks green, including the full dependency chain.
- `MJCore` 2162 tests and `MJGlobal` 874 tests pass unchanged.
- Both were found and confirmed against a running app on 6.1.0-edge.1: the warning fires once per turn with the completion toast absent, and `Language not found: jinja2` appears on opening any AI Prompt form.

Neither change has a runtime dependency on the other; they're together because they came out of the same investigation and are each a few lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
