### PR TITLE
fix(ng-filter-builder): re-export camelCase aliases dropped in #4185

### DIFF
--- a/.changeset/filter-builder-camelcase-aliases.md
+++ b/.changeset/filter-builder-camelcase-aliases.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-filter-builder": patch
+---
+
+Re-export camelCase aliases (`createEmptyFilter`, `createFilterRule`, `isCompositeFilter`, and the operator helpers) alongside the PascalCase names from #4185 so existing compiled consumers keep resolving.

--- a/packages/Angular/Generic/filter-builder/src/__tests__/filter-types.test.ts
+++ b/packages/Angular/Generic/filter-builder/src/__tests__/filter-types.test.ts
@@ -3,6 +3,7 @@ import {
   IsCompositeFilter,
   IsSimpleFilter,
   CreateEmptyFilter,
+  createEmptyFilter,
   CreateFilterRule,
   GetDefaultOperator,
   GetDefaultValue,
@@ -67,6 +68,11 @@ describe('CreateEmptyFilter', () => {
     const filter = CreateEmptyFilter();
     expect(filter.logic).toBe('and');
     expect(filter.filters).toEqual([]);
+  });
+
+  it('keeps the camelCase alias as the same function', () => {
+    expect(createEmptyFilter).toBe(CreateEmptyFilter);
+    expect(createEmptyFilter().filters).toEqual([]);
   });
 
   it('should create independent instances', () => {

--- a/packages/Angular/Generic/filter-builder/src/lib/types/filter.types.ts
+++ b/packages/Angular/Generic/filter-builder/src/lib/types/filter.types.ts
@@ -75,6 +75,10 @@ export function IsSimpleFilter(
   return 'field' in filter && 'operator' in filter;
 }
 
+/** camelCase aliases — #4185 renamed the public helpers to PascalCase. */
+export const isCompositeFilter = IsCompositeFilter;
+export const isSimpleFilter = IsSimpleFilter;
+
 /**
  * Field types supported by the filter builder
  */
@@ -187,6 +191,9 @@ export function CreateEmptyFilter(): CompositeFilterDescriptor {
   return { logic: 'and', filters: [] };
 }
 
+/** camelCase alias — #4185 renamed the public helpers to PascalCase. */
+export const createEmptyFilter = CreateEmptyFilter;
+
 /**
  * Create a new filter rule with default values
  * @param field The field name to filter on
@@ -199,6 +206,9 @@ export function CreateFilterRule(field: string, type: FilterFieldType = 'string'
     value: GetDefaultValue(type)
   };
 }
+
+/** camelCase alias — #4185 renamed the public helpers to PascalCase. */
+export const createFilterRule = CreateFilterRule;
 
 /**
  * Get the default operator for a field type

--- a/packages/Angular/Generic/filter-builder/src/lib/types/operators.ts
+++ b/packages/Angular/Generic/filter-builder/src/lib/types/operators.ts
@@ -118,3 +118,8 @@ export function OperatorRequiresValue(operator: FilterOperator): boolean {
   const nullOperators: FilterOperator[] = ['isnull', 'isnotnull', 'isempty', 'isnotempty'];
   return !nullOperators.includes(operator);
 }
+
+/** camelCase aliases — #4185 renamed the public helpers to PascalCase. */
+export const getOperatorsForType = GetOperatorsForType;
+export const getOperatorInfo = GetOperatorInfo;
+export const operatorRequiresValue = OperatorRequiresValue;

--- a/packages/Angular/Generic/filter-builder/src/public-api.ts
+++ b/packages/Angular/Generic/filter-builder/src/public-api.ts
@@ -29,7 +29,11 @@ export {
   IsCompositeFilter,
   IsSimpleFilter,
   CreateEmptyFilter,
-  CreateFilterRule
+  CreateFilterRule,
+  isCompositeFilter,
+  isSimpleFilter,
+  createEmptyFilter,
+  createFilterRule
 } from './lib/types/filter.types';
 
 // Operators
@@ -42,5 +46,8 @@ export {
   LOOKUP_OPERATORS,
   GetOperatorsForType,
   GetOperatorInfo,
-  OperatorRequiresValue
+  OperatorRequiresValue,
+  getOperatorsForType,
+  getOperatorInfo,
+  operatorRequiresValue
 } from './lib/types/operators';


### PR DESCRIPTION
## Summary
- `#4185` renamed public filter-builder helpers to PascalCase (`CreateEmptyFilter`, `CreateFilterRule`, `IsCompositeFilter`, operator helpers).
- Compiled consumers that still import `createEmptyFilter` (including a stale `ng-entity-viewer` dist) fail Explorer boot with `No matching export … createEmptyFilter`.
- Re-export the old camelCase names as aliases of the PascalCase functions so both spellings resolve.

## Test plan
- [x] `pnpm test` in `@memberjunction/ng-filter-builder` (44 passing)
- [x] Rebuild filter-builder + entity-viewer; Explorer `ng serve` on :4201 compiles
- [ ] Confirm Explorer loads at http://localhost:4201 against MJAPI :4103