### PR TITLE
fix(integration-engine): the empty-batch watchdog must see an unmoving cursor

### DIFF
--- a/.changeset/empty-batch-watchdog-cursor.md
+++ b/.changeset/empty-batch-watchdog-cursor.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/integration-engine": patch
+---
+
+The empty-batch watchdog now counts only empties at an UNMOVING position. A per-item fan-out connector legitimately returns long runs of empty batches while its cursor walks forward over sparse data; warning on those trained operators to dismiss the exact message a real stuck cursor would wear. The streak now requires the position tuple (watermark, afterKey, page, offset, cursor) to be unchanged across the empties — a stuck cursor, by definition, leaves the position where it was.

--- a/packages/Integration/engine/src/EmptyBatchWatchdog.ts
+++ b/packages/Integration/engine/src/EmptyBatchWatchdog.ts
@@ -1,0 +1,38 @@
+/**
+ * P3-D refinement: decides when a run of empty batches is WORTH WARNING ABOUT.
+ *
+ * A connector returning empty pages with HasMore=true forever would spin silently to the
+ * per-map batch cap; the original watchdog warned after N consecutive empties. But "empty"
+ * alone is the wrong signal: a per-item fan-out connector (one upstream call per parent
+ * record) legitimately returns long runs of empty batches while its position walks forward
+ * over sparse data. Counting those trained operators to ignore the warning — right up until
+ * a real stuck cursor arrived wearing the same message.
+ *
+ * A stuck cursor, by definition, leaves the position where it was. So the streak only counts
+ * empties whose position tuple (watermark, afterKey, page, offset, cursor) did not move.
+ */
+export class EmptyBatchWatchdog {
+    private streak = 0;
+    private lastEmptyPosition: string | null = null;
+
+    /**
+     * Observe one fetched batch. Returns the current stuck-empty streak length — the caller
+     * warns when it crosses its threshold. Movement (records, no-more, or an advanced
+     * position) resets the streak.
+     */
+    public Observe(recordCount: number, hasMore: boolean, position: ReadonlyArray<unknown>): number {
+        if (recordCount !== 0 || hasMore !== true) {
+            this.streak = 0;
+            this.lastEmptyPosition = null;
+            return 0;
+        }
+        const key = position.map(v => (v === undefined || v === null ? '' : String(v))).join('|');
+        if (key === this.lastEmptyPosition) {
+            this.streak++;
+        } else {
+            this.streak = 1;
+            this.lastEmptyPosition = key;
+        }
+        return this.streak;
+    }
+}

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -47,6 +47,7 @@ import { WatermarkService } from './WatermarkService.js';
 import { SyncLogger } from './SyncLogger.js';
 import { CONTENT_HASH_COLUMN, computeContentHash } from './ContentHash.js';
 import { RecordMapBatch } from './RecordMapBatch.js';
+import { EmptyBatchWatchdog } from './EmptyBatchWatchdog.js';
 import { buildContentHashPrefetchFilter, quoteTextLiteral } from './prefetchFilter.js';
 import { serializeKeyValue } from './KeySerialization.js';
 import { CUSTOM_OVERFLOW_COLUMN, reconcileOverflowValue, foldCustomKeyStats, type CustomKeyAccumulator } from './CustomOverflow.js';
@@ -2717,7 +2718,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         let watermarkFloorSaved: string | null = null; // §8a durability floor last persisted mid-run (null = none)
         let fetchGapCount = 0;            // CONSECUTIVE skipped pages (reset on any clean fetch)
         const MAX_FETCH_GAPS = 25;        // give up + hold the watermark if this many pages fail in a row (API down)
-        let consecutiveEmptyBatches = 0;  // P3-D: detect a connector that pages empty-but-HasMore forever
+        const emptyBatchWatchdog = new EmptyBatchWatchdog();  // P3-D: detect a STUCK empty-but-HasMore pager
         let oversizeBatchWarned = false;  // pagination rule: warn ONCE per object that the connector ignored BatchSize
         const MAX_BATCHES_PER_MAP = 5000;
         const EMPTY_BATCH_WARN_THRESHOLD = 5; // warn once after this many empty-but-HasMore batches in a row
@@ -3172,20 +3173,21 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             }
             // P3-D: a connector returning empty pages with HasMore=true would otherwise spin silently
             // to MAX_BATCHES_PER_MAP. Surface a structured warning once the empty streak crosses the
-            // threshold so the connector bug is visible, not buried.
-            if (batch.Records.length === 0 && batch.HasMore === true) {
-                consecutiveEmptyBatches++;
-                if (consecutiveEmptyBatches === EMPTY_BATCH_WARN_THRESHOLD) {
+            // threshold so the connector bug is visible, not buried. The watchdog only counts
+            // empties at an UNMOVING position — empty pages whose cursor advanced are ordinary
+            // pagination over sparse data (see EmptyBatchWatchdog).
+            {
+                const stuckStreak = emptyBatchWatchdog.Observe(batch.Records.length, batch.HasMore === true,
+                    [currentWatermark, currentAfterKey, currentPage, currentOffset, currentCursor]);
+                if (stuckStreak === EMPTY_BATCH_WARN_THRESHOLD) {
                     logger?.warning(
                         entityMap.ExternalObjectName ?? entityMap.ID,
                         'CONSECUTIVE_EMPTY_BATCHES',
-                        `'${entityMap.ExternalObjectName}' returned ${EMPTY_BATCH_WARN_THRESHOLD} empty batches in a row while still reporting HasMore=true ` +
-                        `(batch ${batchCount}/${MAX_BATCHES_PER_MAP}). Likely a connector pagination bug (cursor not advancing / HasMore stuck true).`,
-                        { batchCount, consecutiveEmptyBatches },
+                        `'${entityMap.ExternalObjectName}' returned ${EMPTY_BATCH_WARN_THRESHOLD} empty batches in a row at an UNMOVING position while still reporting HasMore=true ` +
+                        `(batch ${batchCount}/${MAX_BATCHES_PER_MAP}). The cursor is not advancing — connector pagination bug.`,
+                        { batchCount, consecutiveEmptyBatches: stuckStreak },
                     );
                 }
-            } else {
-                consecutiveEmptyBatches = 0;
             }
             hasMore = batch.HasMore === true; // Explicit boolean check — prevents truthy undefined from looping
         }

--- a/packages/Integration/engine/src/__tests__/EmptyBatchWatchdog.test.ts
+++ b/packages/Integration/engine/src/__tests__/EmptyBatchWatchdog.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The empty-batch watchdog counts only empties at an UNMOVING position. The failure mode it
+ * replaces was measured live: a per-item fan-out connector (one upstream call per parent
+ * record over sparse data) fired the old empties-only warning dozens of times per run, all
+ * false — training operators to dismiss the exact message that a real stuck cursor would wear.
+ */
+import { describe, it, expect } from 'vitest';
+import { EmptyBatchWatchdog } from '../EmptyBatchWatchdog.js';
+
+describe('EmptyBatchWatchdog', () => {
+    it('counts consecutive empties at the same position', () => {
+        const w = new EmptyBatchWatchdog();
+        expect(w.Observe(0, true, [null, null, null, 100, null])).toBe(1);
+        expect(w.Observe(0, true, [null, null, null, 100, null])).toBe(2);
+        expect(w.Observe(0, true, [null, null, null, 100, null])).toBe(3);
+    });
+
+    it('does NOT count empties whose position advanced — sparse pagination is not a bug', () => {
+        const w = new EmptyBatchWatchdog();
+        // A fan-out connector walking forward: every batch empty, offset always moving.
+        for (let offset = 0; offset < 50; offset += 1) {
+            expect(w.Observe(0, true, [null, null, null, offset, null])).toBe(1);
+        }
+    });
+
+    it('a batch with records resets the streak', () => {
+        const w = new EmptyBatchWatchdog();
+        w.Observe(0, true, ['a']);
+        w.Observe(0, true, ['a']);
+        expect(w.Observe(3, true, ['a'])).toBe(0);
+        expect(w.Observe(0, true, ['a'])).toBe(1);
+    });
+
+    it('HasMore=false resets and never counts (the loop is ending anyway)', () => {
+        const w = new EmptyBatchWatchdog();
+        w.Observe(0, true, ['a']);
+        expect(w.Observe(0, false, ['a'])).toBe(0);
+        expect(w.Observe(0, true, ['a'])).toBe(1);
+    });
+
+    it('any component of the position tuple moving counts as movement', () => {
+        const w = new EmptyBatchWatchdog();
+        expect(w.Observe(0, true, ['w1', 'k1', 1, 10, 'c1'])).toBe(1);
+        expect(w.Observe(0, true, ['w1', 'k1', 1, 10, 'c2'])).toBe(1); // cursor moved
+        expect(w.Observe(0, true, ['w2', 'k1', 1, 10, 'c2'])).toBe(1); // watermark moved
+        expect(w.Observe(0, true, ['w2', 'k1', 1, 10, 'c2'])).toBe(2); // truly stuck now
+    });
+
+    it('null and undefined position components are treated identically', () => {
+        // The loop's position vars are a mix of `undefined` (never set) and `null` (cleared);
+        // a connector toggling between them has not moved.
+        const w = new EmptyBatchWatchdog();
+        expect(w.Observe(0, true, [undefined, null, undefined, 5, null])).toBe(1);
+        expect(w.Observe(0, true, [null, undefined, null, 5, undefined])).toBe(2);
+    });
+});


### PR DESCRIPTION
## The defect

The P3-D watchdog warns after N consecutive empty batches with `HasMore=true` — but "empty" alone is the wrong signal. A per-item fan-out connector (one upstream call per parent record) legitimately returns long runs of empty batches while its position walks forward over sparse data. Measured live on such a connector: dozens of false `CONSECUTIVE_EMPTY_BATCHES` / "likely a pagination bug" warnings per run, every one spurious — which trains operators to dismiss exactly the message a *real* stuck cursor would produce.

## The fix

A stuck cursor, by definition, leaves the position where it was. The streak now counts only empties whose position tuple — `(watermark, afterKey, page, offset, cursor)` — did not move; any component advancing resets the streak. `null`/`undefined` components compare as identical (the loop's position vars mix both).

The decision is extracted into a pure `EmptyBatchWatchdog` class (the fetch loop isn't unit-harnessable), used at the same call site, same warning code, message updated to say what is now actually known ("at an UNMOVING position … the cursor is not advancing").

## Tests

6 behavior tests on the pure class, including the fan-out shape that produced the false alarms (50 empty batches, offset always advancing → streak never exceeds 1) and the true-positive (position frozen → streak climbs). Package tsc error count identical to clean HEAD (16 pre-existing, none in the new code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)