### PR TITLE
Artifacts: a type with no viewer plugin gets a file card and a real Download

### DIFF
--- a/.changeset/artifact-viewer-no-plugin-fallback.md
+++ b/.changeset/artifact-viewer-no-plugin-fallback.md
@@ -1,0 +1,16 @@
+---
+"@memberjunction/ng-artifacts": patch
+---
+
+**An artifact with no viewer plugin gets a file card and a real Download, not an empty pane.**
+
+The viewer panel's display tab knew two things: a type's plugin, or the extracted markdown/HTML
+attributes. A type with neither — CSV today, any new file type tomorrow — rendered nothing, and
+offered no way to get the file: a file-backed version has no inline `Content`, and the panel had no
+download action. First-adopter feedback: an exported exam CSV opened to a blank pane.
+
+Now such an artifact shows a file card (name, type, size) with a Download button — file-backed
+content via the pre-authenticated URL fetched to a blob so the browser saves it (falling back to
+opening the URL if storage refuses the cross-origin fetch), inline content via its data URL — and
+text-like content (`text/*`, JSON, XML, CSV) is fetched and shown as plain text, capped at 200 KB
+with a note to download the rest. Plugins and extracted attributes still take precedence.

--- a/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.css
+++ b/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.css
@@ -1064,3 +1064,17 @@
     padding: 8px;
   }
 }
+
+/* No-plugin fallback: a file card with a download action, text underneath when it is text-like */
+.file-fallback { display: flex; flex-direction: column; gap: var(--mj-space-3, 12px); padding: var(--mj-space-4, 16px); }
+.file-fallback-card {
+  display: flex; align-items: center; gap: var(--mj-space-3, 12px);
+  padding: var(--mj-space-3, 12px) var(--mj-space-4, 16px);
+  border: 1px solid var(--mj-border-default); border-radius: var(--mj-radius-md, 8px);
+  background: var(--mj-bg-surface-card, var(--mj-bg-surface));
+}
+.file-fallback-card > i { font-size: 1.5rem; color: var(--mj-brand-primary); }
+.file-fallback-meta { flex: 1; min-width: 0; }
+.file-fallback-name { font-weight: var(--mj-font-semibold, 600); color: var(--mj-text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-fallback-sub { font-size: var(--mj-text-sm, 0.85rem); color: var(--mj-text-muted); }
+.file-fallback-text { max-height: 60vh; overflow: auto; margin: 0; }

--- a/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.dom.test.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.dom.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import type { MJArtifactEntity, MJArtifactVersionEntity } from '@memberjunction/core-entities';
 import { MJNotificationService } from '@memberjunction/ng-notifications';
+import { ArtifactFileService } from '../services/artifact-file.service';
 import { renderComponentFixture, query, text, capture, StubEmptyStateComponent } from '@memberjunction/ng-test-utils';
 import { ArtifactViewerPanelComponent } from './artifact-viewer-panel.component';
 
@@ -28,13 +29,13 @@ const ARTIFACT = { Name: 'Q3 Report', Description: 'Quarterly numbers' } as unkn
 const VERSION = { ID: 'v1', VersionNumber: 2 } as unknown as MJArtifactVersionEntity;
 type OnInitProto = { ngOnInit: () => Promise<void> };
 
-interface State { isLoading?: boolean; error?: string | null; artifact?: MJArtifactEntity | null; allVersions?: MJArtifactVersionEntity[]; selectedVersionNumber?: number }
+interface State { isLoading?: boolean; error?: string | null; artifact?: MJArtifactEntity | null; allVersions?: MJArtifactVersionEntity[]; selectedVersionNumber?: number; artifactVersion?: MJArtifactVersionEntity | null; activeTab?: string; driverClass?: string | null; displayMarkdown?: string | null }
 function render(state: State = {}, inputs: Record<string, unknown> = {}) {
   vi.spyOn(ArtifactViewerPanelComponent.prototype as unknown as OnInitProto, 'ngOnInit').mockResolvedValue(undefined);
   return renderComponentFixture(ArtifactViewerPanelComponent, {
     imports: CHILDREN,
     declarations: [ArtifactViewerPanelComponent],
-    providers: [{ provide: MJNotificationService, useValue: {} }],
+    providers: [{ provide: MJNotificationService, useValue: {} }, { provide: ArtifactFileService, useValue: fileServiceStub }],
     inputs: { artifactId: 'a1', ...inputs },
     setup: (c) => {
       c.isLoading = state.isLoading ?? false;
@@ -42,11 +43,46 @@ function render(state: State = {}, inputs: Record<string, unknown> = {}) {
       c.artifact = state.artifact ?? ARTIFACT;
       c.allVersions = state.allVersions ?? [VERSION];
       c.selectedVersionNumber = state.selectedVersionNumber ?? 2;
+      if (state.artifactVersion !== undefined) c.artifactVersion = state.artifactVersion;
+      if (state.activeTab) c.activeTab = state.activeTab;
+      if (state.driverClass !== undefined) (c as unknown as { artifactTypeDriverClass: string | null }).artifactTypeDriverClass = state.driverClass;
+      if (state.displayMarkdown !== undefined) c.displayMarkdown = state.displayMarkdown;
     },
   });
 }
 
+const fileServiceStub = {
+  getDownloadUrl: vi.fn(async () => 'https://storage.example/exam.csv'),
+  dataUrlToArrayBuffer: (dataUrl: string) => Uint8Array.from(atob(dataUrl.slice(dataUrl.indexOf(',') + 1)), (c) => c.charCodeAt(0)).buffer,
+  dataUrlToObjectUrl: () => 'blob:stub',
+};
+
 afterEach(() => vi.restoreAllMocks());
+
+describe('ArtifactViewerPanelComponent (DOM) — no viewer plugin fallback', () => {
+  const csvVersion = {
+    ID: 'v-csv', VersionNumber: 1, ContentMode: 'Text', MimeType: 'text/csv', FileName: 'exam.csv',
+    Content: `data:text/csv;base64,${btoa('Number,Question\n1,What is a quorum?')}`,
+  } as unknown as MJArtifactVersionEntity;
+  const csvArtifact = { Name: 'exam.csv', Type: 'CSV' } as unknown as MJArtifactEntity;
+
+  it('shows a file card with a Download action for a type with no plugin, instead of an empty pane', () => {
+    const f = render({ artifact: csvArtifact, allVersions: [csvVersion], selectedVersionNumber: 1, artifactVersion: csvVersion, activeTab: 'display', driverClass: null });
+    expect(query(f, '[data-testid="file-fallback"]')).not.toBeNull();
+    expect(text(f, '.file-fallback-name')).toContain('exam.csv');
+    expect(query(f, '.file-fallback button')).not.toBeNull();
+  });
+
+  it('is not shown when a plugin exists', () => {
+    const f = render({ artifact: csvArtifact, allVersions: [csvVersion], selectedVersionNumber: 1, artifactVersion: csvVersion, activeTab: 'display', driverClass: 'SomePlugin' });
+    expect(query(f, '[data-testid="file-fallback"]')).toBeNull();
+  });
+
+  it('is not shown when extracted markdown is available', () => {
+    const f = render({ artifact: csvArtifact, allVersions: [csvVersion], selectedVersionNumber: 1, artifactVersion: csvVersion, activeTab: 'display', driverClass: null, displayMarkdown: '# extracted' });
+    expect(query(f, '[data-testid="file-fallback"]')).toBeNull();
+  });
+});
 
 describe('ArtifactViewerPanelComponent (DOM)', () => {
   it('shows the loading state while loading', () => {

--- a/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.html
+++ b/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.html
@@ -156,6 +156,26 @@
                 } @else if (displayHtml) {
                   <div class="html-content" [innerHTML]="displayHtml"></div>
                 }
+              } @else if (showFileFallback) {
+                <!-- No viewer plugin for this type: a file card with a real Download, plus the text for text-like content -->
+                <div class="file-fallback" data-testid="file-fallback">
+                  <div class="file-fallback-card">
+                    <i class="fas" [ngClass]="artifactIcon" aria-hidden="true"></i>
+                    <div class="file-fallback-meta">
+                      <div class="file-fallback-name">{{ fallbackFileName }}</div>
+                      <div class="file-fallback-sub">{{ artifactVersion?.MimeType || artifact.Type }}@if (fallbackSize) { · {{ fallbackSize }}}</div>
+                    </div>
+                    <button class="btn-icon btn-primary" type="button" (click)="downloadArtifactFile()" [disabled]="fallbackBusy" title="Download">
+                      <i class="fas fa-download"></i> {{ fallbackBusy ? 'Preparing…' : 'Download' }}
+                    </button>
+                  </div>
+                  @if (fallbackText !== null) {
+                    <pre class="plaintext-viewer file-fallback-text">{{ fallbackText }}</pre>
+                    @if (fallbackTextTruncated) {
+                      <div class="file-fallback-sub">Showing the first part only — download the file for all of it.</div>
+                    }
+                  }
+                </div>
               }
             </div>
           }

--- a/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.ts
+++ b/packages/Angular/Generic/artifacts/src/lib/components/artifact-viewer-panel.component.ts
@@ -10,6 +10,7 @@ import { takeUntil } from 'rxjs/operators';
 import { ArtifactTypePluginViewerComponent } from './artifact-type-plugin-viewer.component';
 import { ArtifactViewerTab, NavigationRequest } from './base-artifact-viewer.component';
 import { ArtifactIconService } from '../services/artifact-icon.service';
+import { ArtifactFileService } from '../services/artifact-file.service';
 import { RecentAccessService } from '@memberjunction/ng-shared-generic';
 
 @Component({
@@ -70,6 +71,17 @@ export class ArtifactViewerPanelComponent extends BaseAngularComponent implement
   public activeTab: string = 'display'; // Changed to string to support dynamic tabs
   public displayMarkdown: string | null = null;
   public displayHtml: string | null = null;
+  /**
+   * The no-plugin fallback. An artifact type with no viewer plugin (CSV today) used to render an empty
+   * pane: the display tab only knew the extracted markdown/HTML attributes, and a file-backed version
+   * has no inline Content to show. Now such an artifact gets a file card with a Download action, and
+   * text-like content (text/*, JSON, CSV) is fetched and shown as plain text — capped, so a large file
+   * is downloaded rather than rendered.
+   */
+  public fallbackText: string | null = null;
+  public fallbackTextTruncated = false;
+  public fallbackBusy = false;
+  private static readonly FALLBACK_TEXT_MAX_CHARS = 200_000;
   public versionAttributes: MJArtifactVersionAttributeEntity[] = [];
   private artifactTypeDriverClass: string | null = null;
   /** Populated from ArtifactType.ContentCategory. Used to suppress the JSON tab for
@@ -213,7 +225,8 @@ export class ArtifactViewerPanelComponent extends BaseAngularComponent implement
     private cdr: ChangeDetectorRef,
     private notificationService: MJNotificationService,
     private sanitizer: DomSanitizer,
-    private artifactIconService: ArtifactIconService
+    private artifactIconService: ArtifactIconService,
+    private artifactFileService: ArtifactFileService
   ) {
     super();
     this.recentAccessService = new RecentAccessService();
@@ -303,6 +316,8 @@ export class ArtifactViewerPanelComponent extends BaseAngularComponent implement
     this.jsonContent = '';
     this.displayMarkdown = null;
     this.displayHtml = null;
+    this.fallbackText = null;
+    this.fallbackTextTruncated = false;
     this.artifactCollections = [];
     this.currentVersionCollections = [];
     this.primaryCollection = null;
@@ -527,6 +542,7 @@ export class ArtifactViewerPanelComponent extends BaseAngularComponent implement
         // Set active tab to the first available tab
         this.setActiveTabToFirstAvailable();
       }
+      await this.prepareNoPluginFallback(isCurrentLoad);
     } catch (err) {
       if (!isCurrentLoad()) {
         return;
@@ -564,6 +580,107 @@ export class ArtifactViewerPanelComponent extends BaseAngularComponent implement
     const pluginHasContent = this.pluginViewer?.pluginInstance?.hasDisplayContent ?? false;
 
     return pluginHasContent || !!this.displayMarkdown || !!this.displayHtml;
+  }
+
+  /** True when the display tab has nothing better than the file card to show. */
+  get showFileFallback(): boolean {
+    return !this.hasPlugin && !!this.artifactVersion && !this.displayMarkdown && !this.displayHtml;
+  }
+
+  /** The file name shown on the fallback card. */
+  get fallbackFileName(): string {
+    return this.artifactVersion?.FileName || this.artifact?.Name || 'file';
+  }
+
+  /** Human file size for the fallback card, when the version knows it. */
+  get fallbackSize(): string | null {
+    const content = this.artifactVersion?.Content;
+    if (this.artifactVersion?.ContentMode === 'Text' && content?.startsWith('data:')) {
+      const b64 = content.slice(content.indexOf(',') + 1);
+      return this.formatBytes(Math.floor((b64.length * 3) / 4));
+    }
+    return null;
+  }
+
+  /** Text-like MIME types are shown inline on the fallback card; everything else is download-only. */
+  private isTextLike(mime: string | null | undefined): boolean {
+    const m = (mime ?? '').toLowerCase();
+    return m.startsWith('text/') || m === 'application/json' || m === 'application/xml' || m === 'application/csv';
+  }
+
+  /**
+   * Fetch text-like content for the no-plugin fallback. File-backed: MJ's pre-authenticated URL;
+   * inline: the data URL. Silent on failure — the Download action still works.
+   */
+  private async prepareNoPluginFallback(isCurrentLoad: () => boolean): Promise<void> {
+    this.fallbackText = null;
+    this.fallbackTextTruncated = false;
+    const version = this.artifactVersion;
+    if (!this.showFileFallback || !version || !this.isTextLike(version.MimeType)) return;
+    try {
+      let text: string | null = null;
+      if (version.ContentMode === 'File') {
+        const url = await this.artifactFileService.getDownloadUrl(version.ID);
+        const res = await fetch(url);
+        if (res.ok) text = await res.text();
+      } else if (version.Content?.startsWith('data:')) {
+        text = new TextDecoder().decode(this.artifactFileService.dataUrlToArrayBuffer(version.Content));
+      } else if (typeof version.Content === 'string') {
+        text = version.Content;
+      }
+      if (!isCurrentLoad() || text == null) return;
+      if (text.length > ArtifactViewerPanelComponent.FALLBACK_TEXT_MAX_CHARS) {
+        text = text.slice(0, ArtifactViewerPanelComponent.FALLBACK_TEXT_MAX_CHARS);
+        this.fallbackTextTruncated = true;
+      }
+      this.fallbackText = text;
+      this.cdr.markForCheck();
+    } catch (err) {
+      LogError(`Artifact viewer: could not load text for the no-plugin fallback: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  /** Download the artifact's file: file-backed via MJ's URL (fetched to a blob so the browser saves it), inline via the data URL. */
+  public async downloadArtifactFile(): Promise<void> {
+    const version = this.artifactVersion;
+    if (!version || this.fallbackBusy) return;
+    this.fallbackBusy = true;
+    try {
+      let objectUrl: string | null = null;
+      if (version.ContentMode === 'File') {
+        const url = await this.artifactFileService.getDownloadUrl(version.ID);
+        try {
+          const res = await fetch(url);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          objectUrl = URL.createObjectURL(await res.blob());
+        } catch {
+          window.open(url, '_blank', 'noopener'); // storage refused the cross-origin fetch — let the browser handle it
+          return;
+        }
+      } else if (version.Content?.startsWith('data:')) {
+        objectUrl = this.artifactFileService.dataUrlToObjectUrl(version.Content, version.MimeType || 'application/octet-stream');
+      } else if (typeof version.Content === 'string') {
+        objectUrl = URL.createObjectURL(new Blob([version.Content], { type: version.MimeType || 'text/plain' }));
+      }
+      if (!objectUrl) return;
+      const a = document.createElement('a');
+      a.href = objectUrl;
+      a.download = this.fallbackFileName;
+      a.rel = 'noopener';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(objectUrl as string), 60_000);
+    } finally {
+      this.fallbackBusy = false;
+      this.cdr.markForCheck();
+    }
+  }
+
+  private formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`;
   }
 
   get hasPlugin(): boolean {


### PR DESCRIPTION
## Summary

The artifact viewer panel's display tab knew two things: a type's viewer plugin, or the extracted `displayMarkdown` / `displayHtml` attributes. An artifact with neither — CSV today (`MJ: Artifact Types` has the type but no `DriverClass`), any new file type tomorrow — rendered an empty pane, and the panel offered no way to get the file: a file-backed version has no inline `Content`, and there was no download action.

First-adopter feedback: an exported exam CSV opened to a blank pane; the file was correct in storage.

## Changes

- `artifact-viewer-panel`: when there is no plugin and no extracted attributes, the display tab shows a file card (name, type, size when known) with a **Download** button. File-backed content is fetched from `ArtifactFileService.getDownloadUrl` to a blob so the browser saves it (falls back to opening the URL if storage refuses the cross-origin fetch); inline content downloads via its data URL.
- Text-like content (`text/*`, JSON, XML, CSV) is fetched and shown as plain text under the card, capped at 200 KB with a note to download the rest.
- Plugins and extracted attributes keep precedence; nothing changes for types that already have a viewer.

## Testing

- `@memberjunction/ng-artifacts`: package suite passes; 2 new DOM tests — the fallback card and Download render for a CSV version with no plugin; the fallback is absent when a plugin exists or extracted markdown is available.
- Changeset: patch.

## Notes for reviewers

- `ArtifactFileService` is now injected into the panel (it was only used by the plugins); the DOM test provides a stub.
- A dedicated CSV viewer plugin (tabular preview) would be a further step; this PR makes every plugin-less type usable first.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eFe1FMgTsv5EcxsDEBWtF