### PR TITLE
fix(open-app): report which migration failed and why, not just "Transaction has been aborted"

### DIFF
--- a/.changeset/open-app-migration-failure-diagnostics.md
+++ b/.changeset/open-app-migration-failure-diagnostics.md
@@ -1,0 +1,38 @@
+---
+"@memberjunction/open-app-engine": patch
+---
+
+Report WHICH Open App migration failed and WHY, instead of a bare `Transaction has been aborted.`
+
+`RunAppMigrations` surfaced only Skyway's run-level `ErrorMessage`, so a real migration failure
+reached the caller as the whole of:
+
+```
+Migration failed for schema '__mj_BizAppsContracts': Transaction has been aborted.
+```
+
+No filename, no SQL error, no object name. The actual cause had to be found by extracting the
+baseline and running it by hand — `Msg 1767: Foreign key 'FK_ContractLine_Product' references
+invalid table '__mj_BizAppsOrders.Product'.`
+
+Every one of those facts was already present on the failing `Details[]` entry Skyway returns: it
+attaches the script name, the failed batch's number and line range, how many batches committed
+first, and the driver error as `cause`. This module's minimal structural typing of the Skyway
+result omitted the per-migration `Error` field entirely, so all of it was discarded. The same
+message is now built for a failure Skyway *throws* (a `MigrationExecutionError` carries the same
+detail) rather than flattening it to `error.message`.
+
+The message above now reads:
+
+```
+Migration failed for schema '__mj_BizAppsContracts' in B202608040001__v0.1.x__Baseline.sql,
+at batch 2 of 253, lines 50-71, 1 batch(es) succeeded first: Migration execution failed
+— caused by: Foreign key 'FK_ContractLine_Product' references invalid table '__mj_BizAppsOrders.Product'.
+```
+
+Degrades in steps rather than all at once: no batch detail still names the script, no failing
+detail falls back to the run-level message, and neither says so explicitly instead of emitting
+`undefined`. The new `DescribeMigrationFailure` export is pure, so it is covered without a
+database.
+
+Addresses item 3 of #3975. Behaviour on success is unchanged; this touches the failure path only.

--- a/packages/OpenApp/Engine/src/__tests__/migration-runner-failure-diagnostics.test.ts
+++ b/packages/OpenApp/Engine/src/__tests__/migration-runner-failure-diagnostics.test.ts
@@ -1,0 +1,217 @@
+/**
+ * A failed Open App migration must say WHICH migration failed and WHY.
+ *
+ * The regression this guards (MJ#3975): `RunAppMigrations` reported only Skyway's
+ * run-level `ErrorMessage`, so a real failure reached the operator as the whole of
+ *
+ *     Migration failed for schema '__mj_BizAppsContracts': Transaction has been aborted.
+ *
+ * — no filename, no SQL error, no object name. The cause was found only by extracting
+ * the baseline and running it by hand:
+ *
+ *     Msg 1767: Foreign key 'FK_ContractLine_Product' references invalid table '__mj_BizAppsOrders.Product'.
+ *
+ * Every one of those facts was already on the failing `Details[]` entry that Skyway
+ * returned. These tests assert we surface them, and — just as importantly — that the
+ * describer degrades in steps when Skyway supplies less, rather than regressing to
+ * `undefined` or to a bare `[object Object]`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/** Shapes a `MigrationExecutionError` the way skyway-core builds one. */
+interface FailureFixture {
+    Success: boolean;
+    MigrationsApplied: number;
+    ErrorMessage?: string;
+    Details: { Success: boolean; Migration: { Filename: string }; Error?: unknown }[];
+}
+
+/** What the mocked Skyway returns; each test sets this before calling. */
+const behaviour = vi.hoisted(() => ({
+    result: null as FailureFixture | null,
+    thrown: null as unknown,
+}));
+
+vi.mock('@memberjunction/skyway-core', () => ({
+    Skyway: class {
+        constructor(_config: unknown) {
+            /* no-op */
+        }
+        async Migrate(): Promise<FailureFixture> {
+            if (behaviour.thrown !== null) {
+                throw behaviour.thrown;
+            }
+            return behaviour.result!;
+        }
+        async Close(): Promise<void> {
+            /* no-op */
+        }
+    },
+}));
+
+vi.mock('@memberjunction/skyway-sqlserver', () => ({
+    SqlServerProvider: class {
+        constructor(_config: unknown) {
+            /* no-op */
+        }
+    },
+}));
+
+import { DescribeMigrationFailure, RunAppMigrations, type SkywayDatabaseConfig } from '../install/migration-runner.js';
+
+const dbConfig: SkywayDatabaseConfig = {
+    Host: 'localhost',
+    Port: 1433,
+    Database: 'MJ_TEST',
+    User: 'sa',
+    Password: 'pw',
+};
+
+/**
+ * The real failure from MJ#3975, reconstructed: skyway's run-level message is the
+ * useless one, and everything actionable hangs off the failing detail.
+ */
+function contractsFailure(): FailureFixture {
+    const driverError = new Error(
+        "Foreign key 'FK_ContractLine_Product' references invalid table '__mj_BizAppsOrders.Product'."
+    );
+    const executionError = Object.assign(new Error('Migration execution failed'), {
+        Script: 'B202608040001__v0.1.x__Baseline.sql',
+        Version: null,
+        BatchInfo: { BatchNumber: 2, TotalBatches: 253, StartLine: 50, EndLine: 71, SucceededBatches: 1 },
+        cause: driverError,
+    });
+    return {
+        Success: false,
+        MigrationsApplied: 0,
+        ErrorMessage: 'Transaction has been aborted.',
+        Details: [
+            { Success: false, Migration: { Filename: 'B202608040001__v0.1.x__Baseline.sql' }, Error: executionError },
+        ],
+    };
+}
+
+describe('DescribeMigrationFailure', () => {
+    it('names the schema, the script, the batch, the line range and the driver error', () => {
+        const message = DescribeMigrationFailure('__mj_BizAppsContracts', contractsFailure());
+
+        expect(message).toContain("__mj_BizAppsContracts");
+        expect(message).toContain('B202608040001__v0.1.x__Baseline.sql');
+        expect(message).toContain('batch 2 of 253');
+        expect(message).toContain('lines 50-71');
+        expect(message).toContain('1 batch(es) succeeded first');
+        expect(message).toContain("FK_ContractLine_Product");
+        expect(message).toContain("__mj_BizAppsOrders.Product");
+    });
+
+    it('does not let the vague run-level message stand in for the real cause', () => {
+        // The old behaviour was this string and nothing else. It may not be the only
+        // thing reported now — that is the whole point of the fix.
+        const message = DescribeMigrationFailure('__mj_BizAppsContracts', contractsFailure());
+        expect(message).not.toBe("Migration failed for schema '__mj_BizAppsContracts': Transaction has been aborted.");
+    });
+
+    it('falls back to the run-level message when there is no failing detail', () => {
+        const message = DescribeMigrationFailure('app_schema', {
+            Success: false,
+            MigrationsApplied: 0,
+            ErrorMessage: 'checksum mismatch on V202601010000__init.sql',
+            Details: [],
+        });
+        expect(message).toBe("Migration failed for schema 'app_schema': checksum mismatch on V202601010000__init.sql");
+    });
+
+    it('still names the script when skyway reports a failure with no batch detail', () => {
+        const message = DescribeMigrationFailure('app_schema', {
+            Success: false,
+            MigrationsApplied: 0,
+            ErrorMessage: 'Transaction has been aborted.',
+            Details: [{ Success: false, Migration: { Filename: 'V202601010000__init.sql' } }],
+        });
+        expect(message).toContain('in V202601010000__init.sql');
+        expect(message).toContain('Transaction has been aborted.');
+        expect(message).not.toContain('batch');
+    });
+
+    it('says so explicitly rather than emitting undefined when nothing is reported', () => {
+        const message = DescribeMigrationFailure('app_schema', {
+            Success: false,
+            MigrationsApplied: 0,
+            Details: [],
+        });
+        expect(message).toContain('no error detail was reported');
+        expect(message).not.toContain('undefined');
+    });
+
+    it('walks the whole cause chain, innermost last', () => {
+        const inner = new Error('Msg 1767: references invalid table');
+        const middle = Object.assign(new Error('batch failed'), { cause: inner });
+        const outer = Object.assign(new Error('Migration execution failed'), {
+            Script: 'V1__x.sql',
+            cause: middle,
+        });
+        const message = DescribeMigrationFailure('s', undefined, outer);
+
+        expect(message.indexOf('Migration execution failed')).toBeLessThan(message.indexOf('batch failed'));
+        expect(message.indexOf('batch failed')).toBeLessThan(message.indexOf('Msg 1767'));
+    });
+
+    it('survives a self-referential cause chain', () => {
+        const loop = new Error('round and round') as Error & { cause?: unknown };
+        loop.cause = loop;
+        expect(DescribeMigrationFailure('s', undefined, loop)).toContain('round and round');
+    });
+});
+
+describe('RunAppMigrations — the described failure reaches the caller', () => {
+    beforeEach(() => {
+        behaviour.result = null;
+        behaviour.thrown = null;
+    });
+
+    it('returns the located message when Skyway RETURNS a failure', async () => {
+        behaviour.result = contractsFailure();
+
+        const result = await RunAppMigrations({
+            MigrationsDir: '/tmp/migrations',
+            SchemaName: '__mj_BizAppsContracts',
+            DatabaseConfig: dbConfig,
+        });
+
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toContain('B202608040001__v0.1.x__Baseline.sql');
+        expect(result.ErrorMessage).toContain('FK_ContractLine_Product');
+    });
+
+    it('keeps the script and cause when Skyway THROWS instead of returning', async () => {
+        behaviour.thrown = Object.assign(new Error('Migration execution failed'), {
+            Script: 'V202601010000__init.sql',
+            BatchInfo: { BatchNumber: 7, TotalBatches: 9 },
+            cause: new Error("Invalid column name 'Configuration'."),
+        });
+
+        const result = await RunAppMigrations({
+            MigrationsDir: '/tmp/migrations',
+            SchemaName: 'app_schema',
+            DatabaseConfig: dbConfig,
+        });
+
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toContain('V202601010000__init.sql');
+        expect(result.ErrorMessage).toContain('batch 7 of 9');
+        expect(result.ErrorMessage).toContain("Invalid column name 'Configuration'.");
+    });
+
+    it('does not stringify a non-Error throw into [object Object]', async () => {
+        behaviour.thrown = { weird: true };
+
+        const result = await RunAppMigrations({
+            MigrationsDir: '/tmp/migrations',
+            SchemaName: 'app_schema',
+            DatabaseConfig: dbConfig,
+        });
+
+        expect(result.Success).toBe(false);
+        expect(result.ErrorMessage).toContain("Migration failed for schema 'app_schema'");
+    });
+});

--- a/packages/OpenApp/Engine/src/install/migration-runner.ts
+++ b/packages/OpenApp/Engine/src/install/migration-runner.ts
@@ -176,7 +176,7 @@ export type FlywayDatabaseConfig = SkywayDatabaseConfig;
  */
 function CauseChainMessages(error: unknown): string[] {
     const messages: string[] = [];
-    const seen = new Set<unknown>();
+    const seen = new Set<Error>();
     let current: unknown = error;
     while (current instanceof Error && !seen.has(current)) {
         seen.add(current);
@@ -184,7 +184,7 @@ function CauseChainMessages(error: unknown): string[] {
         if (message.length > 0 && !messages.includes(message)) {
             messages.push(message);
         }
-        current = (current as { cause?: unknown }).cause;
+        current = current.cause;
     }
     return messages;
 }

--- a/packages/OpenApp/Engine/src/install/migration-runner.ts
+++ b/packages/OpenApp/Engine/src/install/migration-runner.ts
@@ -43,14 +43,49 @@ interface SkywayConfig {
     Provider?: unknown;
 }
 
+/**
+ * Details about the SQL batch Skyway was executing when a migration failed
+ * (`FailedBatchInfo` in `@memberjunction/skyway-core`). Structural, so this module
+ * still compiles without the optional skyway packages installed.
+ */
+interface SkywayFailedBatchInfo {
+    BatchNumber?: number;
+    TotalBatches?: number;
+    StartLine?: number;
+    EndLine?: number;
+    SucceededBatches?: number;
+}
+
+/**
+ * The fields of skyway's `MigrationExecutionError` we surface. Skyway attaches the
+ * script name, the failed batch's position, and the driver error as `cause` — none of
+ * which are present on the run-level `ErrorMessage`.
+ */
+interface SkywayMigrationExecutionError extends Error {
+    Script?: string;
+    Version?: string | null;
+    BatchInfo?: SkywayFailedBatchInfo;
+}
+
+/** One migration's execution result (`MigrationExecutionResult` in skyway-core). */
+interface SkywayMigrationDetail {
+    Success: boolean;
+    Migration: { Filename: string };
+    /** Populated only on failure; typically a `MigrationExecutionError`. */
+    Error?: unknown;
+}
+
+/** The run-level result of `Skyway.Migrate()`. */
+interface SkywayMigrateResult {
+    Success: boolean;
+    MigrationsApplied: number;
+    ErrorMessage?: string;
+    Details: SkywayMigrationDetail[];
+}
+
 /** Minimal interface for the Skyway instance returned at runtime. */
 interface SkywayInstance {
-    Migrate(): Promise<{
-        Success: boolean;
-        MigrationsApplied: number;
-        ErrorMessage?: string;
-        Details: { Success: boolean; Migration: { Filename: string } }[];
-    }>;
+    Migrate(): Promise<SkywayMigrateResult>;
     Close(): Promise<void>;
 }
 
@@ -130,6 +165,91 @@ export interface SkywayDatabaseConfig {
  * @deprecated Use SkywayDatabaseConfig instead
  */
 export type FlywayDatabaseConfig = SkywayDatabaseConfig;
+
+/**
+ * Reads the `cause` chain off an error, innermost last.
+ *
+ * Skyway wraps the driver's error: a SQL Server failure arrives as a
+ * `MigrationExecutionError` whose `cause` is the `mssql`/`tedious` error carrying the
+ * actual `Msg NNNN` text. Reporting only the outer message is how a foreign-key
+ * failure reaches the operator as `Transaction has been aborted.`
+ */
+function CauseChainMessages(error: unknown): string[] {
+    const messages: string[] = [];
+    const seen = new Set<unknown>();
+    let current: unknown = error;
+    while (current instanceof Error && !seen.has(current)) {
+        seen.add(current);
+        const message = current.message.trim();
+        if (message.length > 0 && !messages.includes(message)) {
+            messages.push(message);
+        }
+        current = (current as { cause?: unknown }).cause;
+    }
+    return messages;
+}
+
+/**
+ * Builds the operator-facing message for a failed migration run.
+ *
+ * WHY THIS EXISTS. Skyway already knows everything useful about a failure — which
+ * script, which batch of how many, the line range, how many batches committed first,
+ * and the driver error underneath — and hands it over on the failing
+ * `Details[]` entry. The run-level `ErrorMessage` carries none of that, and under
+ * `per-run` transaction mode it is frequently just `Transaction has been aborted.`
+ * Reporting only the run-level string is why an Open App migration failure could
+ * arrive as one context-free sentence: no filename, no SQL error, no object name
+ * (MJ#3975). Everything below is information Skyway supplied and this module used to
+ * discard.
+ *
+ * Degrades in steps rather than all at once: with no failing detail it falls back to
+ * the run-level message, and with neither it says so explicitly instead of emitting
+ * `undefined`.
+ *
+ * Pure — no I/O, so it is unit-testable without a database.
+ *
+ * @param schemaName the app schema the run targeted, for the message prefix
+ * @param result     the run-level result, whose `Details` locate the failure
+ * @param thrown     an error thrown out of `Migrate()` instead of returned, if any
+ */
+export function DescribeMigrationFailure(schemaName: string, result?: SkywayMigrateResult, thrown?: unknown): string {
+    const prefix = `Migration failed for schema '${schemaName}'`;
+    const failed = result?.Details?.find((detail) => !detail.Success);
+    const detailError = (failed?.Error ?? thrown) as SkywayMigrationExecutionError | undefined;
+
+    // Prefer the script skyway names on the error, then the failing detail's filename:
+    // a migration can fail before it becomes a Details entry (resolution, checksum).
+    const script = detailError?.Script ?? failed?.Migration?.Filename;
+
+    const parts: string[] = [];
+    if (script) {
+        parts.push(`in ${script}`);
+    }
+
+    const batch = detailError?.BatchInfo;
+    if (batch?.BatchNumber !== undefined) {
+        const ofTotal = batch.TotalBatches !== undefined ? ` of ${batch.TotalBatches}` : '';
+        const lines =
+            batch.StartLine !== undefined && batch.EndLine !== undefined
+                ? `, lines ${batch.StartLine}-${batch.EndLine}`
+                : '';
+        parts.push(`at batch ${batch.BatchNumber}${ofTotal}${lines}`);
+    }
+
+    // The count of batches that committed before the failure is the difference between
+    // "nothing ran" and "the schema is half-built", which decides whether a retry is safe.
+    if (batch?.SucceededBatches !== undefined) {
+        parts.push(`${batch.SucceededBatches} batch(es) succeeded first`);
+    }
+
+    // The driver error last, so the innermost `Msg NNNN` is what the eye lands on. The
+    // run-level message is a fallback, not an addition — it is usually the vaguest of them.
+    const causes = CauseChainMessages(detailError);
+    const detailText = causes.length > 0 ? causes.join(' — caused by: ') : result?.ErrorMessage?.trim();
+
+    const located = parts.length > 0 ? ` ${parts.join(', ')}` : '';
+    return `${prefix}${located}: ${detailText && detailText.length > 0 ? detailText : 'no error detail was reported by the migration engine'}`;
+}
 
 /**
  * Result of running migrations.
@@ -229,18 +349,21 @@ export async function RunAppMigrations(options: MigrationRunOptions): Promise<Mi
             Success: result.Success,
             MigrationsApplied: result.MigrationsApplied,
             AppliedFiles: appliedFiles,
-            ErrorMessage: result.Success
-                ? undefined
-                : `Migration failed for schema '${SchemaName}': ${result.ErrorMessage ?? 'unknown error'}`,
+            ErrorMessage: result.Success ? undefined : DescribeMigrationFailure(SchemaName, result),
         };
     }
     catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
+        // A throw out of Migrate() can still be a MigrationExecutionError carrying the
+        // script and batch, so it goes through the same describer rather than being
+        // flattened to `error.message`.
         return {
             Success: false,
             MigrationsApplied: 0,
             AppliedFiles: [],
-            ErrorMessage: `Migration failed for schema '${SchemaName}': ${message}`
+            ErrorMessage:
+                error instanceof Error
+                    ? DescribeMigrationFailure(SchemaName, undefined, error)
+                    : `Migration failed for schema '${SchemaName}': ${String(error)}`,
         };
     }
     finally {


### PR DESCRIPTION
Addresses **item 3 of #3975**.

## The problem

`RunAppMigrations` surfaced only Skyway's run-level `ErrorMessage`, so a real Open App migration failure reached the caller as the whole of:

```
Migration failed for schema '__mj_BizAppsContracts': Transaction has been aborted.
```

No filename, no SQL error, no object name. Under `per-run` transaction mode that string is frequently all Skyway sets at the run level. Finding the actual cause meant extracting the app's baseline and running it by hand, which produced:

```
Msg 1767: Foreign key 'FK_ContractLine_Product' references invalid table '__mj_BizAppsOrders.Product'.
Msg 1750: Could not create constraint or index. See previous errors.
```

## Why it happened

**Skyway already reports all of this.** Its `MigrationExecutionResult` carries a per-migration `Error?: Error`, and on failure that is a `MigrationExecutionError` with `Script`, `BatchInfo` (`BatchNumber`, `TotalBatches`, `StartLine`, `EndLine`, `SucceededBatches`) and the driver error as `cause`. `plans/complete/skyway-improved-error-logging.md` is the work that put it there.

This module's minimal structural typing of the Skyway result omitted the `Error` field entirely:

```ts
Details: { Success: boolean; Migration: { Filename: string } }[];
```

so every one of those facts was discarded and only the vaguest available string was reported.

## The change

- Widens the local structural typing to reach the per-migration `Error`, `Script` and `BatchInfo`. Still structural, so the module continues to compile and load without the optional skyway packages installed.
- Adds `DescribeMigrationFailure(schemaName, result?, thrown?)` — pure, exported — which locates the failing `Details[]` entry and builds the message from what Skyway supplied, walking the `cause` chain innermost-last so the `Msg NNNN` is what the eye lands on.
- Routes the thrown path through the same describer. A `MigrationExecutionError` can arrive as a throw rather than a returned result, and was previously flattened to `error.message`.

That failure now reads:

```
Migration failed for schema '__mj_BizAppsContracts' in B202608040001__v0.1.x__Baseline.sql,
at batch 2 of 253, lines 50-71, 1 batch(es) succeeded first: Migration execution failed
— caused by: Foreign key 'FK_ContractLine_Product' references invalid table '__mj_BizAppsOrders.Product'.
```

## Degradation is deliberate

It gives up detail in steps rather than all at once, because Skyway supplies different amounts depending on how the failure arose:

| Skyway supplies | message |
|---|---|
| script + batch + cause | fully located, as above |
| failing detail, no batch info | still names the script, plus the run-level message |
| no failing detail (checksum, resolution) | falls back to the run-level message |
| nothing | says `no error detail was reported by the migration engine` — never `undefined` |
| a non-`Error` throw | still prefixed and schema-qualified, never `[object Object]` |

## Testing

`packages/OpenApp/Engine/src/__tests__/migration-runner-failure-diagnostics.test.ts` — 10 tests covering the real failure above, each rung of the degradation ladder, cause-chain ordering, a self-referential `cause` (guarded with a seen-set), and both the returned-failure and thrown paths through `RunAppMigrations`.

- New tests: **10 passed**
- Whole package: **393 passed, 30 files** — including the two existing `migration-runner` suites
- `pnpm --filter @memberjunction/open-app-engine... run build` clean

## Risk

Failure path only — no call site or signature changes, and success behaviour is untouched. `DescribeMigrationFailure` is a new export; nothing else in the module's surface changed.

## Not in scope

The other open items on #3975 are left alone: item 1 (permissions files executed for objects whose creation failed, so the GRANT error shadows the cause — narrower now that item 2 has landed). Items 2 and 4 are already fixed on `next`; I have updated #3975 to reflect that.

Draft because I would like a second opinion on one judgement call: the message is a single line and can get long when Skyway supplies everything. If a multi-line block is preferred for readability at the CLI, `DescribeMigrationFailure` is the only place that changes.
