### PR TITLE
fix(ng-base-forms): a date-only field is a calendar day, not an instant

### DIFF
--- a/.changeset/form-field-date-only-utc.md
+++ b/.changeset/form-field-date-only-utc.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-base-forms": patch
+---
+
+fix(ng-base-forms): a `date` column is a calendar day, not an instant. Read mode formatted date-only fields with a local-time formatter, so a stored 2026-11-20 rendered as 11/19/2026 for anyone west of Greenwich while edit mode showed the 20th. Date-only fields now render the stored day in the reader's locale format; `datetime` / `datetimeoffset` fields are unchanged and still render as local time.

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.dom.test.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.dom.test.ts
@@ -74,6 +74,8 @@ function makeWidgetEntityInfo(): EntityInfo {
       { ID: 'F3', Name: 'Description', Type: 'nvarchar', Length: 200, AllowsNull: true, AllowUpdateAPI: true },
       { ID: 'F4', Name: 'Quantity', Type: 'int', AllowsNull: true, AllowUpdateAPI: true },
       { ID: 'F5', Name: 'LaunchDate', Type: 'datetime', AllowsNull: true, AllowUpdateAPI: true },
+      // A DATE-ONLY column, deliberately beside the datetime above: the two must render differently.
+      { ID: 'F9', Name: 'EffectiveDate', Type: 'date', AllowsNull: true, AllowUpdateAPI: true },
       { ID: 'F6', Name: 'IsActive', Type: 'bit', AllowsNull: true, AllowUpdateAPI: true },
       {
         ID: 'F7',
@@ -351,4 +353,63 @@ describe('MjFormFieldComponent (DOM)', () => {
       expect(query(f, '.mj-fk-dropdown')).toBeNull();
     });
   });
+});
+
+describe('date-only fields are a calendar day, not an instant', () => {
+    /**
+     * READ AND EDIT MODE DISAGREED BY A DAY, on ordinary valid data.
+     *
+     * A `date` column arrives as UTC midnight. Read mode ran it through `toLocaleString()`, a
+     * LOCAL-time formatter, which subtracts the reader's offset and lands on the previous day for
+     * everyone west of Greenwich. Edit mode used `toISOString()` and was correct. So a stored
+     * 2026-11-20 showed as 11/19/2026 on the form and 2026-11-20 in the editor, same field.
+     *
+     * These tests PIN A TIMEZONE rather than trusting the runner's. A suite that happens to run in
+     * UTC cannot observe this bug at all, which is how it survived: every assertion passes at
+     * Greenwich and fails in New York.
+     */
+    const AT = (tz: string, fn: () => void) => {
+        const original = process.env.TZ;
+        process.env.TZ = tz;
+        try {
+            fn();
+        } finally {
+            process.env.TZ = original;
+        }
+    };
+
+    it('renders the stored day, not the previous one, west of Greenwich', () => {
+        AT('America/New_York', () => {
+            const w = makeWidget({ EffectiveDate: new Date('2026-11-20T00:00:00.000Z') });
+            const f = render({ Record: w, FieldName: 'EffectiveDate', Type: 'textbox' });
+            const shown = text(f, '.mj-forms-field-value');
+            expect(shown, `a stored 2026-11-20 must not render as the 19th (got ${shown})`).toContain('20');
+            expect(shown).not.toContain('19');
+        });
+    });
+
+    it('does not roll a January date back into the previous YEAR', () => {
+        AT('America/New_York', () => {
+            const w = makeWidget({ EffectiveDate: new Date('2026-01-01T00:00:00.000Z') });
+            const f = render({ Record: w, FieldName: 'EffectiveDate', Type: 'textbox' });
+            expect(text(f, '.mj-forms-field-value')).not.toContain('2025');
+        });
+    });
+
+    it('shows no time of day — a calendar day has none', () => {
+        AT('America/New_York', () => {
+            const w = makeWidget({ EffectiveDate: new Date('2026-11-20T00:00:00.000Z') });
+            const f = render({ Record: w, FieldName: 'EffectiveDate', Type: 'textbox' });
+            expect(text(f, '.mj-forms-field-value')).not.toMatch(/\d{1,2}:\d{2}/);
+        });
+    });
+
+    it('leaves a TIMESTAMP in local time, with its time — that one really is an instant', () => {
+        AT('America/New_York', () => {
+            const w = makeWidget({ LaunchDate: new Date('2026-11-20T22:30:00.000Z') });
+            const f = render({ Record: w, FieldName: 'LaunchDate', Type: 'textbox' });
+            const shown = text(f, '.mj-forms-field-value');
+            expect(shown, 'a datetime must keep local-time rendering').toMatch(/\d{1,2}:\d{2}/);
+        });
+    });
 });

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.ts
@@ -1882,10 +1882,42 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
   }
 
   /** Format a value for display */
+  /**
+   * Whether this field holds a DATE with no time, as opposed to a timestamp.
+   *
+   * The distinction decides which timezone the value may be rendered in, and getting it wrong
+   * moves the day. A `date` column has no time and no zone: it is a calendar day, and the only
+   * correct way to show it is in the zone it was written in. A `datetime`/`datetimeoffset` names
+   * an instant, and the correct way to show THAT is the reader's local zone.
+   */
+  private get IsDateOnlyField(): boolean {
+    return (this.FieldInfo?.Type ?? '').trim().toLowerCase() === 'date';
+  }
+
   FormatValue(): string {
     const val = this.Value;
     if (val === null || val === undefined) return '';
     if (val instanceof Date) {
+      /**
+       * A DATE-ONLY VALUE IS NOT AN INSTANT, AND toLocaleString() TREATS IT AS ONE.
+       *
+       * A `date` column arrives as UTC midnight. Passing that through a LOCAL-time formatter
+       * subtracts the reader's offset and lands on the previous day for everyone west of
+       * Greenwich: a stored 2026-11-20 rendered as `11/19/2026, 7:00:00 PM` in America/New_York,
+       * and 2026-01-01 rendered as `12/31/2025` — the wrong YEAR.
+       *
+       * The edit path does not have this bug: `DateInputValue` uses `toISOString()`, which is UTC.
+       * So the two modes DISAGREED — a rep opened a record and saw 19 November, clicked Edit and
+       * saw the 20th, on the same field, with no invalid data anywhere. Read mode was simply wrong.
+       *
+       * Pinning the timezone rather than switching to `toISOString()` keeps the reader's locale
+       * format (a US reader still sees 11/20/2026, a UK reader 20/11/2026) and changes only the
+       * zone the day is computed in. A TIMESTAMP is left exactly as it was: it names an instant,
+       * and local time is the right way to show one.
+       */
+      if (this.IsDateOnlyField) {
+        return val.toLocaleDateString(undefined, { timeZone: 'UTC' });
+      }
       return val.toLocaleString();
     }
     return String(val);


### PR DESCRIPTION
Read mode and edit mode disagree by a day, on ordinary valid data. No corruption, no invalid input.

## The defect

A `date` column has no time and no zone — it is a calendar day — and arrives as UTC midnight. `FormatValue()` renders it with `toLocaleString()`, a **local-time** formatter, which subtracts the reader's offset and lands on the previous day for everyone west of Greenwich.

Measured in `America/New_York`, executing this file's own source:

| stored (SQL `date`) | read mode showed | edit mode showed |
|---|---|---|
| `2026-11-20` | **11/19/2026, 7:00:00 PM** | 2026-11-20 |
| `2026-09-30` | **9/29/2026, 8:00:00 PM** | 2026-09-30 |
| `2026-01-01` | **12/31/2025, 7:00:00 PM** | 2026-01-01 |

The last one is the wrong **year**.

Edit mode was already correct — `DateInputValue` uses `toISOString()`. So a user opens a record and sees 19 November, clicks Edit, and sees the 20th. Same field, same session.

## The fix

`EntityFieldInfo.Type` already distinguishes the two cases, so the component can tell a calendar day from an instant:

- **`date`** → `toLocaleDateString(undefined, { timeZone: 'UTC' })`
- **`datetime` / `datetimeoffset`** → unchanged `toLocaleString()`

Pinning the timezone rather than switching to `toISOString()` keeps the reader's locale format — a US reader still sees `11/20/2026`, a UK reader `20/11/2026` — and changes only the zone the day is computed in. A timestamp names an instant, and local time with a time-of-day is the right way to show one.

## Why it survived

**The tests pin a timezone rather than trusting the runner's.** Every assertion here passes at Greenwich and fails in New York, so a UTC CI box could never observe this. That is why it shipped.

Four tests added; **three fail against the previous implementation**. The fourth asserts a timestamp still renders in local time *with* its time-of-day, so a future "fix" cannot drag instants into UTC while chasing this one.

Full `@memberjunction/ng-base-forms` suite: **328 passed / 26 files**.

## Not fixed here, deliberately

`new Date('2026-02-31')` rolls over to 3 March rather than failing, so an impossible date-shaped string displays as a different day. I wrote a round-trip guard in `DateInputValue` and **removed it**: `BaseEntity` coerces the value on `Set`, so the getter receives `2026-03-03` and the original text is already gone. The guard could never fire.

That belongs in the entity's type coercion, not in a form field, and deserves its own issue rather than an assertion that cannot execute.

## Provenance

Found while investigating `bc-aidp-next-golive#185`, which reported a related symptom against a BizApps Sales component that turns out to be retired. The live defect is here, in MJ, and affects every app that renders a date field.
