### PR TITLE
fix(ng-entity-viewer): human-first load-error state on the entity data grid

### DIFF
--- a/.changeset/entity-grid-friendly-load-error.md
+++ b/.changeset/entity-grid-friendly-load-error.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-entity-viewer": patch
+---
+
+The entity data grid's load-error state now leads with a human message ("The server may be busy or briefly unreachable — retrying usually fixes this") instead of the raw transport error, keeps the technical detail as a de-emphasized parenthetical, and logs every load failure via LogError.

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.html
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.html
@@ -329,8 +329,8 @@
         [Size]="EmptyStateSize"
         Variant="error"
         Icon="fa-solid fa-triangle-exclamation"
-        Title="Could not load data"
-        [Message]="errorMessage"
+        Title="Couldn't load this data"
+        [Message]="FriendlyErrorMessage"
         ActionText="Retry"
         ActionIcon="fa-solid fa-arrows-rotate"
         (Action)="Refresh()" />

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.ts
@@ -15,7 +15,7 @@ import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import type { EntityActionUXContext, EntityActionUXResult } from '@memberjunction/ng-entity-action-ux';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { RunView, RunViewParams, Metadata, EntityInfo, EntityFieldInfo, AggregateResult, AggregateValue, AggregateExpression } from '@memberjunction/core';
+import { LogError, RunView, RunViewParams, Metadata, EntityInfo, EntityFieldInfo, AggregateResult, AggregateValue, AggregateExpression } from '@memberjunction/core';
 import { UUIDsEqual } from '@memberjunction/global';
 import { EntityActionEngineBase } from '@memberjunction/actions-base';
 import { PageChangeEvent } from '@memberjunction/ng-pagination';
@@ -1558,7 +1558,30 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
 
   // Loading state
   loading: boolean = false;
-  errorMessage: string = '';
+  private _errorMessage: string = '';
+  /**
+   * Raw technical error from the last failed load. Kept for callers and the
+   * console; the error STATE shown to users leads with FriendlyErrorMessage.
+   * Setting a non-empty value logs the technical detail.
+   */
+  get errorMessage(): string {
+    return this._errorMessage;
+  }
+  set errorMessage(value: string) {
+    this._errorMessage = value;
+    if (value) {
+      LogError(`EntityDataGrid data load failed: ${value}`);
+    }
+  }
+  /**
+   * Human-first message for the error empty-state. Users see what happened and
+   * what to do; the raw error rides along as a de-emphasized parenthetical so a
+   * screenshot still carries the detail support needs.
+   */
+  get FriendlyErrorMessage(): string {
+    const friendly = 'The server may be busy or briefly unreachable — retrying usually fixes this.';
+    return this._errorMessage ? `${friendly} (Detail: ${this._errorMessage})` : friendly;
+  }
   totalRowCount: number = 0;
   private _loadDataPromise: Promise<void> | null = null;
 


### PR DESCRIPTION
Found during BlueCypress UAT end-to-end testing on the AIDP local stack (no linked issue). When a grid load fails transiently, users saw the raw transport string — "Could not load data / GraphQL Error (Code: unknown)" — with no hint of what happened or what to do.

## Root cause

The error empty-state in `entity-data-grid.component.html` bound the raw `errorMessage` as its primary message. The Retry action already existed and worked; only the words were developer-facing.

## Fix

- The error state now leads with human text: title "Couldn't load this data", message "The server may be busy or briefly unreachable — retrying usually fixes this."
- The raw technical detail stays in the message as a de-emphasized parenthetical, so a user screenshot still carries what support needs.
- `errorMessage` is now a setter-backed property that calls `LogError` whenever a non-empty error is set, covering all five assignment sites (client, infinite, and view-load paths) without touching each one.
- The existing Retry button and `Refresh()` wiring are unchanged.

## Verification

- `pnpm run build` (ngc) clean and `pnpm test` in ng-entity-viewer: 19 files, 153 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
