### PR TITLE
ci: advanced CodeQL setup with generated code excluded and a risk-based JS/TS split

### DIFF
--- a/.github/codeql/codeql-config-core.yml
+++ b/.github/codeql/codeql-config-core.yml
@@ -1,0 +1,62 @@
+# .github/codeql/codeql-config-core.yml
+#
+# JOB A — the security-critical packages. 1,572 JavaScript/TypeScript files after
+# filtering, verified against MemberJunction/MJ@next on 5 September 2026.
+#
+# This job exists so the code where a finding matters most is scanned on the extended
+# query suite and on every pull request, rather than waiting for a weekly run of the
+# whole repository. It is under one fifth of the JS/TS surface that timed out at the
+# six-hour ceiling, so it should complete with a wide margin.
+#
+# Generated code is excluded here as it is everywhere else in this workflow. Only six
+# generated JavaScript/TypeScript files sit inside these packages, but one of them —
+# packages/MJServer/src/generated/graphql-schemas/__mj.ts — is 88,876 lines, roughly a
+# fifth of everything this job would otherwise read, and it is regenerated from
+# metadata on every CodeGen run. The coverage trade this makes is recorded in
+# codeql-config.yml under "THE COVERAGE QUESTION".
+#
+# The exclusion list below is the shared baseline from codeql-config.yml. Keep the
+# three files identical in that section; see the notes there for why each pattern is
+# present or absent.
+
+name: "MemberJunction CodeQL — security-critical packages"
+
+paths:
+  - 'packages/MJServer/**'
+  - 'packages/AuthProviders/**'
+  - 'packages/AI/**'
+  - 'packages/Actions/**'
+  - 'packages/MJGlobal/**'
+  - 'packages/React/runtime/**'
+
+paths-ignore:
+  # --- build and distribution output ------------------------------------------------
+  - '**/dist/**'
+  - '**/*.min.js'
+  - '**/*.bundle.js'
+  - '**/*.map'
+
+  # --- dependencies -----------------------------------------------------------------
+  - '**/node_modules/**'
+
+  # --- generated artifacts ----------------------------------------------------------
+  - '**/generated/**'
+  - '**/GeneratedEntities/**'
+  - '**/*.generated.ts'
+
+  # --- tests and fixtures -----------------------------------------------------------
+  # **/test/** (singular) is deliberately absent — see codeql-config.yml.
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - '**/*.test.ts'
+  - '**/*.test.js'
+  - '**/*.spec.ts'
+  - '**/*.spec.js'
+  - '**/tests/**'
+  - '**/fixtures/**'
+  - '**/__fixtures__/**'
+
+  # --- coverage, docs and samples ---------------------------------------------------
+  - '**/coverage/**'
+  - '**/docs/**'
+  - '**/*.md'

--- a/.github/codeql/codeql-config-rest.yml
+++ b/.github/codeql/codeql-config-rest.yml
@@ -1,0 +1,83 @@
+# .github/codeql/codeql-config-rest.yml
+#
+# JOB B — everything the security-critical job does not cover. 3,680 JavaScript/
+# TypeScript files after filtering, verified against MemberJunction/MJ@next on
+# 5 September 2026. Predominantly the Angular Explorer packages.
+#
+# Runs weekly and on demand only. At 3,680 files it is 45% of the surface that hit the
+# six-hour ceiling, so it should fit, but it is the job to watch on the first run.
+#
+# The exclusion list below is the shared baseline from codeql-config.yml, plus the six
+# package paths the security-critical job owns. Keep the baseline section identical
+# across the three files; see the notes in codeql-config.yml for why each pattern is
+# present or absent.
+
+name: "MemberJunction CodeQL — remaining packages"
+
+paths-ignore:
+  # --- already covered by the security-critical job, excluded here to avoid
+  # --- analysing the same file twice and to keep this job inside the time budget
+  - 'packages/MJServer/**'
+  - 'packages/AuthProviders/**'
+  - 'packages/AI/**'
+  - 'packages/Actions/**'
+  - 'packages/MJGlobal/**'
+  - 'packages/React/runtime/**'
+
+  # --- build and distribution output ------------------------------------------------
+  - '**/dist/**'                 # 28 files
+  - '**/*.min.js'
+  - '**/*.bundle.js'
+  - '**/*.map'
+
+  # --- dependencies -----------------------------------------------------------------
+  # Matches nothing today: node_modules is not committed. Kept as a guard in case it
+  # ever is. This is the one pattern where a guard beats a tidy config.
+  - '**/node_modules/**'
+
+  # --- generated artifacts ----------------------------------------------------------
+  # 787 files, of which 406 are JavaScript/TypeScript. 767 of them sit in ONE directory:
+  #   packages/Angular/Explorer/core-entity-forms/src/lib/generated   (403 .ts, 383 .html)
+  # These are Angular entity form components generated from MemberJunction metadata.
+  # BC-POL-012 §8.3 treats such artifacts as regenerated rather than authored.
+  #
+  # The residual risk of excluding them is lower than it first appears: they are UI form
+  # scaffolds, not data access, so the "a generator template emits an unparameterized
+  # query into 787 files" scenario does not apply to this particular set. The generated
+  # code that does touch data access — the GraphQL schema under MJServer — is excluded
+  # from Job A for the same time-budget reason, and that trade is recorded in
+  # codeql-config.yml under "THE COVERAGE QUESTION".
+  #
+  # Record this exclusion in BC-POL-012 Annex A and exception EX-2026-002 rather than
+  # only here.
+  - '**/generated/**'
+  - '**/GeneratedEntities/**'
+  - '**/*.generated.ts'
+
+  # --- tests and fixtures -----------------------------------------------------------
+  # 2,524 JavaScript/TypeScript files match these patterns — 31% of the JS/TS surface
+  # and the single largest lever. Test-only issues are not reported.
+  #
+  # **/test/** (singular) is deliberately absent: packages/MJCLI/src/commands/test/ is
+  # the shipping implementation of the `mj test` command, 17 authored files, and it is
+  # this job's territory. See codeql-config.yml.
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - '**/*.test.ts'
+  - '**/*.test.js'
+  - '**/*.spec.ts'
+  - '**/*.spec.js'
+  - '**/tests/**'
+  - '**/fixtures/**'
+  - '**/__fixtures__/**'
+
+  # --- coverage, docs and samples ---------------------------------------------------
+  - '**/coverage/**'
+  - '**/docs/**'
+  - '**/*.md'
+
+# NOT COVERED BY ANY JOB IN THIS WORKFLOW, STATED SO IT IS NOT MISTAKEN FOR COVERAGE:
+#   migrations/  —  690 .sql files and 4 .md. CodeQL has no SQL analysis, so schema
+#   migrations are outside the reach of code scanning entirely. Review of migrations
+#   remains a human control under BC-POL-012 §10, and the automated migration check
+#   enforced as a required status check is a correctness gate, not a security scan.

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,121 @@
+# .github/codeql/codeql-config.yml
+#
+# Used by the actions and python analyses. The two JavaScript/TypeScript analyses have
+# their own configs (codeql-config-core.yml and codeql-config-rest.yml) because they
+# split the language between them; the exclusions below are the shared baseline, kept
+# identical across all three files so that the three tell one story.
+#
+# Path filters apply to languages CodeQL analyses without a build — which is all three
+# used here (actions, python, javascript-typescript). They are the main free lever
+# against the JavaScript/TypeScript timeout.
+#
+# The principle: exclude code nobody wrote and code that never ships. Do not exclude
+# anything an engineer authored that reaches a customer.
+#
+# VERIFIED against MemberJunction/MJ@next on 5 September 2026 by verify-paths.sh:
+# 19,900 files in the tree, 8,183 of them JavaScript/TypeScript. Every pattern below
+# matched something real, except node_modules — see the note against it.
+
+name: "MemberJunction CodeQL config"
+
+paths-ignore:
+  # --- build and distribution output: generated from source, not source -------------
+  - '**/dist/**'                     # 28 files
+  - '**/*.min.js'
+  - '**/*.bundle.js'
+  - '**/*.map'
+
+  # REMOVED after verification, because they matched nothing in this repository and
+  # a pattern matching nothing tells the next reader something untrue:
+  #   **/build/**          0 matches
+  #   **/out/**            0 matches
+  #   **/lib/**/*.js       0 matches — this was the risky one. It was in the draft to
+  #                        catch compiled output sitting beside TypeScript sources.
+  #                        MJ has no such layout, so the pattern carried only the risk
+  #                        of silently excluding authored JavaScript, and no benefit.
+
+  # --- dependencies -----------------------------------------------------------------
+  # Kept deliberately despite matching 0 files today. node_modules is not committed,
+  # and this line exists so that it stays excluded if it ever is committed by accident.
+  # This is the one pattern where a guard is worth more than a tidy config.
+  - '**/node_modules/**'
+
+  # --- deterministically generated artifacts ----------------------------------------
+  # Confirmed against the repository. BC-POL-012 §8.3 treats these as regenerated from
+  # metadata rather than authored, which is what makes excluding them defensible.
+  # 787 files match, 406 of them JavaScript/TypeScript; 767 sit in one directory,
+  # packages/Angular/Explorer/core-entity-forms/src/lib/generated.
+  - '**/generated/**'                      # 787 files
+  - '**/GeneratedEntities/**'               # 7 files
+  - '**/*.generated.ts'                     # 2 files
+  #
+  # THREE PATTERNS FROM THE DRAFT WERE REMOVED AFTER LOOKING AT WHAT THEY ACTUALLY MATCH:
+  #
+  #   **/GeneratedActions/**   REMOVED — over-broad, and exactly the mistake this check
+  #                            exists to catch. packages/GeneratedActions/ is a real
+  #                            package with a README, a package.json and authored source.
+  #                            Only packages/GeneratedActions/src/generated/ is output,
+  #                            and **/generated/** already covers it. Excluding the whole
+  #                            package because its name contains "Generated" would have
+  #                            dropped authored, shipping code from the scan.
+  #
+  #   **/generated-for-prompt/**        REMOVED — all 6 files are .md, already excluded.
+  #   **/integrations-auto-generated/** REMOVED — all 7 files are .json under metadata/,
+  #                                     not analysed by any language here.
+  #
+  #   **/generated_entities/**          REMOVED — 0 matches. The repository uses
+  #                                     GeneratedEntities, not the snake_case spelling.
+  #
+  #   MJGeneratedCode / MJGeneratedCodeCategory: no pattern needed. They looked like
+  #   entity names worth protecting, but they are directories INSIDE
+  #   packages/Angular/Explorer/core-entity-forms/src/lib/generated/Entities/, so
+  #   **/generated/** already covers them, correctly.
+  #
+  # THE COVERAGE QUESTION THIS SECTION RAISES, RECORDED RATHER THAN BURIED.
+  # Generated code ships to customers. Excluding it means a flaw in a code generator's
+  # template — one that emits, say, an unparameterised query into every generated file —
+  # is invisible to this scan. The generator itself is authored TypeScript and is
+  # scanned, but scanning the generator does not prove its output is safe.
+  # The position taken: generated output is excluded from every analysis in this
+  # workflow, including the security-critical one, because the purpose of the setup is
+  # to fit inside the Actions time budget and generated code is the largest block of
+  # code nobody wrote. This is a known limitation of scanning coverage and belongs in
+  # BC-POL-012 Annex A and in exception EX-2026-002, not only in a comment here.
+
+  # --- tests and fixtures -----------------------------------------------------------
+  # 2,524 JavaScript/TypeScript files match these patterns — 31% of the JS/TS surface
+  # and the single largest lever. Test-only issues are not reported. That is the trade.
+  #
+  # **/test/** (singular) is deliberately NOT in this list. The only directory of that
+  # name holding JavaScript/TypeScript is packages/MJCLI/src/commands/test/ — the 17
+  # authored files that implement the `mj test` command, which ships. Every directory
+  # named tests/ (plural) holds test code, so that pattern stays.
+  - '**/__tests__/**'
+  - '**/__mocks__/**'
+  - '**/*.test.ts'
+  - '**/*.test.js'
+  - '**/*.spec.ts'
+  - '**/*.spec.js'
+  - '**/tests/**'
+  - '**/fixtures/**'
+  - '**/__fixtures__/**'
+
+  # --- coverage, docs and samples ---------------------------------------------------
+  - '**/coverage/**'
+  - '**/docs/**'
+  - '**/*.md'
+
+# Deliberately NOT excluded, because they are authored code that reaches customers.
+# File counts are all file types, verified 5 September 2026:
+#   packages/MJServer/**            291    — the API surface
+#   packages/AuthProviders/**        24    — identity
+#   packages/AI/**                 1803    — prompt and agent pipeline; the largest package
+#   packages/Actions/**             650    — including the code execution sandbox
+#   packages/React/runtime/**        49    — model-authored component execution
+#   packages/MJGlobal/**             73    — SQL expression validation
+#
+# NOT COVERED BY ANY ANALYSIS IN THIS WORKFLOW, STATED SO IT IS NOT MISTAKEN FOR COVERAGE:
+#   migrations/  —  690 .sql files and 4 .md. CodeQL has no SQL analysis, so schema
+#   migrations are outside the reach of code scanning entirely. Review of migrations
+#   remains a human control under BC-POL-012 §10, and the automated migration check
+#   enforced as a required status check is a correctness gate, not a security scan.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,177 @@
+# .github/workflows/codeql.yml
+#
+# Advanced CodeQL setup for MemberJunction/MJ.
+# Replaces default setup. Enabling this workflow disables default setup — do that
+# deliberately in one change rather than discovering the swap.
+#
+# WHY FOUR ANALYSES RATHER THAN THREE, AND WHAT ACTUALLY CAUSED THE TIMEOUT
+#
+# Default setup analysed all of JavaScript/TypeScript in one job and hit the six-hour
+# Actions ceiling, so TypeScript — the language the platform is written in — produced no
+# findings at all. The job log of that run (3 September 2026) shows where the time went:
+#
+#   extraction of all 8,183 files            4.5 min
+#   queries 1–57 of 105                       10 min
+#   query 58, SqlInjection                    329 min
+#   query 59, CodeInjection                   341 min
+#   queries 60–105                            never ran; cancelled at 360 min
+#
+# Two taint-tracking queries consumed the budget; everything else was cheap. The trigger
+# is the generated code: the generated GraphQL resolvers under MJServer alone hold 411
+# template-string SQL statements feeding ExecuteSQL, and the excluded generated files
+# hold 843 SQL-building lines against 161 in the authored security-critical packages.
+# With generated code excluded, both JavaScript/TypeScript analyses were measured
+# locally on 5 September 2026 with the same CodeQL 2.26.4 bundle, 4 threads and 14 GB:
+#
+#   id        language               files  suite              measured   when
+#   actions   actions                  n/a  security-extended  ~1 min     PR, merge, weekly, manual
+#   python    python                   n/a  security-extended  ~1 min     PR, merge, weekly, manual
+#   js-core   javascript-typescript  1,572  security-extended  ~3 min     PR, weekly, manual
+#   js-rest   javascript-typescript  3,680  default            ~3 min     weekly, manual
+#
+# SqlInjection and CodeInjection took 14 s each on js-core and under 50 s each on
+# js-rest. Hosted runners are slower per core than the machine that measured this, so
+# expect a small multiple of those figures in Actions, not hours. The 350-minute
+# timeout below is a safety net, not a forecast.
+#
+# js-core is MJServer, AuthProviders, AI, Actions, MJGlobal and React/runtime — the API
+# surface, identity, the prompt and agent pipeline, the code execution sandbox, SQL
+# expression validation and model-authored component execution. It runs the extended
+# suite on every pull request. js-rest is the remainder, predominantly Angular
+# Explorer, weekly.
+#
+# The result is better than a single scan of everything: the code where a finding matters
+# most is scanned more often and more deeply than the code where it matters least.
+#
+# js-core is NOT run on merge to next. Every change reaches next through a pull request —
+# direct commits are blocked and review is required — so the pull-request run has already
+# analysed it. The weekly run on next is what keeps the default-branch alert baseline
+# current.
+#
+# WHY A "plan" JOB
+#
+# Which analyses run depends on the event, and the natural place to express that — a
+# job-level `if` on matrix.run_on — is not allowed: the matrix context is unavailable in
+# jobs.<id>.if, and GitHub rejects the workflow. So a short first job filters the list
+# of analyses for the current event and hands the survivors to the matrix. Analyses that
+# do not apply never start, which also keeps them out of the run's job list.
+#
+# Run on demand before a significant release rather than waiting for Monday:
+#   gh workflow run CodeQL --repo MemberJunction/MJ --ref next
+
+name: CodeQL
+
+on:
+  push:
+    branches: [next]
+  pull_request:
+    branches: [next]
+  schedule:
+    - cron: '0 10 * * 1'      # Monday 10:00 UTC
+  workflow_dispatch:
+
+jobs:
+  plan:
+    name: Select analyses
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - name: Select analyses for ${{ github.event_name }}
+        id: select
+        env:
+          EVENT: ${{ github.event_name }}
+        # run_on controls which events each analysis answers to:
+        #   always    every event
+        #   pr        pull requests, the weekly schedule and manual runs — not merges
+        #   schedule  the weekly schedule and manual runs only
+        #
+        # queries: '' means the default suite. js-rest was given the default suite when
+        # the extended one was assumed not to fit the ceiling; measured at ~3 min it
+        # would now fit, so upgrading it is a choice, not a constraint.
+        run: |
+          selected=$(jq -c --arg event "$EVENT" '
+            { include: map(select(
+                .run_on == "always"
+                or (.run_on == "pr" and $event != "push")
+                or (.run_on == "schedule" and ($event == "schedule" or $event == "workflow_dispatch"))
+              )) }' <<'JSON'
+          [
+            { "id": "actions",
+              "language": "actions",
+              "queries": "security-extended",
+              "config": "./.github/codeql/codeql-config.yml",
+              "category": "/language:actions",
+              "run_on": "always" },
+
+            { "id": "python",
+              "language": "python",
+              "queries": "security-extended",
+              "config": "./.github/codeql/codeql-config.yml",
+              "category": "/language:python",
+              "run_on": "always" },
+
+            { "id": "js-core",
+              "language": "javascript-typescript",
+              "queries": "security-extended",
+              "config": "./.github/codeql/codeql-config-core.yml",
+              "category": "/language:javascript-typescript/core",
+              "run_on": "pr" },
+
+            { "id": "js-rest",
+              "language": "javascript-typescript",
+              "queries": "",
+              "config": "./.github/codeql/codeql-config-rest.yml",
+              "category": "/language:javascript-typescript/rest",
+              "run_on": "schedule" }
+          ]
+          JSON
+          )
+          echo "Event: $EVENT"
+          echo "Selected: $(jq -r '.include[].id' <<<"$selected" | paste -sd, -)"
+          echo "matrix=$selected" >> "$GITHUB_OUTPUT"
+
+  analyze:
+    name: Analyze (${{ matrix.id }})
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 350        # fail cleanly below the 360-minute job ceiling
+
+    # Per-analysis concurrency. A superseded run is cancelled for everything except
+    # js-rest, which is the long one: a merge landing mid-analysis must not kill it. That
+    # is the failure mode that produced continuous compute and no findings under default
+    # setup.
+    concurrency:
+      group: codeql-${{ matrix.id }}-${{ github.ref }}
+      cancel-in-progress: ${{ matrix.id != 'js-rest' }}
+
+    permissions:
+      security-events: write    # required to upload results
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false          # one language failing must not hide the others
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: ${{ matrix.queries }}
+          config-file: ${{ matrix.config }}
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          # Distinct categories keep the two JavaScript/TypeScript analyses as separate
+          # result sets. Without this the second upload overwrites the first and half the
+          # codebase silently disappears from the Security tab.
+          category: ${{ matrix.category }}


### PR DESCRIPTION
## Summary

Replaces CodeQL default setup, which never produced a JavaScript/TypeScript result for this repository, with an advanced setup: one workflow, three config files, four analyses.

| id | language | files | suite | measured locally | when |
|---|---|---|---|---|---|
| actions | actions | n/a | security-extended | ~1 min | PR, merge, weekly, manual |
| python | python | n/a | security-extended | ~1 min | PR, merge, weekly, manual |
| js-core | javascript-typescript | 1,572 | security-extended | ~3 min | PR, weekly, manual |
| js-rest | javascript-typescript | 3,680 | default | ~3 min | weekly, manual |

`js-core` is MJServer, AuthProviders, AI, Actions, MJGlobal and React/runtime: the API surface, identity, the prompt and agent pipeline, the code execution sandbox, SQL expression validation and model-authored component execution. `js-rest` is everything else, predominantly Angular Explorer.

## What actually caused the six-hour timeout

The log of the only default-setup run (3 September) shows where the time went:

| phase | duration |
|---|---|
| extraction, all 8,183 JS/TS files | 4.5 min |
| queries 1–57 of 105 | 10 min |
| query 58, SqlInjection | 329 min |
| query 59, CodeInjection | 341 min |
| queries 60–105 | never ran, cancelled at 360 min |

Two taint-tracking queries consumed the budget. The generated code is the trigger: the generated GraphQL resolvers under MJServer alone contain 411 template-string SQL statements feeding `ExecuteSQL`, and the excluded generated files hold 843 SQL-building lines against 161 in the authored security-critical packages.

With generated code excluded, both JS/TS analyses were run locally on a clean checkout of `next` with the same CodeQL 2.26.4 bundle GitHub used, limited to the hosted runner's 4 threads and 14 GB:

| analysis | build database | run queries | findings |
|---|---|---|---|
| js-core | 30 s | 2 min 8 s | 133 |
| js-rest | 1 min 7 s | 2 min 11 s | 172 |

SqlInjection and CodeInjection took 14 s each on js-core and under 50 s each on js-rest. Hosted runner cores are slower than the measuring machine, so expect a small multiple of these figures in Actions.

## Design notes

- **Generated code is excluded from every analysis**, including js-core. That is what makes the scan fit. The coverage trade is recorded in `codeql-config.yml` under "THE COVERAGE QUESTION".
- **A `plan` job selects the analyses for the event.** The `matrix` context is not available in a job-level `if`, so a short first job filters the analysis list with `jq` and hands the survivors to the matrix via `fromJSON`. Analyses that do not apply never start. Verified with `actionlint` and by running the selection step locally for all four events.
- **`**/tests/**` is excluded, `**/test/**` is not.** The only `test/` directory holding JS/TS is `packages/MJCLI/src/commands/test/`, the 17 authored files that implement `mj test`. Every `tests/` directory holds test code.
- **Three over-broad patterns removed** after checking what they match: `**/GeneratedActions/**` (an authored package; only its `src/generated/` is output and `**/generated/**` already covers it), `**/generated-for-prompt/**` (Markdown only), `**/integrations-auto-generated/**` (JSON only).
- **Distinct categories** for the two JS/TS analyses so the second upload does not overwrite the first.
- **Per-analysis concurrency**, with `js-rest` uncancellable so a merge landing mid-analysis does not kill the long run.
- `js-rest` keeps the default suite. It was chosen when the extended suite was assumed not to fit; at ~3 minutes it now would, so upgrading is a choice for a follow-up, not a constraint.

## Before merging

- Default setup is already `not-configured` on this repository, so the first run will not fail on upload.
- The first pull-request run will upload roughly 130 alerts for js-core, and the first weekly run roughly 170 more for js-rest. About 130 of the total are polynomial regular-expression alerts. This is the baseline the old setup never produced, not a regression.
- Pull requests from forks cannot upload code-scanning results; per-PR findings appear only for branches in the organisation.
- No changeset: no published package is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
