### PR TITLE
fix(code-editor): fall back to file extensions when resolving a language by name

### DIFF
--- a/.changeset/fix-code-editor-language-by-extension.md
+++ b/.changeset/fix-code-editor-language-by-extension.md
@@ -7,3 +7,5 @@ Resolve a language by its file extension when the name does not match, restoring
 `_findLanguage` matched only `name` and `alias`. Several names in common use are registered by CodeMirror as extensions instead — `jinja2` is one of Jinja's (`["j2", "jinja", "jinja2"]`) while its only matchable name is `"Jinja"`. Core-entity-forms' template editors ask for `jinja2` at six call sites, so every prompt and template opened with `Language not found: jinja2` and no highlighting at all — on content that is Nunjucks, where `{{ }}` and `{% %}` are most of what you are reading.
 
 Deliberately a fallback rather than part of the main loop: it runs only when nothing matched by name or alias, so it can turn a miss into a hit but can never change a match that already resolved. That matters because short extensions (`r`, `md`, `ts`) could otherwise outrank another language's real name.
+
+Covered by `ng-code-editor.language.dom.test.ts`, which pins that ordering (`r` resolves to R and `html` to HTML, both of which also appear among other languages' extensions) alongside the `jinja2` case itself.

--- a/.changeset/fix-code-editor-language-by-extension.md
+++ b/.changeset/fix-code-editor-language-by-extension.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/ng-code-editor": patch
+---
+
+Resolve a language by its file extension when the name does not match, restoring syntax highlighting for template editors.
+
+`_findLanguage` matched only `name` and `alias`. Several names in common use are registered by CodeMirror as extensions instead — `jinja2` is one of Jinja's (`["j2", "jinja", "jinja2"]`) while its only matchable name is `"Jinja"`. Core-entity-forms' template editors ask for `jinja2` at six call sites, so every prompt and template opened with `Language not found: jinja2` and no highlighting at all — on content that is Nunjucks, where `{{ }}` and `{% %}` are most of what you are reading.
+
+Deliberately a fallback rather than part of the main loop: it runs only when nothing matched by name or alias, so it can turn a miss into a hit but can never change a match that already resolved. That matters because short extensions (`r`, `md`, `ts`) could otherwise outrank another language's real name.

--- a/packages/Angular/Generic/code-editor/src/lib/ng-code-editor.component.ts
+++ b/packages/Angular/Generic/code-editor/src/lib/ng-code-editor.component.ts
@@ -716,13 +716,30 @@ export class CodeEditorComponent extends BaseAngularComponent implements OnInit,
 
   /** Find the language's extension by its name. Case insensitive. */
   private _findLanguage(name: string) {
+    const wanted = name.toLowerCase();
     for (const lang of this.languages) {
       for (const alias of [lang.name, ...lang.alias]) {
-        if (name.toLowerCase() === alias.toLowerCase()) {
+        if (wanted === alias.toLowerCase()) {
           return lang;
         }
       }
     }
+
+    // Fall back to the file extensions CodeMirror lists for each language. Several names in common
+    // use are registered there rather than as an alias — 'jinja2', for instance, is one of Jinja's
+    // extensions (["j2", "jinja", "jinja2"]) while its only matchable name is "Jinja", so asking for
+    // the name everyone writes returned null and the editor silently lost syntax highlighting.
+    //
+    // Deliberately a FALLBACK and not part of the loop above: it runs only when nothing matched by
+    // name or alias, so it can turn a miss into a hit but can never change a match that already
+    // resolved. That matters because short extensions ('r', 'md', 'ts') would otherwise be able to
+    // outrank another language's real name.
+    for (const lang of this.languages) {
+      if (lang.extensions.some((ext) => wanted === ext.toLowerCase())) {
+        return lang;
+      }
+    }
+
     console.error('Language not found:', name);
     console.info('Supported language names:', this.languages.map((lang) => lang.name).join(', '));
     return null;

--- a/packages/Angular/Generic/code-editor/src/lib/ng-code-editor.language.dom.test.ts
+++ b/packages/Angular/Generic/code-editor/src/lib/ng-code-editor.language.dom.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { languages } from '@codemirror/language-data';
+import { CodeEditorComponent } from './ng-code-editor.component';
+
+/**
+ * Spec for CodeEditorComponent's language lookup.
+ *
+ * Called on the prototype against a stub `this`, because `_findLanguage` is pure over
+ * `this.languages` — no CodeMirror EditorView is constructed, which is what the toolbar spec next
+ * to this file has to mock ngOnInit to avoid. Lives under the DOM preset rather than __tests__
+ * because importing the component class needs the Angular compile (see vitest.config.ts).
+ */
+const find = (name: string) =>
+  (CodeEditorComponent.prototype as unknown as { _findLanguage(n: string): { name: string } | null })
+    ._findLanguage.call({ languages }, name);
+
+describe('CodeEditorComponent._findLanguage', () => {
+  it('resolves a name that CodeMirror registers only as a file extension', () => {
+    // 'jinja2' is one of Jinja's extensions (["j2","jinja","jinja2"]) and its only name is "Jinja".
+    // core-entity-forms' template editors ask for 'jinja2', which matched nothing before.
+    expect(find('jinja2')?.name).toBe('Jinja');
+  });
+
+  it('resolves by name, case-insensitively', () => {
+    expect(find('Jinja')?.name).toBe('Jinja');
+    expect(find('TYPESCRIPT')?.name).toBe('TypeScript');
+  });
+
+  it('lets a name outrank an extension, never the other way round', () => {
+    // The ordering guarantee behind making extensions a FALLBACK: a string that is one language's
+    // name must resolve to it even when it also appears among some other language's extensions.
+    expect(find('r')?.name).toBe('R');
+    expect(find('html')?.name).toBe('HTML');
+  });
+
+  it('returns null when nothing matches by name, alias or extension', () => {
+    expect(find('definitely-not-a-language')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`CodeEditorComponent._findLanguage()` matches only `name` and `alias`:

```ts
for (const lang of this.languages) {
  for (const alias of [lang.name, ...lang.alias]) {
    if (name.toLowerCase() === alias.toLowerCase()) return lang;
  }
}
console.error('Language not found:', name);
```

Several names in common use are registered by CodeMirror as **extensions** instead. `jinja2` is one of Jinja's — the entry is `name: "Jinja", extensions: ["j2", "jinja", "jinja2"]`, with no alias — so `"Jinja"` is the only string that matches.

`template-editor.component` and `templates-form.component` both ask for `jinja2`, at six call sites between them. The result is that **every prompt and template in the Explorer forms opens with no syntax highlighting at all**, and a `Language not found: jinja2` error in the console. That content is Nunjucks, where `{{ }}` and `{% %}` are most of what you're reading.

## The change

An extensions pass, after the existing name/alias loop:

```ts
for (const lang of this.languages) {
  if (lang.extensions.some((ext) => wanted === ext.toLowerCase())) return lang;
}
```

Fixed in the editor rather than at the six call sites, so it holds for any caller asking by a name CodeMirror happens to file under extensions.

Deliberately a **fallback** and not part of the main loop. It runs only when nothing matched by name or alias, so it can turn a miss into a hit but can never change a match that already resolves. That ordering matters: short extensions like `r`, `md` and `ts` would otherwise be able to outrank another language's real name.

## Blast radius

`jinja2` is the **only** language name MJ requests whose resolution changes. Checked every value handed to `mj-code-editor` against `@codemirror/language-data`:

| requested | resolves today | after this change |
|---|---|---|
| `jinja2` | **nothing** | Jinja, via extension |
| `html`, `javascript`, `typescript`, `sql`, `python`, `json`, `markdown`, `css`, `yaml` | name/alias | unchanged — the first loop still wins |

So for everything already working this is a no-op, and the fallback is reached only where the editor currently gives up.

## Testing

`turbo build --filter=@memberjunction/ng-code-editor` — 12/12 tasks green.

Verified against `@codemirror/language-data` that `jinja2` appears in `extensions` and not in `name` or `alias`, which is why the current lookup can't reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
