### PR TITLE
release-lines: register line 6.1 as the cycle #2 candidate

### DIFF
--- a/release-lines.json
+++ b/release-lines.json
@@ -65,6 +65,10 @@
         }
       },
       "scorecard": "certifications/5.51.0.md"
+    },
+    "6.1": {
+      "status": "candidate",
+      "candidateDate": "2026-09-11"
     }
   }
 }


### PR DESCRIPTION
Adds `lines["6.1"]` as `{ "status": "candidate", "candidateDate": "2026-09-11" }`.

This is the reviewed precondition for the candidate cut (#4205): status fields on `release-lines.json` are CODEOWNERS territory and never arrive by direct push, so the `cut-candidate` job appends only `newest` and `releases` afterwards and refuses to start unless this entry exists. The validator accepts the future date (`--mode pr` passes against `origin/next`).

Merge order: this PR first, then #4205, then dispatch the cut on Fri Sep 11. Merging this early is harmless: a candidate line with no releases is exactly what the schema describes until the cut runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
