### PR TITLE
fix(sqlserver): deterministic save-call SQL variable suffixes, with a fail-able 120k test (supersedes #4257, loom #12 WP3)

### DIFF
--- a/.changeset/deterministic-save-sql-suffix.md
+++ b/.changeset/deterministic-save-sql-suffix.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/sqlserver-dataprovider": patch
+---
+
+Make MetadataSync save-call SQL variable suffixes a PK hash instead of a random uuid slice, so recaptures of an unchanged tree are byte-identical and large batches do not collide (loom #12 WP3).

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -1120,6 +1120,15 @@ export class SQLServerDataProvider
   /** Per transaction-group counts so the same PK twice in one batch gets `_hash_2`. */
   private _saveCallSuffixCounts = new WeakMap<object, Map<string, number>>();
 
+  /**
+   * Naming contract for the variable suffix appended to every `@Field` in a
+   * rendered save call: `_<8 lowercase hex>` (see `SaveCallVariableHash`),
+   * followed by `_<n>` with n >= 2 only when the same hash has already been
+   * allocated inside the same `TransactionGroup`. Outside a transaction group
+   * every save is its own batch, so the bare form is always emitted there —
+   * which is what MetadataSync captures contain. Downstream parsers (for
+   * example a MetadataSync ID-parity gate) may rely on this shape.
+   */
   protected allocateSaveCallSuffix(entity: BaseEntity): string {
     const pkValues = entity.PrimaryKey?.KeyValuePairs?.map((p) => p.Value) ?? [];
     const hash = SQLServerDataProvider.SaveCallVariableHash(

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -78,6 +78,7 @@ import { DuplicateRecordDetector } from '@memberjunction/ai-vector-dupe';
 import type { IColocatedVectorHost } from '@memberjunction/ai-vectordb';
 import type { DatabasePlatform } from '@memberjunction/sql-dialect';
 
+import { createHash } from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 import { UUIDsEqual } from '@memberjunction/global';
 import { SQLServerDialect, SQLDialect } from '@memberjunction/sql-dialect';
@@ -1107,8 +1108,42 @@ export class SQLServerDataProvider
   }
 
   /**
+   * First 8 hex of sha1(`${schema}.${table}|${pk values}`). Deterministic so
+   * MetadataSync recaptures of an unchanged tree are byte-identical. Random
+   * uuidv4 suffixes collided across large captures (loom #12 WP3 / F-D).
+   */
+  public static SaveCallVariableHash(schemaName: string, baseTable: string, pkValues: unknown[]): string {
+    const pk = pkValues.map((v) => (v === null || v === undefined ? '' : String(v))).join('|');
+    return createHash('sha1').update(`${schemaName}.${baseTable}|${pk}`).digest('hex').slice(0, 8);
+  }
+
+  /** Per transaction-group counts so the same PK twice in one batch gets `_hash_2`. */
+  private _saveCallSuffixCounts = new WeakMap<object, Map<string, number>>();
+
+  protected allocateSaveCallSuffix(entity: BaseEntity): string {
+    const pkValues = entity.PrimaryKey?.KeyValuePairs?.map((p) => p.Value) ?? [];
+    const hash = SQLServerDataProvider.SaveCallVariableHash(
+      entity.EntityInfo.SchemaName,
+      entity.EntityInfo.BaseTable,
+      pkValues,
+    );
+    const group = entity.TransactionGroup;
+    if (!group) {
+      return `_${hash}`;
+    }
+    let counts = this._saveCallSuffixCounts.get(group);
+    if (!counts) {
+      counts = new Map();
+      this._saveCallSuffixCounts.set(group, counts);
+    }
+    const n = (counts.get(hash) ?? 0) + 1;
+    counts.set(hash, n);
+    return n === 1 ? `_${hash}` : `_${hash}_${n}`;
+  }
+
+  /**
    * Renders the SQL Server DECLARE/SET/EXEC binding for a save call.
-   * Emits per-field uuid-suffixed variables to keep batched saves
+   * Emits per-field PK-hash-suffixed variables to keep batched saves
    * (`SQLServerTransactionGroup`) collision-free. PKs on UPDATE are
    * tail-appended from `entity.PrimaryKey.KeyValuePairs`.
    *
@@ -1124,7 +1159,7 @@ export class SQLServerDataProvider
     isUpdate: boolean,
     _spName: string,
   ): SaveCallBinding {
-    const uniqueSuffix = '_' + uuidv4().substring(0, 8).replace(/-/g, '');
+    const uniqueSuffix = this.allocateSaveCallSuffix(entity);
     const declarations: string[] = [];
     const setStatements: string[] = [];
     const execParams: string[] = [];

--- a/packages/SQLServerDataProvider/src/__tests__/save-delete-paths.test.ts
+++ b/packages/SQLServerDataProvider/src/__tests__/save-delete-paths.test.ts
@@ -388,17 +388,34 @@ describe('SQLServerDataProvider save-call variable suffix (loom #12 WP3)', () =>
     expect(sfxB).toBe(`${sfxA}_2`);
   });
 
-  it('120_000 unique PKs in one batch produce 120_000 distinct declarations after disambiguation', () => {
-    const counts = new Map<string, number>();
+  it('120_000 distinct PKs in one transaction group → 120_000 distinct suffixes, and exactly the two sha1[:8] collisions the keys really produce', async () => {
+    // Drives the REAL allocator, not a re-implementation of it. The expectation is
+    // pinned to what sha1 does on these keys: `dbo.Widget|id-0` … `id-119999`
+    // collide twice in their first 8 hex chars (id-42236 / id-64356 → 031e1622,
+    // id-101514 / id-104669 → 37ccdac1). So a correct allocator yields 119_998
+    // bare `_<hash>` suffixes plus two `_<hash>_2`. Ignoring the transaction
+    // group drops to 119_998 distinct; a degenerate hash yields one bare suffix
+    // and 119_999 `_n` suffixes. Both fail here.
+    const { SQLServerTransactionGroup } = await import('../SQLServerTransactionGroup');
+    const group = new SQLServerTransactionGroup();
+    const info = makeWidgetEntityInfo();
+    const entity = makeNewWidgetEntity(info, TEST_USER);
+    const provider = makeProvider();
+
     const suffixes = new Set<string>();
+    const disambiguated: string[] = [];
     for (let i = 0; i < 120_000; i++) {
-      const hash = SQLServerDataProvider.SaveCallVariableHash('dbo', 'Widget', [`id-${i}`]);
-      const n = (counts.get(hash) ?? 0) + 1;
-      counts.set(hash, n);
-      const sfx = n === 1 ? `_${hash}` : `_${hash}_${n}`;
-      expect(suffixes.has(sfx)).toBe(false);
+      // Hydrate resets the cached PrimaryKey (a plain Set('ID') would not), so one
+      // entity instance can stand in for 120_000 distinct records.
+      entity.Hydrate({ ID: `id-${i}` });
+      entity.TransactionGroup = group;
+      const sfx = provider.AllocateSaveCallSuffix(entity);
+      expect(sfx).toMatch(/^_[0-9a-f]{8}(?:_[0-9]+)?$/);
+      if (sfx.length > 9) disambiguated.push(`id-${i}${sfx}`);
       suffixes.add(sfx);
     }
+
     expect(suffixes.size).toBe(120_000);
+    expect(disambiguated).toEqual(['id-64356_031e1622_2', 'id-104669_37ccdac1_2']);
   });
 });

--- a/packages/SQLServerDataProvider/src/__tests__/save-delete-paths.test.ts
+++ b/packages/SQLServerDataProvider/src/__tests__/save-delete-paths.test.ts
@@ -76,6 +76,10 @@ class SaveDeleteTestProvider extends SQLServerDataProvider {
   protected override async HandleEntityAIActions(): Promise<void> {
     // no-op — AI engine not under test
   }
+
+  public AllocateSaveCallSuffix(entity: BaseEntity): string {
+    return this.allocateSaveCallSuffix(entity);
+  }
 }
 
 function makeProvider(): SaveDeleteTestProvider {
@@ -84,9 +88,9 @@ function makeProvider(): SaveDeleteTestProvider {
   return provider;
 }
 
-/** Extracts the uuid-derived variable suffix RenderSaveCallBinding appended (e.g. '_a1b2c3d4'). */
+/** Extracts the PK-hash variable suffix RenderSaveCallBinding appended (e.g. '_a1b2c3d4' or '_a1b2c3d4_2'). */
 function extractSuffix(sql: string, codeName: string): string {
-  const match = new RegExp(`@${codeName}(_[0-9a-f]{8})`).exec(sql);
+  const match = new RegExp(`@${codeName}(_[0-9a-f]{8}(?:_[0-9]+)?)`).exec(sql);
   expect(match, `expected a suffixed @${codeName} variable in:\n${sql}`).not.toBeNull();
   return (match as RegExpExecArray)[1];
 }
@@ -323,5 +327,78 @@ describe('SQLServerDataProvider delete path (real Delete() → GenerateDeleteSQL
     const deleted = await provider.Delete(entity, new EntityDeleteOptions(), TEST_USER);
 
     expect(deleted).toBe(true);
+  });
+});
+
+describe('SQLServerDataProvider save-call variable suffix (loom #12 WP3)', () => {
+  beforeEach(() => {
+    mssqlState.Reset();
+  });
+
+  it('same record → same suffix across two independent Save() calls', async () => {
+    const info = makeWidgetEntityInfo();
+    const a = makeSavedWidgetEntity(info, TEST_USER);
+    const b = makeSavedWidgetEntity(info, TEST_USER);
+    a.Set('Name', 'Once');
+    b.Set('Name', 'Twice');
+    mssqlState.QueueResult({ rows: [{ ...savedWidgetRow(), Name: 'Once' }] });
+    mssqlState.QueueResult({ rows: [{ ...savedWidgetRow(), Name: 'Twice' }] });
+    const provider = makeProvider();
+    await provider.Save(a, TEST_USER, new EntitySaveOptions());
+    await provider.Save(b, TEST_USER, new EntitySaveOptions());
+    const sfxA = extractSuffix(mssqlState.Queries[0].sql, 'Name');
+    const sfxB = extractSuffix(mssqlState.Queries[1].sql, 'Name');
+    expect(sfxA).toBe(sfxB);
+    expect(sfxA).toMatch(/^_[0-9a-f]{8}$/);
+    expect(sfxA).toBe(
+      '_' + SQLServerDataProvider.SaveCallVariableHash('dbo', 'Widget', ['w-0001']),
+    );
+  });
+
+  it('different records → different suffixes', async () => {
+    const info = makeWidgetEntityInfo();
+    const a = makeSavedWidgetEntity(info, TEST_USER);
+    const b = makeNewWidgetEntity(info, TEST_USER);
+    b.Set('ID', 'w-9999');
+    b.Set('Name', 'Other');
+    b.Set('IsActive', true);
+    a.Set('Name', 'First');
+    mssqlState.QueueResult({ rows: [{ ...savedWidgetRow(), Name: 'First' }] });
+    mssqlState.QueueResult({ rows: [{ ...savedWidgetRow(), ID: 'w-9999', Name: 'Other' }] });
+    const provider = makeProvider();
+    await provider.Save(a, TEST_USER, new EntitySaveOptions());
+    await provider.Save(b, TEST_USER, new EntitySaveOptions());
+    expect(extractSuffix(mssqlState.Queries[0].sql, 'Name')).not.toBe(
+      extractSuffix(mssqlState.Queries[1].sql, 'Name'),
+    );
+  });
+
+  it('same record twice inside one transaction group → _hash and _hash_2', async () => {
+    const { SQLServerTransactionGroup } = await import('../SQLServerTransactionGroup');
+    const group = new SQLServerTransactionGroup();
+    const info = makeWidgetEntityInfo();
+    const a = makeSavedWidgetEntity(info, TEST_USER);
+    const b = makeSavedWidgetEntity(info, TEST_USER);
+    a.TransactionGroup = group;
+    b.TransactionGroup = group;
+    const provider = makeProvider();
+    const sfxA = provider.AllocateSaveCallSuffix(a);
+    const sfxB = provider.AllocateSaveCallSuffix(b);
+    expect(sfxA).toMatch(/^_[0-9a-f]{8}$/);
+    expect(sfxB).toBe(`${sfxA}_2`);
+  });
+
+  it('120_000 unique PKs in one batch produce 120_000 distinct declarations after disambiguation', () => {
+    const counts = new Map<string, number>();
+    const suffixes = new Set<string>();
+    for (let i = 0; i < 120_000; i++) {
+      const hash = SQLServerDataProvider.SaveCallVariableHash('dbo', 'Widget', [`id-${i}`]);
+      const n = (counts.get(hash) ?? 0) + 1;
+      counts.set(hash, n);
+      const sfx = n === 1 ? `_${hash}` : `_${hash}_${n}`;
+      expect(suffixes.has(sfx)).toBe(false);
+      suffixes.add(sfx);
+    }
+    expect(suffixes.size).toBe(120_000);
   });
 });


### PR DESCRIPTION
Supersedes #4257 (same first commit, `489aecd7`, kept intact) and adds the two round-1 review items on top. Implements **WP3** of [loom #12](https://github.com/MemberJunction/loom/pull/12) (F-D).

## What the WP3 commit does (unchanged from #4257)

`SQLServerDataProvider.RenderSaveCallBinding` no longer mints `@Field_<uuidv4 8 hex>`. The suffix is `sha1(`${schema}.${table}|${pk values}`)[:8]`; the same record saved twice inside one `SQLServerTransactionGroup` gets `_hash` then `_hash_2`. MetadataSync recaptures of an unchanged tree become byte-identical, and the birthday collisions seen across cheese's 120k-variable captures stop being random. PostgreSQL's binding is positional / json-arg and is untouched. Changeset: `patch`.

## What this PR adds (`6d57f6e5`)

1. **The 120,000-record test now drives the real allocator.** In #4257 it re-implemented the counting loop inline and asserted on its own copy, so it passed even with `SaveCallVariableHash` returning a constant. It now allocates suffixes for 120,000 distinct PKs on a real entity inside one transaction group (`Hydrate` per iteration, because `Set('ID')` does not clear the cached `PrimaryKey`) and pins what sha1 really does on those keys: two first-8-hex collisions (`id-42236`/`id-64356` → `031e1622`, `id-101514`/`id-104669` → `37ccdac1`), so 119,998 bare suffixes plus exactly two `_2`.
2. **The suffix naming contract is stated in the allocator's JSDoc**: `_<8 lowercase hex>`, then `_<n>` (n ≥ 2) only when the same hash repeats inside one transaction group; never outside one, which is what MetadataSync captures contain. Cheese's `check-sync-id-parity.mjs` regex keys on the bare form; WP4 should widen it to accept `(_\d+)?`.

## Verified by running (clean checkout, provider's 63 workspace deps built)

| Check | Result |
|---|---|
| `save-delete-paths.test.ts` | 14/14 |
| Full `@memberjunction/sqlserver-dataprovider` suite | 145/145 across 13 files |
| `pnpm run build` for the package | exit 0 |

Mutations of `SQLServerDataProvider.ts`, each restored before the next:

| Mutation | Old 120k test | New 120k test | Other suffix tests |
|---|---|---|---|
| M1 `uuidv4().substring(0, 8)` restored in `RenderSaveCallBinding` | passes | passes (allocator untouched) | `same record → same suffix` fails |
| M2 allocator ignores the transaction group | passes | **fails**: `expected '_6679d1fd' to be '_6679d1fd_2'` | `same record twice inside one transaction group` fails |
| M3 `SaveCallVariableHash` returns `'00000000'` | passes | **fails**: `expected '_00000000' not to be '_00000000'` | `different records → different suffixes` fails |

The old test surviving all three is why it was rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111QTtJ2moiCVtEMeLknW9t

---
_Generated by [Claude Code](https://claude.ai/code/session_0111QTtJ2moiCVtEMeLknW9t)_