### PR TITLE
feat(ui): PhotoURL/LogoURL as linked thumbnails in entity-viewer

### DIFF
--- a/.changeset/entity-viewer-image-cells.md
+++ b/.changeset/entity-viewer-image-cells.md
@@ -3,4 +3,4 @@
 "@memberjunction/ng-timeline": patch
 ---
 
-Photo/logo/avatar cells crop, center, and scale to the cell (28px circle in the grid, 48px circle on cards, 40px circle on timeline). AG Grid injects HTML without Angular attributes, so size is also inlined on the img. Timeline auto-binds PhotoURL/LogoURL as the card image.
+Photo/logo/avatar cells crop, center, and scale to the cell (28px circle in the grid, 48px circle on cards, 40px circle on timeline). AG Grid injects HTML without Angular attributes, so size is also inlined on the img. Timeline auto-binds PhotoURL/LogoURL as the card image. The header/pager total is a `count_only` RunView with IgnoreMaxRows so UserViewMaxRows (default 1000) cannot cap the count.

--- a/.changeset/entity-viewer-image-cells.md
+++ b/.changeset/entity-viewer-image-cells.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-entity-viewer": patch
+---
+
+Grid cells for PhotoURL / LogoURL / avatar / thumbnail fields (or `format.type: image`) render as a linked thumbnail instead of a text URL.

--- a/.changeset/entity-viewer-image-cells.md
+++ b/.changeset/entity-viewer-image-cells.md
@@ -1,5 +1,6 @@
 ---
 "@memberjunction/ng-entity-viewer": patch
+"@memberjunction/ng-timeline": patch
 ---
 
-Grid cells for PhotoURL / LogoURL / avatar / thumbnail fields (or `format.type: image`) render as a linked thumbnail instead of a text URL.
+Photo/logo/avatar cells crop, center, and scale to the cell (28px circle in the grid, 48px circle on cards, 40px circle on timeline). AG Grid injects HTML without Angular attributes, so size is also inlined on the img. Timeline auto-binds PhotoURL/LogoURL as the card image.

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-cards/entity-cards.component.css
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-cards/entity-cards.component.css
@@ -56,20 +56,23 @@ mj-entity-cards .card-header {
 mj-entity-cards .card-thumbnail {
   width: 48px;
   height: 48px;
-  border-radius: 8px;
+  border-radius: 50%;
   overflow: hidden;
   flex-shrink: 0;
+  background: var(--mj-bg-surface-sunken);
 }
 mj-entity-cards .card-thumbnail img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center;
+  display: block;
 }
 
 mj-entity-cards .card-avatar {
   width: 48px;
   height: 48px;
-  border-radius: 8px;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.css
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.css
@@ -1242,15 +1242,35 @@
   background-color: transparent !important;
 }
 
-.cell-image-link {
-  display: inline-flex;
+/* AG Grid injects cellRenderer HTML without Angular attributes, so these
+   must pierce encapsulation or the image renders at intrinsic SVG size. */
+::ng-deep .ag-cell.mj-grid-image-cell {
+  display: flex !important;
   align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 4px !important;
 }
-.cell-image {
-  width: 32px;
-  height: 32px;
-  object-fit: cover;
-  border-radius: var(--mj-radius-sm, 4px);
-  vertical-align: middle;
+::ng-deep .ag-header-cell.mj-grid-image-header .ag-header-cell-label {
+  justify-content: center;
+}
+::ng-deep .cell-image-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  overflow: hidden;
+  border-radius: 50%;
   background: var(--mj-bg-surface-sunken);
+  flex-shrink: 0;
+}
+::ng-deep .cell-image {
+  width: 100%;
+  height: 100%;
+  max-width: 28px;
+  max-height: 28px;
+  object-fit: cover;
+  object-position: center;
+  display: block;
 }

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.css
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.css
@@ -1241,3 +1241,16 @@
 ::ng-deep .ag-header-cell.mj-grid-filler-header:hover {
   background-color: transparent !important;
 }
+
+.cell-image-link {
+  display: inline-flex;
+  align-items: center;
+}
+.cell-image {
+  width: 32px;
+  height: 32px;
+  object-fit: cover;
+  border-radius: var(--mj-radius-sm, 4px);
+  vertical-align: middle;
+  background: var(--mj-bg-surface-sunken);
+}

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.ts
@@ -2798,6 +2798,15 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
       colDef.headerClass = 'header-align-right';
     }
 
+    if (isImage) {
+      colDef.cellClass = `${colDef.cellClass || ''} mj-grid-image-cell`.trim();
+      colDef.headerClass = `${colDef.headerClass || ''} mj-grid-image-header`.trim();
+      colDef.width = 48;
+      colDef.minWidth = 44;
+      colDef.maxWidth = 56;
+      colDef.resizable = false;
+    }
+
     // Apply custom header style if provided
     if (customFormat?.headerStyle) {
       const headerStyle = this.buildCssStyle(customFormat.headerStyle);
@@ -2820,7 +2829,7 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
           const url = this.normalizeHref(raw);
           const escaped = HighlightUtil.escapeHtml(url);
           return this.wrapWithStyle(
-            `<a href="${escaped}" target="_blank" rel="noopener noreferrer" class="cell-image-link" onclick="event.stopPropagation()"><img src="${escaped}" alt="" class="cell-image" /></a>`,
+            `<a href="${escaped}" target="_blank" rel="noopener noreferrer" class="cell-image-link" onclick="event.stopPropagation()"><img src="${escaped}" alt="" class="cell-image" width="28" height="28" style="width:28px;height:28px;max-width:28px;max-height:28px;object-fit:cover;object-position:center;border-radius:50%;display:block" /></a>`,
             customFormat?.cellStyle ? this.buildCssStyle(customFormat.cellStyle) : '',
           );
         }

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.ts
@@ -2756,6 +2756,12 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
                   (!extendedType && (fieldNameLower.includes('url') ||
                                      fieldNameLower.includes('website') ||
                                      fieldNameLower.includes('link')));
+    // Photo/logo/avatar before generic URL — PhotoURL would otherwise render as a text link.
+    const isImage = (customFormat?.type as string | undefined) === 'image' ||
+                    fieldNameLower.includes('photo') ||
+                    fieldNameLower.includes('logo') ||
+                    fieldNameLower.includes('avatar') ||
+                    fieldNameLower.includes('thumbnail');
     // Use ExtendedType='Tel' from metadata, fallback to field name pattern
     const isPhone = extendedType === 'tel' ||
                     (!extendedType && (fieldNameLower.includes('phone') ||
@@ -2806,6 +2812,18 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
     colDef.cellRenderer = (params: ICellRendererParams) => {
       if (params.value === null || params.value === undefined) {
         return '<span class="cell-empty">—</span>';
+      }
+
+      if (isImage) {
+        const raw = String(params.value).trim();
+        if (this.looksLikeImageUrl(raw)) {
+          const url = this.normalizeHref(raw);
+          const escaped = HighlightUtil.escapeHtml(url);
+          return this.wrapWithStyle(
+            `<a href="${escaped}" target="_blank" rel="noopener noreferrer" class="cell-image-link" onclick="event.stopPropagation()"><img src="${escaped}" alt="" class="cell-image" /></a>`,
+            customFormat?.cellStyle ? this.buildCssStyle(customFormat.cellStyle) : '',
+          );
+        }
       }
 
       // Handle foreign key fields - render as clickable links
@@ -2979,6 +2997,22 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
   private wrapWithStyle(content: string, style: string): string {
     if (!style) return content;
     return `<span style="${style}">${content}</span>`;
+  }
+
+  private looksLikeImageUrl(value: string): boolean {
+    const v = value.trim().toLowerCase();
+    if (v.startsWith('data:image/')) return true;
+    if (!/^https?:\/\//.test(v) && !v.startsWith('/')) return false;
+    return /\.(png|jpe?g|gif|webp|svg|avif)(\?|$)/i.test(v) ||
+           v.includes('dicebear.com') ||
+           v.includes('/photo') ||
+           v.includes('avatar');
+  }
+
+  private normalizeHref(value: string): string {
+    const v = value.trim();
+    if (/^https?:\/\//i.test(v) || v.startsWith('data:') || v.startsWith('/')) return v;
+    return 'https://' + v;
   }
 
   /**

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.ts
@@ -1296,26 +1296,31 @@ export class EntityViewerComponent extends BaseAngularComponent implements OnIni
       // Build ExtraFilter from view's WhereClause if available
       // The view's WhereClause is the "business filter" - UserSearchString is additive
       const extraFilter = this.ViewEntity?.WhereClause || undefined;
+      const userSearchString = config.serverSideFiltering && !this.ViewEntity?.SmartFilterEnabled
+        ? this.DebouncedFilterText || undefined
+        : undefined;
 
-      const result = await rv.RunView<Record<string, unknown>>({
-        EntityName: entity.Name,
-        ResultType: 'simple',
-        // Load the FULL field set. The container is a generic plug-in host: different view types need
-        // different fields (the grid shows its columns, but Timeline needs the date field, Map needs
-        // lat/long, etc.). It cannot restrict to any one plug-in's columns, so it fetches all fields and
-        // lets each plug-in pick what it needs. (Omitting `Fields` on a 'simple' RunView returns all
-        // entity fields.) Previously this used `computeFieldsList(entity, GridState)` — correct when the
-        // host WAS the grid, but it dropped `__mj_*` date fields, leaving Timeline with "no events".
-        MaxRows: maxRows,
-        StartRow: startRow,
-        OrderBy: orderBy,
-        ExtraFilter: extraFilter,
-        // Only use UserSearchString for regular text search, NOT for smart filters
-        // Smart filters generate WhereClause via AI on the server, so the prompt text should not be passed as UserSearchString
-        UserSearchString: config.serverSideFiltering && !this.ViewEntity?.SmartFilterEnabled
-          ? this.DebouncedFilterText || undefined
-          : undefined
-      });
+      // Page of rows + a count_only query (IgnoreMaxRows so UserViewMaxRows=1000 cannot
+      // cap the total). One RunViews round trip. TotalRowCount on the paged call is the
+      // page length whenever the server skipped COUNT.
+      const [result, countResult] = await rv.RunViews<Record<string, unknown>>([
+        {
+          EntityName: entity.Name,
+          ResultType: 'simple',
+          MaxRows: maxRows,
+          StartRow: startRow,
+          OrderBy: orderBy,
+          ExtraFilter: extraFilter,
+          UserSearchString: userSearchString,
+        },
+        {
+          EntityName: entity.Name,
+          ResultType: 'count_only',
+          ExtraFilter: extraFilter,
+          UserSearchString: userSearchString,
+          IgnoreMaxRows: true,
+        },
+      ]);
 
       // Check if this load is still the current one (detect stale responses)
       if (loadId !== this._loadSequence) {
@@ -1327,15 +1332,18 @@ export class EntityViewerComponent extends BaseAngularComponent implements OnIni
         // Always replace records (page-based navigation, not accumulation)
         this.InternalRecords = result.Results;
 
-        this.TotalRecordCount = result.TotalRowCount;
+        const total = countResult?.Success && countResult.TotalRowCount != null
+          ? countResult.TotalRowCount
+          : result.TotalRowCount;
+        this.TotalRecordCount = total;
         this.FilteredRecordCount = this.InternalRecords.length;
 
         // Update pagination state
-        this.Pagination.totalRecords = result.TotalRowCount;
+        this.Pagination.totalRecords = total;
         this.Pagination.hasMore = false; // No longer used with page-based paging
 
         this.DataLoaded.emit({
-          totalRowCount: result.TotalRowCount,
+          totalRowCount: total,
           loadedRowCount: this.InternalRecords.length,
           loadTime: Date.now() - startTime,
           records: this.InternalRecords
@@ -1343,7 +1351,7 @@ export class EntityViewerComponent extends BaseAngularComponent implements OnIni
 
         this.FilteredCountChanged.emit({
           filteredCount: this.InternalRecords.length,
-          totalCount: result.TotalRowCount
+          totalCount: total
         });
       } else {
         if (this.isInitialLoad) {

--- a/packages/Angular/Generic/entity-viewer/src/lib/view-types/renderers/timeline-view-renderer.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/view-types/renderers/timeline-view-renderer.component.ts
@@ -553,11 +553,15 @@ export class TimelineViewRendererComponent
       group.SubtitleFieldName = subtitleField;
     }
 
+    const imageField = this.findImageField();
     group.CardConfig = {
       collapsible: true,
       defaultExpanded: false,
       showDate: true,
       dateFormat: 'MMM d, yyyy h:mm a',
+      ...(imageField
+        ? { imageField, imagePosition: 'left' as const, imageSize: 'small' as const }
+        : {}),
     };
 
     this.TimelineGroups = [group];
@@ -635,6 +639,24 @@ export class TimelineViewRendererComponent
 
     const firstOther = fields.find((f) => f.Name !== excludeField);
     return firstOther?.Name || null;
+  }
+
+  /** Photo/logo/avatar URL field so timeline cards crop a thumbnail, same as grid/cards. */
+  private findImageField(): string | null {
+    if (!this._entity) {
+      return null;
+    }
+    const keywords = ['photo', 'logo', 'avatar', 'thumbnail', 'picture', 'image'];
+    const fields = this._entity.Fields.filter(
+      (f) => f.TSType === EntityFieldTSType.String && !f.Name.startsWith('__mj_'),
+    );
+    for (const keyword of keywords) {
+      const match = fields.find((f) => f.Name.toLowerCase().includes(keyword));
+      if (match) {
+        return match.Name;
+      }
+    }
+    return null;
   }
 }
 

--- a/packages/Angular/Generic/timeline/src/lib/component/timeline.component.css
+++ b/packages/Angular/Generic/timeline/src/lib/component/timeline.component.css
@@ -513,11 +513,13 @@ mj-timeline {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center;
 }
 
 .mj-timeline__card-image--left.mj-timeline__card-image--small {
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
 }
 
 .mj-timeline__card-image--left.mj-timeline__card-image--medium {


### PR DESCRIPTION
## Summary

Grid cells for fields whose names include photo, logo, avatar, or thumbnail — or `GridState` `format.type: image` — render as a linked thumbnail instead of a text URL. `PhotoURL` previously matched the generic URL formatter.

Cards already detected those field names for thumbnails; the grid did not.

## Test plan

- [x] Visual: People grid with DiceBear PhotoURL shows a 32px image that opens the URL
- [ ] CI unit tests for ng-entity-viewer