### PR TITLE
fix(conversations): make diagnostic logging opt-in instead of unconditional

### DIFF
--- a/.changeset/conversations-logging-opt-in.md
+++ b/.changeset/conversations-logging-opt-in.md
@@ -6,7 +6,7 @@ Make the conversation UI's diagnostic logging opt-in instead of unconditional.
 
 Reported from a deployed app: "the browser's dev console is absolutely packed with spam. Every single character a user types into the input box triggers a message in the console. This isn't something we can put out into the world since some users will bring that up and it looks terrible."
 
-Nothing is removed — twelve `console.*` calls become `LogStatusEx({ …, verboseOnly: true })`, so they are silent by default and still there for anyone tracing this code. In a browser, verbose is enabled by `window.MJ_VERBOSE = true`, `localStorage.setItem('MJ_VERBOSE','true')`, or a `?mj_verbose=true` URL parameter.
+Nothing is removed — twelve `console.*` calls become `LogStatusEx({ …, verboseOnly: true })`, so they are silent by default and still there for anyone tracing this code. In a browser, verbose is enabled by `window.MJ_VERBOSE = true`, `localStorage.setItem('MJ_VERBOSE','true')`, or a `?MJ_VERBOSE=true` URL parameter.
 
 **The per-keystroke pair**, which is the specific behaviour in the report: `ComposerDraftStore.SetDraft` logs on every character typed, and `conversation-chat-area` logs the same event again on the way in. Together they are the largest single source of console output in the app.
 

--- a/.changeset/conversations-logging-opt-in.md
+++ b/.changeset/conversations-logging-opt-in.md
@@ -1,0 +1,19 @@
+---
+"@memberjunction/ng-conversations": patch
+---
+
+Make the conversation UI's diagnostic logging opt-in instead of unconditional.
+
+Reported from a deployed app: "the browser's dev console is absolutely packed with spam. Every single character a user types into the input box triggers a message in the console. This isn't something we can put out into the world since some users will bring that up and it looks terrible."
+
+Nothing is removed — twelve `console.*` calls become `LogStatusEx({ …, verboseOnly: true })`, so they are silent by default and still there for anyone tracing this code. In a browser, verbose is enabled by `window.MJ_VERBOSE = true`, `localStorage.setItem('MJ_VERBOSE','true')`, or a `?mj_verbose=true` URL parameter.
+
+**The per-keystroke pair**, which is the specific behaviour in the report: `ComposerDraftStore.SetDraft` logs on every character typed, and `conversation-chat-area` logs the same event again on the way in. Together they are the largest single source of console output in the app.
+
+**Task-lifecycle narration**: `ActiveTasksService.add()` and `.remove()` each printed three lines per call (`➕ Task added:`, `📊 Total tasks:`, `🗂️ Conversation IDs with tasks:`), and `markMessageComplete` printed two more describing its own happy path.
+
+**One `console.warn` that was misdiagnosing itself.** `⚠️ No task found for completed message … - task may have been removed prematurely or not added` fired on every turn, by construction. A turn registers exactly one task, against whichever message its flow chose — `activeTasks.add()` is called with the user message, a Sage delegation message, a status message, or the agent response depending on the path — while `markMessageComplete` runs for *every* message in the turn that reaches `Complete` or `Error`. Most calls therefore find no task, which is the normal case and not the lifecycle race the text described. It is now verbose-only and reworded to say what it actually means.
+
+`console.error` is untouched — all 179 in the package.
+
+Scoped deliberately to the per-keystroke path and this instrumentation rather than converting the package's remaining `console.*` calls: raw `console` is the prevailing style across MJ's Angular packages (863 calls vs 105 `LogStatus`), so a wholesale conversion is a convention decision rather than a bug fix.

--- a/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/conversation/conversation-chat-area.component.ts
@@ -684,7 +684,8 @@ export class ConversationChatAreaComponent extends BaseAngularComponent implemen
 
   /** Live draft persistence (store debounces the server write). */
   public OnDraftStateChanged(conversationId: string | null, serialized: string): void {
-    console.log(`[Drafts] chat-area: draft change for '${conversationId ?? 'new'}' (${serialized.length} chars)`);
+    // verboseOnly: fires on every keystroke, same as the store's own SetDraft log below it.
+    LogStatusEx({ message: `[Drafts] chat-area: draft change for '${conversationId ?? 'new'}' (${serialized.length} chars)`, verboseOnly: true });
     this.draftStore.SetDraft(conversationId, serialized);
   }
 

--- a/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/message/message-input.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter, ViewChild, OnInit, OnDestroy, OnChanges, SimpleChanges, AfterViewInit } from '@angular/core';
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
-import { UserInfo, Metadata } from '@memberjunction/core';
+import { UserInfo, Metadata, LogStatusEx } from '@memberjunction/core';
 import { MJConversationDetailEntity, MJEnvironmentEntityExtended, ConversationEngine, UserInfoEngine, TaskGraphSubmitOperation, type TaskGraphSubmitInput } from '@memberjunction/core-entities';
 import { MJAIAgentEntityExtended, MJAIAgentRunEntityExtended, AppContextSnapshot } from "@memberjunction/ai-core-plus";
 import { DialogService } from '../../services/dialog.service';
@@ -2874,17 +2874,21 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
     if (callback) {
       this.streamingService.unregisterMessageCallback(conversationDetail.ID, callback);
       this.registeredCallbacks.delete(conversationDetail.ID);
-      console.log(`[MarkComplete] Unregistered streaming callback for completed message ${conversationDetail.ID}`);
+      LogStatusEx({ message: `[MarkComplete] Unregistered streaming callback for completed message ${conversationDetail.ID}`, verboseOnly: true });
     }
 
     // Remove task from active tasks if it exists
     const task = this.activeTasks.getByConversationDetailId(conversationDetail.ID);
     if (task) {
-      console.log(`✅ Task found for message ${conversationDetail.ID} - removing from active tasks:`, {
-        taskId: task.id,
-        agentName: task.agentName,
-        conversationId: task.conversationId,
-        conversationName: task.conversationName
+      LogStatusEx({
+        message: `✅ Task found for message ${conversationDetail.ID} - removing from active tasks:`,
+        additionalArgs: [{
+          taskId: task.id,
+          agentName: task.agentName,
+          conversationId: task.conversationId,
+          conversationName: task.conversationName
+        }],
+        verboseOnly: true,
       });
 
       this.activeTasks.remove(task.id);
@@ -2901,7 +2905,13 @@ export class MessageInputComponent extends BaseAngularComponent implements OnIni
         );
       }
     } else {
-      console.warn(`⚠️ No task found for completed message ${conversationDetail.ID} - task may have been removed prematurely or not added`);
+      // verboseOnly, and no longer a warning. A turn registers ONE task, against whichever message
+      // its flow chose — activeTasks.add() is called with the user message, a Sage delegation
+      // message, a status message or the agent response depending on the path — while this method
+      // runs for EVERY message in the turn reaching Complete or Error. Most calls therefore land
+      // here, so it is the normal case rather than the lifecycle race the old text described
+      // ("task may have been removed prematurely or not added"). Kept for tracing, off by default.
+      LogStatusEx({ message: `[MarkComplete] No task registered against completed message ${conversationDetail.ID} — expected for any message that did not start the turn`, verboseOnly: true });
     }
 
     // Emit completion event to parent so it can refresh agent run data

--- a/packages/Angular/Generic/conversations/src/lib/services/active-tasks.service.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/active-tasks.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { RunView, UserInfo, Metadata, IMetadataProvider } from '@memberjunction/core';
+import { RunView, UserInfo, Metadata, IMetadataProvider, LogStatusEx } from '@memberjunction/core';
 import { MJAIAgentRunEntity } from '@memberjunction/core-entities';
 import { ConversationEngine } from '@memberjunction/core-entities';
 
@@ -104,9 +104,11 @@ export class ActiveTasksService {
       this.updateConversationIdsSet();
     }
 
-    console.log(`➕ Task added:`, {id, conversationId: fullTask.conversationId, agentName: fullTask.agentName});
-    console.log(`📊 Total tasks:`, this._tasks$.value.size);
-    console.log(`🗂️ Conversation IDs with tasks:`, Array.from(this._conversationIdsWithTasks$.value));
+    // verboseOnly: three lines per add()/remove() is a lot of console for "a Map changed size", but
+    // it is genuinely useful when tracing task lifecycle, so it stays available rather than going.
+    LogStatusEx({ message: `➕ Task added:`, additionalArgs: [{id, conversationId: fullTask.conversationId, agentName: fullTask.agentName}], verboseOnly: true });
+    LogStatusEx({ message: `📊 Total tasks:`, additionalArgs: [this._tasks$.value.size], verboseOnly: true });
+    LogStatusEx({ message: `🗂️ Conversation IDs with tasks:`, additionalArgs: [Array.from(this._conversationIdsWithTasks$.value)], verboseOnly: true });
 
     return id;
   }
@@ -126,9 +128,9 @@ export class ActiveTasksService {
       this.updateConversationIdsSet();
     }
 
-    console.log(`➖ Task removed:`, {id, conversationId: task?.conversationId, agentName: task?.agentName});
-    console.log(`📊 Total tasks remaining:`, this._tasks$.value.size);
-    console.log(`🗂️ Conversation IDs with tasks:`, Array.from(this._conversationIdsWithTasks$.value));
+    LogStatusEx({ message: `➖ Task removed:`, additionalArgs: [{id, conversationId: task?.conversationId, agentName: task?.agentName}], verboseOnly: true });
+    LogStatusEx({ message: `📊 Total tasks remaining:`, additionalArgs: [this._tasks$.value.size], verboseOnly: true });
+    LogStatusEx({ message: `🗂️ Conversation IDs with tasks:`, additionalArgs: [Array.from(this._conversationIdsWithTasks$.value)], verboseOnly: true });
   }
 
   /**

--- a/packages/Angular/Generic/conversations/src/lib/services/composer-draft-store.ts
+++ b/packages/Angular/Generic/conversations/src/lib/services/composer-draft-store.ts
@@ -1,3 +1,4 @@
+import { LogStatusEx } from '@memberjunction/core';
 import { UserInfoEngine } from '@memberjunction/core-entities';
 
 /**
@@ -69,7 +70,9 @@ export class ComposerDraftStore {
             this.drafts.set(key, text);
             this.evictBeyondCap();
         }
-        console.log(`[Drafts] SetDraft('${key}'): ${text.length} chars → debounced persist (${this.drafts.size} draft(s))`);
+        // verboseOnly: this runs on EVERY character typed into the composer, so it is the single
+        // largest source of console noise in the app. Still available with verbose logging on.
+        LogStatusEx({ message: `[Drafts] SetDraft('${key}'): ${text.length} chars → debounced persist (${this.drafts.size} draft(s))`, verboseOnly: true });
         UserInfoEngine.Instance.SetSettingDebounced(ComposerDraftStore.COMPOSER_DRAFTS_SETTING, this.serialize());
     }
 
@@ -86,7 +89,7 @@ export class ComposerDraftStore {
         if (!this.loaded) {
             return; // nothing ever read or written
         }
-        console.log(`[Drafts] Flush: persisting ${this.drafts.size} draft(s) immediately`);
+        LogStatusEx({ message: `[Drafts] Flush: persisting ${this.drafts.size} draft(s) immediately`, verboseOnly: true });
         void UserInfoEngine.Instance.SetSetting(ComposerDraftStore.COMPOSER_DRAFTS_SETTING, this.serialize())
             .then((ok) => { if (!ok) console.warn('[Drafts] Flush: SetSetting reported failure'); })
             .catch((e) => console.warn('[Drafts] Flush: SetSetting threw', e));


### PR DESCRIPTION
> Rebased onto `next` and no longer stacked. It previously sat on #4168, which I withdrew — that PR claimed the agent-completion toast never fires, and it does; see the closing comment there.

## Summary

Reported from a deployed app:

> the browser's dev console is absolutely packed with spam. Every single character a user types into the input box triggers a message in the console. This isn't something we can put out into the world since some users will bring that up and it looks terrible.

**Nothing is removed.** Twelve `console.*` calls become `LogStatusEx({ …, verboseOnly: true })` — silent by default, still there for anyone tracing this code. In a browser, verbose comes from `window.MJ_VERBOSE = true`, `localStorage.setItem('MJ_VERBOSE','true')`, or a `?MJ_VERBOSE=true` URL parameter, all of which `IsVerboseLoggingEnabled` already supports.

5 files, +53 −18. `console.error` is untouched — all 179 in the package.

## What is gated

### The per-keystroke pair — the specific behaviour reported

`ComposerDraftStore.SetDraft` logs on **every character typed**, and `conversation-chat-area` logs the same event again on the way in. Together they are the largest single source of console output in the app.

### Task-lifecycle narration

`ActiveTasksService.add()` and `.remove()` each printed three lines per call:

```ts
console.log(`➕ Task added:`, {id, conversationId, agentName});
console.log(`📊 Total tasks:`, this._tasks$.value.size);
console.log(`🗂️ Conversation IDs with tasks:`, Array.from(...));
```

and `markMessageComplete` printed two more describing its own happy path.

### One `console.warn` that was misdiagnosing itself

`⚠️ No task found for completed message … - task may have been removed prematurely or not added` fired **on every turn, by construction.**

A turn registers exactly one task, against whichever message its flow chose:

| `activeTasks.add()` | keyed on |
|---|---|
| line 1699 | `conversationManagerMessage.ID` |
| line 2107 | `agentResponseMessage.ID` |
| line 2325 | `statusMessage.ID` |
| lines 2411, 2639 | `userMessage.ID` |

Meanwhile `markMessageComplete` runs for *every* message in the turn that reaches `Complete` or `Error` — including the user message, via fifteen `updateConversationDetail(userMessage, …, \'Complete\')` call sites. So most calls find no task, and that is the normal case rather than a lifecycle race.

It is now verbose-only and reworded to say what it means: *"No task registered against completed message … — expected for any message that did not start the turn."*

## Scope, and what I deliberately did not do

The obvious larger change is routing this package's remaining `console.*` through `LogStatus`. I measured before proposing it, and the numbers argue against doing it here:

| | raw `console.*` | `LogStatus` |
|---|---|---|
| all MJ Angular packages | **863** | 105 |

Several use `LogStatus` zero times (`ai-test-harness` 65:0, `react` 53:0, `file-storage` 48:0), and there is no guidance in `CLAUDE.md` either way. So raw `console` is the prevailing style, and `ng-conversations` is not an outlier — it is the largest surface, which is why it is the loudest.

Converting 216 calls in this one package would make it the only Angular package following a different rule. That is a convention decision for a maintainer, not something to land as a bug fix. Happy to do it — it is mechanical — but it should be a deliberate call across the Angular layer.

## Testing

`turbo build --filter=@memberjunction/ng-conversations` — 68/68 tasks green. `npm run check:changeset` and `packages/Standards/bin/run.js check` both pass. Verified every original log message still exists in the source and that `console.error` counts are unchanged in every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

