### PR TITLE
perf(integration-engine): the hash-prefetch must bypass the RunView result cache

### DIFF
--- a/.changeset/prefetch-bypass-runview-cache.md
+++ b/.changeset/prefetch-bypass-runview-cache.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+The content-hash prefetch now bypasses the RunView result cache. Every prefetch queries that batch's own keys, so its cache fingerprint is unique and the cached result can never be hit again — with a result cache active, each batch deposited one dead entry and a long first sync grew the process by O(records processed). Measured in production: a full-history drain of ~500k records exhausted a default node heap and took the host down. The match lookups in the same path already bypass for correctness; the prefetch now bypasses for survival.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -5361,6 +5361,13 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 // 2x margin defended by nothing is not a guard. Same reasoning as baseEngine's own
                 // IgnoreMaxRows use, and this file documents the identical trap on the push side.
                 IgnoreMaxRows: true,
+                // Every prefetch carries THIS batch's keys, so its cache fingerprint is unique and
+                // the cached result can never be hit again — with a result cache active, each batch
+                // deposits one dead entry and a long first sync grows the process by O(records
+                // processed). Measured in production: a full-history drain (~500k records) exhausted
+                // a default node heap and took the host down. The match lookups in this same file
+                // already bypass for correctness; the prefetch must bypass for survival.
+                BypassCache: true,
             }, contextUser);
             if (!res.Success) return undefined;
             const Hashes = new Map<string, string>();

--- a/packages/Integration/engine/src/__tests__/PrefetchProvesAbsence.test.ts
+++ b/packages/Integration/engine/src/__tests__/PrefetchProvesAbsence.test.ts
@@ -179,4 +179,15 @@ describe('the prefetch is unbounded — its result is what absence proofs are ju
         await host.PrefetchContentHashes([created('x')], {});
         expect(lastRunViewParams.current?.['IgnoreMaxRows']).toBe(true);
     });
+
+    it('passes BypassCache so per-batch results never accumulate in a result cache', async () => {
+        // Every prefetch queries THIS batch's keys, so its cache fingerprint is unique and a
+        // cached result can never be hit again. With a result cache active, each batch deposits
+        // one dead entry — memory grows O(records processed) for the life of the process, and a
+        // full-history first sync (~500k records, measured) exhausts a default node heap. The
+        // match lookups already bypass for correctness; the prefetch bypasses for survival.
+        const host = makeHost([]);
+        await host.PrefetchContentHashes([created('x')], {});
+        expect(lastRunViewParams.current?.['BypassCache']).toBe(true);
+    });
 });


### PR DESCRIPTION
## The defect

`PrefetchContentHashes` issues one RunView per apply batch, filtered to **that batch's own keys**. Its cache fingerprint is therefore unique on every call — a cached result can never be hit again. With a result cache active, every batch deposits one permanently-dead cache entry, so process memory grows **O(records processed)** for the life of the process.

Measured consequence in production: a full-history first sync (~500k records, ~50 minutes in) exhausted a default node heap — event loop starved, health endpoint stopped answering entirely, SSM couldn't schedule a shell, and the host needed a hypervisor reboot. The apply pipeline itself is batch-scoped by design (prefetch map, MatchEngine, RecordMapBatch all die with their batch); this cache deposit was the accumulator.

## The fix

One flag: `BypassCache: true` on the prefetch RunView — exactly the flag the match lookups in this same path already pass (they bypass for correctness; the prefetch bypasses for survival). Comment carries the reasoning next to the existing `IgnoreMaxRows` guard it mirrors.

## Tests

Twin test beside the `IgnoreMaxRows` guard in `PrefetchProvesAbsence.test.ts`, using the suite's existing param-capture harness. **Mutation-verified**: removing the flag fails the new test; restoring it passes 12/12. Full package suite: no new failures vs clean HEAD baseline (identical pre-existing set on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)