### PR TITLE
fix(sqlserver-dataprovider): InstanceConnectionString collapsed every connection to one identity

### DIFF
--- a/.changeset/fix-instance-connection-string.md
+++ b/.changeset/fix-instance-connection-string.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/sqlserver-dataprovider": patch
+---
+
+Fix InstanceConnectionString reading the private mssql `_config` member, which is a method in mssql v11+. Every `_config?.x` access returned undefined, so the getter degenerated to `mssql://localhost:1433/` for every connection. Anything keyed by this identity — most critically the shared Redis result caches (RunView/RunQuery/dataset) — collided across processes connected to entirely different databases, letting one process serve another process's cached rows. The getter now reads the public `config` property, restoring distinct per-connection identities.

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -608,15 +608,20 @@ export class SQLServerDataProvider
    * instanceName is only inserted if it is provided in the options
    */
   public get InstanceConnectionString(): string {
-    // For mssql, we need to access the pool's internal connection options
-    // Since mssql v11 doesn't expose config directly, we'll construct from what we know
+    // mssql exposes the pool's connection options as the public `config` property.
+    // Do NOT read the private `_config` member — in mssql v11+ it is a method, so
+    // every `_config?.x` access silently returned undefined and this getter
+    // degenerated to 'mssql://localhost:1433/' for every connection. Anything
+    // keyed by this string (e.g. shared Redis result caches) then collided
+    // across processes connected to entirely different databases.
     const pool = this._pool as any;
+    const config = pool.config;
     const options = {
       type: 'mssql',
-      host: pool._config?.server || 'localhost',
-      port: pool._config?.port || 1433,
-      instanceName: pool._config?.options?.instanceName ? '/' + pool._config.options.instanceName : '',
-      database: pool._config?.database || '',
+      host: config?.server || 'localhost',
+      port: config?.port || 1433,
+      instanceName: config?.options?.instanceName ? '/' + config.options.instanceName : '',
+      database: config?.database || '',
     };
     return options.type + '://' + options.host + ':' + options.port + options.instanceName + '/' + options.database;
   }

--- a/packages/SQLServerDataProvider/src/__tests__/instance-connection-string.test.ts
+++ b/packages/SQLServerDataProvider/src/__tests__/instance-connection-string.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for SQLServerDataProvider.InstanceConnectionString.
+ *
+ * This getter is the identity key for anything scoped per-connection — most
+ * critically the shared Redis result caches (RunView/RunQuery/dataset), whose
+ * keys embed it to keep results from different databases apart.
+ *
+ * Regression context: the getter used to read the pool's private `_config`
+ * member. In mssql v11+ `_config` is a method, so every `_config?.x` access
+ * returned undefined and the getter degenerated to 'mssql://localhost:1433/'
+ * for EVERY connection. Processes connected to different databases then
+ * collided on the same shared-cache keys (2026-09-02 Skip prod incident).
+ * The getter must read the public `config` property instead.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('mssql', async () => (await import('./helpers/mock-mssql')).createMockMssqlModule());
+
+import { SQLServerDataProvider } from '../SQLServerDataProvider';
+
+const instanceConnectionStringGetter = Object.getOwnPropertyDescriptor(
+  SQLServerDataProvider.prototype,
+  'InstanceConnectionString'
+)!.get!;
+
+function connectionStringFor(pool: unknown): string {
+  return instanceConnectionStringGetter.call({ _pool: pool });
+}
+
+describe('SQLServerDataProvider.InstanceConnectionString', () => {
+  it('builds the identity from the pool public config', () => {
+    const pool = { config: { server: 'db.example.com', port: 1433, database: 'MJProd' } };
+    expect(connectionStringFor(pool)).toBe('mssql://db.example.com:1433/MJProd');
+  });
+
+  it('includes the instance name when configured', () => {
+    const pool = {
+      config: { server: 'db.example.com', port: 1499, database: 'MJDev', options: { instanceName: 'SQL2022' } },
+    };
+    expect(connectionStringFor(pool)).toBe('mssql://db.example.com:1499/SQL2022/MJDev');
+  });
+
+  it('falls back to localhost defaults only when config carries no values', () => {
+    expect(connectionStringFor({ config: {} })).toBe('mssql://localhost:1433/');
+  });
+
+  it('does not read the private _config member (a method in mssql v11+)', () => {
+    // Mimics a real mssql v11+ pool: `config` is the public options object,
+    // `_config` is a function. Reading `_config` would degenerate to the
+    // localhost fallback and collapse every connection to one identity.
+    const pool = {
+      config: { server: 'prod-sql.database.windows.net', port: 1433, database: 'SkipProd' },
+      _config: () => ({ server: 'wrong', port: 0, database: 'wrong' }),
+    };
+    expect(connectionStringFor(pool)).toBe('mssql://prod-sql.database.windows.net:1433/SkipProd');
+    expect(connectionStringFor(pool)).not.toContain('localhost');
+  });
+
+  it('gives distinct identities to pools pointed at different databases', () => {
+    const a = connectionStringFor({ config: { server: 'host-a', port: 1433, database: 'DbA' } });
+    const b = connectionStringFor({ config: { server: 'host-b', port: 1433, database: 'DbB' } });
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary
- `InstanceConnectionString` read the pool's private `_config` member, which is a **method** in mssql v11+ — every `_config?.x` access silently returned `undefined`, so the getter degenerated to `mssql://localhost:1433/` for **every** connection, regardless of host or database.
- Everything keyed by this identity inherited the collision: shared Redis result caches (RunView/RunQuery/dataset) let processes connected to *different databases* read and write each other's cache entries, and engine instance caching collapsed to one slot. This was a root contributor to a 2026-09-02 production incident where a poisoned engine load served "No model-vendor candidates were available" on every request for 8 hours until a manual restart.
- Fix: read the public `config` property, which mssql has always set in the `ConnectionPool` constructor. Identities are now distinct per host/port/instance/database (e.g. `mssql://myhost:1433/MyDB`).
- Adds 5 regression tests, including one that mimics the real mssql v11+ pool shape (public `config` object + `_config` function) so a revert to `_config` fails the suite. Includes a patch changeset.

## Upgrade note for consumers
Previously written shared-cache keys carry the degenerate `mssql://localhost:1433/` suffix and become unreadable orphans after upgrading — flush shared Redis caches during rollout.

## Test plan
- [x] Unit: new `instance-connection-string.test.ts` (5 tests) + full package suite pass
- [x] Real driver: verified against mssql 12.7.0 — `_config` is a function, `config` carries server/port/database/instanceName
- [x] End-to-end: built at v5.51.2 with this fix, linked into a consuming app (Skip API) — all new shared-cache keys carry the real `mssql://host:1433/<db>` suffix and the cache-category registry tracks them (registry-based invalidation unaffected)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)