### PR TITLE
feat: Image, Color, JSON EntityField.ExtendedType

### DIFF
--- a/.changeset/extended-type-image-color-json.md
+++ b/.changeset/extended-type-image-color-json.md
@@ -1,0 +1,8 @@
+---
+"@memberjunction/core": minor
+"@memberjunction/ng-base-forms": patch
+"@memberjunction/ng-entity-viewer": patch
+"@memberjunction/codegen-lib": patch
+---
+
+Add Image, Color, and JSON to EntityField.ExtendedType. Forms render an image thumbnail (including inline base64 / data URIs) with an edit-mode upload capped at the field's MaxLength, a color swatch + hex editor, and a pretty-printed JSON textarea. Entity-viewer grid/cards/timeline key image cells off ExtendedType rather than field-name heuristics. PhotoURL, LogoURL, and ImageURL are reclassified to Image with AutoUpdateExtendedType locked so CodeGen cannot overwrite them.

--- a/migrations/v6/V202609051200__v6.1.x__EntityField_ExtendedType_Image_Color_JSON.sql
+++ b/migrations/v6/V202609051200__v6.1.x__EntityField_ExtendedType_Image_Color_JSON.sql
@@ -1,14 +1,11 @@
 -- Widen EntityField.ExtendedType to Image, Color, and JSON.
 --
--- Image  — the value is an image URL, a data:image URI, or raw image base64. UI surfaces
---          (forms, entity-viewer grid/cards/timeline) render a thumbnail. In edit mode the
---          form field allows replacing the value with an upload, capped at the field's
---          MaxLength (or 1 MiB when the column is nvarchar(max)).
--- Color  — the value is a CSS color (hex / rgb / hsl). Forms show a swatch + hex editor.
--- JSON   — the value is a JSON document. Validated on save and pretty-printed in forms.
+-- Image  — the value is an image URL, a data:image URI, or raw image base64.
+-- Color  — the value is a CSS color (hex / rgb / hsl).
+-- JSON   — the value is a JSON document.
 --
--- Also reclassifies existing PhotoURL / LogoURL / ImageURL fields from URL → Image and
--- locks AutoUpdateExtendedType so CodeGen/LLM cannot overwrite the choice.
+-- DDL only: drop and re-create the CHECK constraint. CodeGen regenerates the
+-- EntityFieldValue list and typed unions from this constraint.
 
 ALTER TABLE ${flyway:defaultSchema}.EntityField DROP CONSTRAINT CK_EntityField_ExtendedType;
 ALTER TABLE ${flyway:defaultSchema}.EntityField ADD CONSTRAINT CK_EntityField_ExtendedType CHECK (
@@ -16,60 +13,146 @@ ALTER TABLE ${flyway:defaultSchema}.EntityField ADD CONSTRAINT CK_EntityField_Ex
 );
 GO
 
--- Park existing value-list sequences so the alphabetical resequence cannot collide
--- with the unique (EntityFieldID, Sequence) index.
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue]
-   SET Sequence = Sequence + 100
- WHERE EntityFieldID = '055817F0-6F36-EF11-86D4-6045BDEE16E6';
-GO
 
--- Resequence the existing list alphabetically, leaving room for Color / Image / JSON.
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 1  WHERE ID = '05F5A9C5-F1C8-4694-9058-73EBFD594C6A'; -- Code
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 3  WHERE ID = 'B4A82E72-92D7-40D4-8739-19DA726433ED'; -- Email
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 4  WHERE ID = '1E24001A-7E77-48FD-9AE7-860E114F257D'; -- FaceTime
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 5  WHERE ID = 'E977A29A-6FFA-4294-8309-A1698A94969A'; -- Geo
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 6  WHERE ID = 'D8DBB0DC-44D0-4680-B336-71394F02963A'; -- GeoAddress
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 7  WHERE ID = 'E9E3AEA7-9F3C-47C8-9CE2-5FDF64D34ACF'; -- GeoCity
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 8  WHERE ID = 'AFAE0954-1959-46D7-AD86-7B042BFBAEBB'; -- GeoCountry
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 9  WHERE ID = '38D62F4E-338A-4BF2-B1A6-16106FA0FA01'; -- GeoLatitude
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 10 WHERE ID = '7E3F3656-AD62-4294-A3A9-2EA254C91269'; -- GeoLongitude
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 11 WHERE ID = 'B6D14033-C479-4167-B075-E2796F8A159D'; -- GeoPostalCode
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 12 WHERE ID = 'D2054017-412B-457A-A98E-AA2400128BAD'; -- GeoStateProvince
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 13 WHERE ID = '17A9A6B7-36E3-49A8-B3C8-7185158E0B92'; -- HTML
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 14 WHERE ID = 'A54D1E4D-1190-4C92-B100-523C072CB878'; -- Icon
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 17 WHERE ID = '5434DBD9-19F2-41C9-B8AC-3A4E2C669602'; -- Markdown
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 18 WHERE ID = 'F45F1816-CAAA-434C-8239-3932D448DEB6'; -- MSTeams
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 19 WHERE ID = '68A4F7CA-B203-40C8-ABAC-A91122866B00'; -- Other
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 20 WHERE ID = 'DFD25989-75AD-4F5B-8F18-88E687E067E5'; -- SIP
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 21 WHERE ID = '7758B42A-D133-4052-9991-1869AA5DFD74'; -- SMS
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 22 WHERE ID = '5B3460FB-56CC-4DAB-8375-60BDCD11FE35'; -- Skype
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 23 WHERE ID = 'E1D0D56C-10D6-4A7C-BED8-D4F7A439204D'; -- Tel
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 24 WHERE ID = 'A5865195-4AD1-432D-8797-57D25F3741FF'; -- URL
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 25 WHERE ID = '356C61B4-27B5-48F3-A240-31B0CC6CA23D'; -- WhatsApp
-UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 26 WHERE ID = '45F07992-2974-4F4B-A5C8-FAECCF86BDB9'; -- ZoomMtg
-GO
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/**************************************************************************************************
+ **************************************************************************************************
+ **                                                                                              **
+ **              CODEGEN OUTPUT — EntityField ExtendedType Image/Color/JSON (v6.1.x)             **
+ **                                                                                              **
+ **  Everything below this banner is generated by `mj codegen` AFTER the hand-authored DDL above **
+ **  was applied and the schema introspected. DO NOT hand-edit below this line.                   **
+ **                                                                                              **
+ **************************************************************************************************
+ **************************************************************************************************/
+
+/* SQL text to insert entity field value with ID 572f309f-0918-41fb-a18e-8dfae6d6d642 */
 INSERT INTO [${flyway:defaultSchema}].[EntityFieldValue]
-    ([ID], [EntityFieldID], [Sequence], [Value], [Code], [__mj_CreatedAt], [__mj_UpdatedAt])
-VALUES
-    ('7648FA8F-1C25-49C1-A559-9C79B4689BE8', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 2,  'Color', 'Color', GETUTCDATE(), GETUTCDATE()),
-    ('DF27406B-3F1C-4FB8-8E66-FE61B7F81BC8', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 15, 'Image', 'Image', GETUTCDATE(), GETUTCDATE()),
-    ('17BBF9B5-C49F-4FD5-9562-28EECBD8EDA5', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 16, 'JSON',  'JSON',  GETUTCDATE(), GETUTCDATE());
-GO
+                                       ([ID], [EntityFieldID], [Sequence], [Value], [Code], [__mj_CreatedAt], [__mj_UpdatedAt])
+                                    VALUES
+                                       ('572f309f-0918-41fb-a18e-8dfae6d6d642', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 2, 'Color', 'Color', GETUTCDATE(), GETUTCDATE());
 
--- Reclassify well-known image URL columns. Lock AutoUpdateExtendedType so CodeGen cannot
--- overwrite Image back to URL on the next LLM pass.
-UPDATE [${flyway:defaultSchema}].[EntityField]
-   SET ExtendedType = 'Image',
-       AutoUpdateExtendedType = 0
- WHERE Name IN (N'PhotoURL', N'LogoURL', N'ImageURL')
-   AND (ExtendedType IS NULL OR ExtendedType IN (N'URL', N'Other'));
-GO
+/* SQL text to insert entity field value with ID ef6f2947-4c83-4959-884a-32cd2454ffe1 */
+INSERT INTO [${flyway:defaultSchema}].[EntityFieldValue]
+                                       ([ID], [EntityFieldID], [Sequence], [Value], [Code], [__mj_CreatedAt], [__mj_UpdatedAt])
+                                    VALUES
+                                       ('ef6f2947-4c83-4959-884a-32cd2454ffe1', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 15, 'Image', 'Image', GETUTCDATE(), GETUTCDATE());
 
-EXEC sp_updateextendedproperty
-    @name = N'MS_Description',
-    @value = N'Defines extended behaviors for a field such as Email, Web URLs, Code, Markdown, HTML, Icon, Image, Color, and JSON. When set to Image, the field holds an image URL or inline image (data URI / base64) and UI surfaces render a thumbnail. Color is a CSS color. JSON is a JSON document, validated on save.',
-    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
-    @level1type = N'TABLE',  @level1name = N'EntityField',
-    @level2type = N'COLUMN', @level2name = N'ExtendedType';
-GO
+/* SQL text to insert entity field value with ID 68f5e918-21ac-4c78-a8c7-58077cdf6556 */
+INSERT INTO [${flyway:defaultSchema}].[EntityFieldValue]
+                                       ([ID], [EntityFieldID], [Sequence], [Value], [Code], [__mj_CreatedAt], [__mj_UpdatedAt])
+                                    VALUES
+                                       ('68f5e918-21ac-4c78-a8c7-58077cdf6556', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 16, 'JSON', 'JSON', GETUTCDATE(), GETUTCDATE());
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=3 WHERE ID='B4A82E72-92D7-40D4-8739-19DA726433ED';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=4 WHERE ID='1E24001A-7E77-48FD-9AE7-860E114F257D';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=5 WHERE ID='E977A29A-6FFA-4294-8309-A1698A94969A';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=6 WHERE ID='D8DBB0DC-44D0-4680-B336-71394F02963A';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=7 WHERE ID='E9E3AEA7-9F3C-47C8-9CE2-5FDF64D34ACF';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=8 WHERE ID='AFAE0954-1959-46D7-AD86-7B042BFBAEBB';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=9 WHERE ID='38D62F4E-338A-4BF2-B1A6-16106FA0FA01';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=10 WHERE ID='7E3F3656-AD62-4294-A3A9-2EA254C91269';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=11 WHERE ID='B6D14033-C479-4167-B075-E2796F8A159D';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=12 WHERE ID='D2054017-412B-457A-A98E-AA2400128BAD';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=13 WHERE ID='17A9A6B7-36E3-49A8-B3C8-7185158E0B92';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=14 WHERE ID='A54D1E4D-1190-4C92-B100-523C072CB878';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=17 WHERE ID='F45F1816-CAAA-434C-8239-3932D448DEB6';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=18 WHERE ID='5434DBD9-19F2-41C9-B8AC-3A4E2C669602';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=19 WHERE ID='68A4F7CA-B203-40C8-ABAC-A91122866B00';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=20 WHERE ID='DFD25989-75AD-4F5B-8F18-88E687E067E5';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=21 WHERE ID='7758B42A-D133-4052-9991-1869AA5DFD74';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=22 WHERE ID='5B3460FB-56CC-4DAB-8375-60BDCD11FE35';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=23 WHERE ID='E1D0D56C-10D6-4A7C-BED8-D4F7A439204D';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=24 WHERE ID='A5865195-4AD1-432D-8797-57D25F3741FF';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=25 WHERE ID='356C61B4-27B5-48F3-A240-31B0CC6CA23D';
+
+/* SQL text to update entity field value sequence */
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence=26 WHERE ID='45F07992-2974-4F4B-A5C8-FAECCF86BDB9';

--- a/migrations/v6/V202609051200__v6.1.x__EntityField_ExtendedType_Image_Color_JSON.sql
+++ b/migrations/v6/V202609051200__v6.1.x__EntityField_ExtendedType_Image_Color_JSON.sql
@@ -1,0 +1,75 @@
+-- Widen EntityField.ExtendedType to Image, Color, and JSON.
+--
+-- Image  — the value is an image URL, a data:image URI, or raw image base64. UI surfaces
+--          (forms, entity-viewer grid/cards/timeline) render a thumbnail. In edit mode the
+--          form field allows replacing the value with an upload, capped at the field's
+--          MaxLength (or 1 MiB when the column is nvarchar(max)).
+-- Color  — the value is a CSS color (hex / rgb / hsl). Forms show a swatch + hex editor.
+-- JSON   — the value is a JSON document. Validated on save and pretty-printed in forms.
+--
+-- Also reclassifies existing PhotoURL / LogoURL / ImageURL fields from URL → Image and
+-- locks AutoUpdateExtendedType so CodeGen/LLM cannot overwrite the choice.
+
+ALTER TABLE ${flyway:defaultSchema}.EntityField DROP CONSTRAINT CK_EntityField_ExtendedType;
+ALTER TABLE ${flyway:defaultSchema}.EntityField ADD CONSTRAINT CK_EntityField_ExtendedType CHECK (
+    ExtendedType IN ('Code', 'Color', 'Email', 'FaceTime', 'Geo', 'GeoLatitude', 'GeoLongitude', 'GeoCountry', 'GeoStateProvince', 'GeoCity', 'GeoPostalCode', 'GeoAddress', 'HTML', 'Icon', 'Image', 'JSON', 'Markdown', 'MSTeams', 'Other', 'SIP', 'SMS', 'Skype', 'Tel', 'URL', 'WhatsApp', 'ZoomMtg')
+);
+GO
+
+-- Park existing value-list sequences so the alphabetical resequence cannot collide
+-- with the unique (EntityFieldID, Sequence) index.
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue]
+   SET Sequence = Sequence + 100
+ WHERE EntityFieldID = '055817F0-6F36-EF11-86D4-6045BDEE16E6';
+GO
+
+-- Resequence the existing list alphabetically, leaving room for Color / Image / JSON.
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 1  WHERE ID = '05F5A9C5-F1C8-4694-9058-73EBFD594C6A'; -- Code
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 3  WHERE ID = 'B4A82E72-92D7-40D4-8739-19DA726433ED'; -- Email
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 4  WHERE ID = '1E24001A-7E77-48FD-9AE7-860E114F257D'; -- FaceTime
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 5  WHERE ID = 'E977A29A-6FFA-4294-8309-A1698A94969A'; -- Geo
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 6  WHERE ID = 'D8DBB0DC-44D0-4680-B336-71394F02963A'; -- GeoAddress
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 7  WHERE ID = 'E9E3AEA7-9F3C-47C8-9CE2-5FDF64D34ACF'; -- GeoCity
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 8  WHERE ID = 'AFAE0954-1959-46D7-AD86-7B042BFBAEBB'; -- GeoCountry
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 9  WHERE ID = '38D62F4E-338A-4BF2-B1A6-16106FA0FA01'; -- GeoLatitude
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 10 WHERE ID = '7E3F3656-AD62-4294-A3A9-2EA254C91269'; -- GeoLongitude
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 11 WHERE ID = 'B6D14033-C479-4167-B075-E2796F8A159D'; -- GeoPostalCode
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 12 WHERE ID = 'D2054017-412B-457A-A98E-AA2400128BAD'; -- GeoStateProvince
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 13 WHERE ID = '17A9A6B7-36E3-49A8-B3C8-7185158E0B92'; -- HTML
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 14 WHERE ID = 'A54D1E4D-1190-4C92-B100-523C072CB878'; -- Icon
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 17 WHERE ID = '5434DBD9-19F2-41C9-B8AC-3A4E2C669602'; -- Markdown
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 18 WHERE ID = 'F45F1816-CAAA-434C-8239-3932D448DEB6'; -- MSTeams
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 19 WHERE ID = '68A4F7CA-B203-40C8-ABAC-A91122866B00'; -- Other
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 20 WHERE ID = 'DFD25989-75AD-4F5B-8F18-88E687E067E5'; -- SIP
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 21 WHERE ID = '7758B42A-D133-4052-9991-1869AA5DFD74'; -- SMS
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 22 WHERE ID = '5B3460FB-56CC-4DAB-8375-60BDCD11FE35'; -- Skype
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 23 WHERE ID = 'E1D0D56C-10D6-4A7C-BED8-D4F7A439204D'; -- Tel
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 24 WHERE ID = 'A5865195-4AD1-432D-8797-57D25F3741FF'; -- URL
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 25 WHERE ID = '356C61B4-27B5-48F3-A240-31B0CC6CA23D'; -- WhatsApp
+UPDATE [${flyway:defaultSchema}].[EntityFieldValue] SET Sequence = 26 WHERE ID = '45F07992-2974-4F4B-A5C8-FAECCF86BDB9'; -- ZoomMtg
+GO
+
+INSERT INTO [${flyway:defaultSchema}].[EntityFieldValue]
+    ([ID], [EntityFieldID], [Sequence], [Value], [Code], [__mj_CreatedAt], [__mj_UpdatedAt])
+VALUES
+    ('7648FA8F-1C25-49C1-A559-9C79B4689BE8', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 2,  'Color', 'Color', GETUTCDATE(), GETUTCDATE()),
+    ('DF27406B-3F1C-4FB8-8E66-FE61B7F81BC8', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 15, 'Image', 'Image', GETUTCDATE(), GETUTCDATE()),
+    ('17BBF9B5-C49F-4FD5-9562-28EECBD8EDA5', '055817F0-6F36-EF11-86D4-6045BDEE16E6', 16, 'JSON',  'JSON',  GETUTCDATE(), GETUTCDATE());
+GO
+
+-- Reclassify well-known image URL columns. Lock AutoUpdateExtendedType so CodeGen cannot
+-- overwrite Image back to URL on the next LLM pass.
+UPDATE [${flyway:defaultSchema}].[EntityField]
+   SET ExtendedType = 'Image',
+       AutoUpdateExtendedType = 0
+ WHERE Name IN (N'PhotoURL', N'LogoURL', N'ImageURL')
+   AND (ExtendedType IS NULL OR ExtendedType IN (N'URL', N'Other'));
+GO
+
+EXEC sp_updateextendedproperty
+    @name = N'MS_Description',
+    @value = N'Defines extended behaviors for a field such as Email, Web URLs, Code, Markdown, HTML, Icon, Image, Color, and JSON. When set to Image, the field holds an image URL or inline image (data URI / base64) and UI surfaces render a thumbnail. Color is a CSS color. JSON is a JSON document, validated on save.',
+    @level0type = N'SCHEMA', @level0name = N'${flyway:defaultSchema}',
+    @level1type = N'TABLE',  @level1name = N'EntityField',
+    @level2type = N'COLUMN', @level2name = N'ExtendedType';
+GO

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.css
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.css
@@ -1148,6 +1148,130 @@
   color: var(--mj-status-warning);
 }
 
+/* ============================================
+   IMAGE / COLOR / JSON EXTENDED TYPES
+   ============================================ */
+.mj-forms-image {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.mj-forms-image-preview {
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  object-position: center;
+  border-radius: 8px;
+  border: 1px solid var(--mj-border-default);
+  background: var(--mj-bg-surface);
+  display: block;
+}
+
+.mj-forms-image-preview--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--mj-text-muted);
+  font-size: 22px;
+}
+
+.mj-forms-image-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--mj-text-secondary);
+}
+
+.mj-forms-image-hint {
+  color: var(--mj-text-muted);
+}
+
+.mj-forms-image-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mj-forms-image-file {
+  display: none;
+}
+
+.mj-forms-image-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  font-weight: 600;
+  color: var(--mj-brand-primary);
+  background: color-mix(in srgb, var(--mj-brand-primary) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--mj-brand-primary) 25%, transparent);
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.mj-forms-image-btn:hover {
+  background: color-mix(in srgb, var(--mj-brand-primary) 14%, transparent);
+}
+
+.mj-forms-image-btn--ghost {
+  color: var(--mj-text-secondary);
+  background: transparent;
+  border-color: var(--mj-border-default);
+  font-weight: 500;
+}
+
+.mj-forms-image--edit .mj-forms-field-input {
+  width: 100%;
+}
+
+.mj-forms-color {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.mj-forms-color-swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  border: 1px solid var(--mj-border-default);
+  flex-shrink: 0;
+}
+
+.mj-forms-color-picker {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--mj-border-default);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.mj-forms-color-hex {
+  max-width: 160px;
+}
+
+.mj-forms-json {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 12.5px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  max-height: 360px;
+  overflow: auto;
+  width: 100%;
+}
+
 @keyframes mj-validation-slide-in {
   from {
     opacity: 0;

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.dom.test.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.dom.test.ts
@@ -88,6 +88,9 @@ function makeWidgetEntityInfo(): EntityInfo {
       },
       { ID: 'F8', Name: 'Email', Type: 'nvarchar', Length: 200, AllowsNull: true, AllowUpdateAPI: true },
       { ID: 'F9', Name: 'Website', Type: 'nvarchar', Length: 400, AllowsNull: true, AllowUpdateAPI: true },
+      { ID: 'F10', Name: 'PhotoURL', Type: 'nvarchar', Length: 8000, AllowsNull: true, AllowUpdateAPI: true, ExtendedType: 'Image' },
+      { ID: 'F11', Name: 'ThemeColor', Type: 'nvarchar', Length: 40, AllowsNull: true, AllowUpdateAPI: true, ExtendedType: 'Color' },
+      { ID: 'F12', Name: 'ConfigJSON', Type: 'nvarchar', Length: -1, AllowsNull: true, AllowUpdateAPI: true, ExtendedType: 'JSON' },
     ],
   });
 }
@@ -196,6 +199,69 @@ describe('MjFormFieldComponent (DOM)', () => {
         expect(e.Url).toBe('https://example.com');
         expect(e.OpenInNewTab).toBe(true);
       }
+    });
+
+    const PNG_1X1 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+    const PNG_DATA_URI = `data:image/png;base64,${PNG_1X1}`;
+
+    it('Image ExtendedType renders a data URI as a thumbnail and never dumps the base64 as text', () => {
+      const f = render({
+        Record: makeWidget({ PhotoURL: PNG_DATA_URI }),
+        FieldName: 'PhotoURL',
+        Type: 'textbox',
+        LinkType: 'URL',
+      });
+      const img = query(f, 'img.mj-forms-image-preview') as HTMLImageElement;
+      expect(img).not.toBeNull();
+      expect(img.getAttribute('src')).toBe(PNG_DATA_URI);
+      expect(text(f, '.mj-forms-image-meta')).toContain('Inline image');
+      expect(query(f, '.mj-forms-field-link')).toBeNull();
+    });
+
+    it('Image ExtendedType renders a raw base64 payload (no data: prefix) as an image', () => {
+      const f = render({
+        Record: makeWidget({ PhotoURL: PNG_1X1 }),
+        FieldName: 'PhotoURL',
+        Type: 'textbox',
+      });
+      const img = query(f, 'img.mj-forms-image-preview') as HTMLImageElement;
+      expect(img).not.toBeNull();
+      expect(img.getAttribute('src')).toBe(PNG_DATA_URI);
+    });
+
+    it('Image ExtendedType renders an https URL as a thumbnail even when LinkType is URL', () => {
+      const f = render({
+        Record: makeWidget({ PhotoURL: 'https://cdn.example.com/avatar.png' }),
+        FieldName: 'PhotoURL',
+        Type: 'textbox',
+        LinkType: 'URL',
+      });
+      const img = query(f, 'img.mj-forms-image-preview') as HTMLImageElement;
+      expect(img).not.toBeNull();
+      expect(img.getAttribute('src')).toBe('https://cdn.example.com/avatar.png');
+    });
+
+    it('Color ExtendedType renders a swatch and the hex value', () => {
+      const f = render({
+        Record: makeWidget({ ThemeColor: '#aabbcc' }),
+        FieldName: 'ThemeColor',
+        Type: 'textbox',
+      });
+      const swatch = query(f, '.mj-forms-color-swatch') as HTMLElement;
+      expect(swatch).not.toBeNull();
+      expect(swatch.style.backgroundColor).toBe('rgb(170, 187, 204)');
+      expect(text(f, '.mj-forms-color')).toContain('#aabbcc');
+    });
+
+    it('JSON ExtendedType pretty-prints in read mode', () => {
+      const f = render({
+        Record: makeWidget({ ConfigJSON: '{"a":1}' }),
+        FieldName: 'ConfigJSON',
+        Type: 'textarea',
+      });
+      expect(text(f, 'pre.mj-forms-json')).toContain('"a"');
+      expect(text(f, 'pre.mj-forms-json')).toContain('1');
     });
   });
 
@@ -332,6 +398,41 @@ describe('MjFormFieldComponent (DOM)', () => {
       const f = render({ Record: makeWidget(), FieldName: 'Name', Type: 'textbox', EditMode: true });
       expect(query(f, '.mj-forms-field')).not.toBeNull();
       expect(hasClass(f, '.mj-forms-field', 'mj-forms-field--required-empty')).toBe(false);
+    });
+
+    it('Image ExtendedType edit mode shows upload, hides the data URI from the URL box, and Clear empties the field', () => {
+      const png =
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+      const record = makeWidget({ PhotoURL: png });
+      const f = render({ Record: record, FieldName: 'PhotoURL', Type: 'textbox', EditMode: true });
+      expect(query(f, 'img.mj-forms-image-preview')).not.toBeNull();
+      expect(query(f, 'input.mj-forms-image-file')).not.toBeNull();
+      expect(text(f, '.mj-forms-image-btn')).toContain('Replace');
+      const urlBox = query(f, 'input.mj-forms-field-input') as HTMLInputElement;
+      expect(urlBox.value).toBe('');
+      click(f, '.mj-forms-image-btn--ghost');
+      f.detectChanges();
+      expect(record.Get('PhotoURL')).toBeNull();
+    });
+
+    it('Color ExtendedType edit mode renders a color picker and hex text', () => {
+      const record = makeWidget({ ThemeColor: '#ff0000' });
+      const f = render({ Record: record, FieldName: 'ThemeColor', Type: 'textbox', EditMode: true });
+      const picker = query(f, 'input.mj-forms-color-picker') as HTMLInputElement;
+      expect(picker).not.toBeNull();
+      expect(picker.value).toBe('#ff0000');
+      typeInto(f, 'input.mj-forms-color-hex', '#00ff00');
+      expect(record.Get('ThemeColor')).toBe('#00ff00');
+    });
+
+    it('JSON ExtendedType edit mode uses a textarea and pretty-prints on blur', () => {
+      const record = makeWidget({ ConfigJSON: '{"a":1}' });
+      const f = render({ Record: record, FieldName: 'ConfigJSON', Type: 'textarea', EditMode: true });
+      const area = query(f, 'textarea.mj-forms-json') as HTMLTextAreaElement;
+      expect(area).not.toBeNull();
+      area.dispatchEvent(new Event('blur'));
+      f.detectChanges();
+      expect(String(record.Get('ConfigJSON'))).toContain('\n');
     });
 
     it('autocomplete: focus shows all value-list options, typing filters them, and mousedown selects', () => {

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.html
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.html
@@ -18,6 +18,32 @@
             }
           </span>
         }
+        @else if (ExtendedDisplay === 'image') {
+          <div class="mj-forms-image">
+            @if (ImagePreviewSrc) {
+              <img class="mj-forms-image-preview" [src]="ImagePreviewSrc" alt="" />
+            }
+            @if (IsInlineImageValue) {
+              <span class="mj-forms-image-meta">Inline image ({{ ImageValueSizeLabel }})</span>
+            } @else if (ImagePreviewSrc) {
+              <a class="mj-forms-field-link" (click)="OnUrlLinkClick($event)" title="Open image">
+                {{ ImageUrlDisplay }}
+                <i class="fa-solid fa-arrow-up-right-from-square mj-forms-field-link-icon"></i>
+              </a>
+            } @else {
+              <span class="mj-forms-field-value">{{ FormatValue() }}</span>
+            }
+          </div>
+        }
+        @else if (ExtendedDisplay === 'color') {
+          <div class="mj-forms-color">
+            <span class="mj-forms-color-swatch" [style.background-color]="ColorSwatchValue"></span>
+            <span class="mj-forms-field-value">{{ FormatValue() }}</span>
+          </div>
+        }
+        @else if (ExtendedDisplay === 'json') {
+          <pre class="mj-forms-json">{{ JsonDisplayValue }}</pre>
+        }
         @else {
           @switch (LinkType) {
             @case ('Email') {
@@ -290,6 +316,60 @@
               </div>
             }
           </div>
+        }
+        @else if (ExtendedDisplay === 'image') {
+          <div class="mj-forms-image mj-forms-image--edit">
+            @if (ImagePreviewSrc) {
+              <img class="mj-forms-image-preview" [src]="ImagePreviewSrc" alt="" />
+            } @else {
+              <div class="mj-forms-image-preview mj-forms-image-preview--empty" aria-hidden="true">
+                <i class="fa-regular fa-image"></i>
+              </div>
+            }
+            <div class="mj-forms-image-meta">
+              @if (IsInlineImageValue) {
+                <span>Inline image ({{ ImageValueSizeLabel }})</span>
+              }
+              <span class="mj-forms-image-hint">Max {{ ImageMaxSizeLabel }}</span>
+            </div>
+            <div class="mj-forms-image-actions">
+              <input #imageFileInput type="file" accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+                class="mj-forms-image-file" (change)="OnImageFileSelected($event)">
+              <button type="button" class="mj-forms-image-btn" (click)="imageFileInput.click()">
+                <i class="fa-solid fa-upload"></i>
+                {{ ImagePreviewSrc ? 'Replace' : 'Upload' }}
+              </button>
+              @if (ImagePreviewSrc) {
+                <button type="button" class="mj-forms-image-btn mj-forms-image-btn--ghost" (click)="OnImageClear()">Clear</button>
+              }
+            </div>
+            <input type="text"
+              class="mj-forms-field-input"
+              [value]="ImageUrlInputValue"
+              (input)="OnImageUrlInput($event)"
+              placeholder="https://… or paste a data URI">
+          </div>
+        }
+        @else if (ExtendedDisplay === 'color') {
+          <div class="mj-forms-color mj-forms-color--edit">
+            <input type="color"
+              class="mj-forms-color-picker"
+              [value]="ColorPickerValue"
+              (input)="OnColorPickerInput($event)"
+              [attr.aria-label]="DisplayName + ' color'">
+            <input type="text"
+              class="mj-forms-field-input mj-forms-color-hex"
+              [value]="FormatValue()"
+              (input)="OnInputChange($event)"
+              placeholder="#RRGGBB">
+          </div>
+        }
+        @else if (ExtendedDisplay === 'json') {
+          <textarea
+            class="mj-forms-field-input mj-forms-field-input--textarea mj-forms-json"
+            [value]="FormatValue()"
+            (input)="OnInputChange($event)"
+            (blur)="OnJsonBlur()"></textarea>
         }
         @else if (EditRichTextMode !== 'plain') {
           <!-- Markdown / HTML / Code long-text: edit raw with a syntax-highlighted code editor -->

--- a/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/field/form-field.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ChangeDetectorRef, inject, OnChanges, SimpleChanges, OnDestroy, ElementRef, Renderer2 } from '@angular/core';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
-import { BaseEntity, EntityInfo, EntityFieldInfo, EntityFieldTSType, CompositeKey, KeyValuePair, RunView } from '@memberjunction/core';
+import { BaseEntity, EntityInfo, EntityFieldInfo, EntityFieldTSType, CompositeKey, KeyValuePair, RunView, CoerceImageSrc, IsInlineImageDataUri, CoerceRawImageBase64ToDataUri, MaxStoredImageChars, MaxInlineImageBytes, FormatByteSize, ParseCssHexColor, PrettyPrintJson } from '@memberjunction/core';
 import { BaseEngineRegistry } from '@memberjunction/core';
 import { ValidationErrorInfo, HighlightSearchMatches, detectRichTextFormat, RichTextFormat, UUIDsEqual } from '@memberjunction/global';
 import { FormContext } from '../types/form-types';
@@ -296,6 +296,9 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
   /** Whether the user has interacted with (changed) this field */
   private _touched = false;
 
+  /** Set when an image upload is rejected (type/size) — shown with field validation. */
+  private imageUploadError: string | null = null;
+
   /** Locally computed validation errors for this field */
   private _fieldErrors: ValidationErrorInfo[] = [];
 
@@ -321,6 +324,7 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
 
   /** Whether this field has active error-level validation failures to display */
   get ShowErrors(): boolean {
+    if (this.imageUploadError) return true;
     return this.ShowValidation && this.FieldErrors.some(e => e.Type === 'Failure');
   }
 
@@ -331,8 +335,16 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
 
   /** Error messages to render in the template */
   get DisplayErrors(): ValidationErrorInfo[] {
-    if (!this.ShowValidation) return [];
-    return this.FieldErrors.filter(e => e.Type === 'Failure');
+    const errors = this.ShowValidation
+      ? this.FieldErrors.filter(e => e.Type === 'Failure')
+      : [];
+    if (this.imageUploadError) {
+      return [
+        ...errors,
+        new ValidationErrorInfo(this.FieldName, this.imageUploadError, this.Value),
+      ];
+    }
+    return errors;
   }
 
   /** Warning messages to render in the template */
@@ -1876,6 +1888,66 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
     }
   }
 
+  /**
+   * Runtime display kind from EntityField.ExtendedType. Honored ahead of the
+   * generated `LinkType` input so PhotoURL forms still tagged LinkType=URL
+   * render as images once metadata says Image.
+   */
+  get ExtendedDisplay(): 'image' | 'color' | 'json' | null {
+    switch (this.FieldInfo?.ExtendedType) {
+      case 'Image': return 'image';
+      case 'Color': return 'color';
+      case 'JSON':  return 'json';
+      default:      return null;
+    }
+  }
+
+  get ImagePreviewSrc(): string | null {
+    const raw = this.FormatValue();
+    return CoerceImageSrc(raw);
+  }
+
+  get IsInlineImageValue(): boolean {
+    const raw = this.FormatValue().trim();
+    if (!raw) return false;
+    return IsInlineImageDataUri(raw) || CoerceRawImageBase64ToDataUri(raw) != null;
+  }
+
+  get ImageValueSizeLabel(): string {
+    const raw = this.FormatValue();
+    if (!raw) return '';
+    return FormatByteSize(raw.length);
+  }
+
+  get ImageMaxSizeLabel(): string {
+    return FormatByteSize(MaxInlineImageBytes(this.FieldInfo?.MaxLength ?? 0));
+  }
+
+  /** URL box: empty for inline images so we never dump a data URI into a text input. */
+  get ImageUrlInputValue(): string {
+    if (this.IsInlineImageValue) return '';
+    return this.FormatValue();
+  }
+
+  get ImageUrlDisplay(): string {
+    const raw = this.FormatValue().trim();
+    return raw.replace(/^https?:\/\//i, '').replace(/\/$/, '');
+  }
+
+  get ColorPickerValue(): string {
+    return ParseCssHexColor(this.FormatValue()) ?? '#000000';
+  }
+
+  get ColorSwatchValue(): string {
+    return ParseCssHexColor(this.FormatValue()) ?? 'transparent';
+  }
+
+  get JsonDisplayValue(): string {
+    // Pretty-print only in read mode. Edit mode shows the live value; OnJsonBlur pretty-prints.
+    if (this.EditMode) return this.FormatValue();
+    return PrettyPrintJson(this.FormatValue());
+  }
+
   /** Handle value changes coming from the embedded code editor (emits a plain string). */
   OnCodeEditorChange(value: string): void {
     this.Value = value;
@@ -2051,7 +2123,134 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
    */
   OnInputChange(event: Event): void {
     const input = event.target as HTMLInputElement;
+    this.imageUploadError = null;
     this.Value = input.value;
+  }
+
+  OnImageUrlInput(event: Event): void {
+    this.OnInputChange(event);
+  }
+
+  OnImageClear(): void {
+    this.imageUploadError = null;
+    this.Value = null;
+    this.cdr.markForCheck();
+  }
+
+  async OnImageFileSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    this.imageUploadError = null;
+    if (!file) return;
+
+    const allowed = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp', 'image/svg+xml']);
+    if (file.type && !allowed.has(file.type)) {
+      this.imageUploadError = 'That file is not a supported image type (PNG, JPEG, GIF, WebP, or SVG).';
+      this._touched = true;
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const absoluteReadCap = 8 * 1024 * 1024;
+    if (file.size > absoluteReadCap) {
+      this.imageUploadError = `File is too large to read (max ${FormatByteSize(absoluteReadCap)}).`;
+      this._touched = true;
+      this.cdr.markForCheck();
+      return;
+    }
+
+    try {
+      const maxChars = MaxStoredImageChars(this.FieldInfo?.MaxLength ?? 0);
+      const dataUri = await this.readFileAsDataUri(file);
+      if (!IsInlineImageDataUri(dataUri)) {
+        this.imageUploadError = 'That file is not a supported image type (PNG, JPEG, GIF, WebP, or SVG).';
+        this._touched = true;
+        this.cdr.markForCheck();
+        return;
+      }
+      if (dataUri.length <= maxChars) {
+        this.Value = dataUri;
+        this.cdr.markForCheck();
+        return;
+      }
+      const compressed = await this.compressImageDataUriToFit(dataUri, maxChars);
+      if (compressed) {
+        this.Value = compressed;
+        this.cdr.markForCheck();
+        return;
+      }
+      this.imageUploadError = `Image is too large for this field (max ${this.ImageMaxSizeLabel}). Try a smaller file or paste an image URL.`;
+      this._touched = true;
+    } catch {
+      this.imageUploadError = 'Could not read that image.';
+      this._touched = true;
+    }
+    this.cdr.markForCheck();
+  }
+
+  OnColorPickerInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.imageUploadError = null;
+    this.Value = input.value;
+  }
+
+  OnJsonBlur(): void {
+    const raw = this.FormatValue();
+    const pretty = PrettyPrintJson(raw);
+    if (pretty !== raw) {
+      this.Value = pretty;
+    }
+  }
+
+  private readFileAsDataUri(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result ?? ''));
+      reader.onerror = () => reject(reader.error ?? new Error('read failed'));
+      reader.readAsDataURL(file);
+    });
+  }
+
+  private loadHtmlImage(src: string): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('image decode failed'));
+      img.src = src;
+    });
+  }
+
+  /**
+   * Re-encode a raster data URI as JPEG, shrinking dimensions/quality until it fits
+   * `maxChars`. GIF/SVG are left alone (would lose animation / vectors).
+   */
+  private async compressImageDataUriToFit(dataUri: string, maxChars: number): Promise<string | null> {
+    if (typeof document === 'undefined') return null;
+    if (/^data:image\/(gif|svg\+xml)/i.test(dataUri)) return null;
+    const img = await this.loadHtmlImage(dataUri);
+    const naturalW = img.naturalWidth || img.width;
+    const naturalH = img.naturalHeight || img.height;
+    if (!naturalW || !naturalH) return null;
+
+    let maxDim = Math.min(Math.max(naturalW, naturalH), 1024);
+    let quality = 0.85;
+    for (let i = 0; i < 8; i++) {
+      const scale = maxDim / Math.max(naturalW, naturalH);
+      const w = Math.max(1, Math.round(naturalW * scale));
+      const h = Math.max(1, Math.round(naturalH * scale));
+      const canvas = document.createElement('canvas');
+      canvas.width = w;
+      canvas.height = h;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return null;
+      ctx.drawImage(img, 0, 0, w, h);
+      const next = canvas.toDataURL('image/jpeg', quality);
+      if (next.length <= maxChars) return next;
+      maxDim = Math.max(32, Math.round(maxDim * 0.65));
+      quality = Math.max(0.4, quality - 0.1);
+    }
+    return null;
   }
 
   /**
@@ -2111,6 +2310,7 @@ export class MjFormFieldComponent extends BaseAngularComponent implements OnChan
    */
   get StoredDateIsUnreadable(): boolean {
     if (!this.EditMode) return false;
+    if (this.Type !== 'datepicker' && this.FieldInfo?.TSType !== EntityFieldTSType.Date) return false;
     const val = this.Value;
     if (val === null || val === undefined || val === '') return false;
     return this.DateInputValue === '';

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-cards/entity-cards.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-cards/entity-cards.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnChanges, OnInit, SimpleChanges, ElementRef, AfterViewChecked, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
-import { EntityInfo, EntityFieldInfo, EntityFieldValueListType, RunView } from '@memberjunction/core';
+import { EntityInfo, EntityFieldInfo, EntityFieldValueListType, RunView, CoerceImageSrc } from '@memberjunction/core';
 import { CardTemplate, CardDisplayField, CardFieldType, RecordSelectedEvent, RecordOpenedEvent } from '../types';
 import { buildCompositeKey, buildPkString, computeFieldsList } from '../utils/record.util';
 import { PillColorUtil } from '../pill/pill.component';
@@ -413,22 +413,14 @@ export class EntityCardsComponent extends BaseAngularComponent implements OnChan
    * Returns an array so we can fall back per-record if one is empty
    */
   private findThumbnailFields(fields: EntityFieldInfo[]): string[] {
-    const imageKeywords = ['image', 'photo', 'picture', 'thumbnail', 'avatar', 'logo', 'icon'];
-    const foundFields: string[] = [];
-    const foundFieldNames = new Set<string>();
-
-    for (const keyword of imageKeywords) {
-      const matchingFields = fields.filter(f =>
-        f.Name.toLowerCase().includes(keyword) &&
-        f.TSType === 'string' &&
-        !foundFieldNames.has(f.Name)
-      );
-      for (const field of matchingFields) {
-        foundFields.push(field.Name);
-        foundFieldNames.add(field.Name);
-      }
-    }
-    return foundFields;
+    const images = fields
+      .filter(f => f.ExtendedType === 'Image' && f.TSType === 'string')
+      .map(f => f.Name);
+    const imageSet = new Set(images);
+    const icons = fields
+      .filter(f => f.ExtendedType === 'Icon' && f.TSType === 'string' && !imageSet.has(f.Name))
+      .map(f => f.Name);
+    return [...images, ...icons];
   }
 
   private findBadgeField(fields: EntityFieldInfo[]): string | null {
@@ -702,18 +694,13 @@ export class EntityCardsComponent extends BaseAngularComponent implements OnChan
     if (!fieldInfo) return 'none';
 
     const { fieldName, value } = fieldInfo;
+    const fieldMeta = this.entity?.Fields.find(f => f.Name === fieldName);
 
-    // Check if value is an image URL
+    if (fieldMeta?.ExtendedType === 'Image' && CoerceImageSrc(value)) return 'image';
+    if (fieldMeta?.ExtendedType === 'Icon') return 'icon';
+
     if (this.isImageValue(value)) return 'image';
-
-    // Check if value looks like an icon class
     if (this.isIconClass(value)) return 'icon';
-
-    // If field name suggests it's an icon field, treat non-URL values as icon classes
-    const fieldNameLower = fieldName.toLowerCase();
-    if (fieldNameLower.includes('icon') || fieldNameLower.includes('class')) {
-      return 'icon';
-    }
 
     return 'none';
   }
@@ -723,7 +710,8 @@ export class EntityCardsComponent extends BaseAngularComponent implements OnChan
    */
   getThumbnailUrl(record: Record<string, unknown>): string {
     const fieldInfo = this.getEffectiveThumbnailField(record);
-    return fieldInfo?.value || '';
+    if (!fieldInfo) return '';
+    return CoerceImageSrc(fieldInfo.value) || fieldInfo.value;
   }
 
   /**
@@ -746,11 +734,7 @@ export class EntityCardsComponent extends BaseAngularComponent implements OnChan
   }
 
   private isImageValue(value: string): boolean {
-    if (!value) return false;
-    const trimmed = value.trim();
-    if (trimmed.startsWith('data:image/')) return true;
-    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return true;
-    return false;
+    return CoerceImageSrc(value) != null;
   }
 
   private isIconClass(value: string): boolean {

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-data-grid/entity-data-grid.component.ts
@@ -15,7 +15,7 @@ import { BaseAngularComponent } from '@memberjunction/ng-base-types';
 import type { EntityActionUXContext, EntityActionUXResult } from '@memberjunction/ng-entity-action-ux';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { LogError, RunView, RunViewParams, Metadata, EntityInfo, EntityFieldInfo, AggregateResult, AggregateValue, AggregateExpression } from '@memberjunction/core';
+import { LogError, RunView, RunViewParams, Metadata, EntityInfo, EntityFieldInfo, AggregateResult, AggregateValue, AggregateExpression, CoerceImageSrc, ParseCssHexColor } from '@memberjunction/core';
 import { UUIDsEqual } from '@memberjunction/global';
 import { EntityActionEngineBase } from '@memberjunction/actions-base';
 import { PageChangeEvent } from '@memberjunction/ng-pagination';
@@ -2779,12 +2779,12 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
                   (!extendedType && (fieldNameLower.includes('url') ||
                                      fieldNameLower.includes('website') ||
                                      fieldNameLower.includes('link')));
-    // Photo/logo/avatar before generic URL — PhotoURL would otherwise render as a text link.
+    // Image cells key off ExtendedType (or a User View format override). Field-name
+    // heuristics (PhotoURL/LogoURL) are not used — those columns are classified as
+    // ExtendedType='Image' in metadata.
     const isImage = (customFormat?.type as string | undefined) === 'image' ||
-                    fieldNameLower.includes('photo') ||
-                    fieldNameLower.includes('logo') ||
-                    fieldNameLower.includes('avatar') ||
-                    fieldNameLower.includes('thumbnail');
+                    extendedType === 'image';
+    const isColor = extendedType === 'color';
     // Use ExtendedType='Tel' from metadata, fallback to field name pattern
     const isPhone = extendedType === 'tel' ||
                     (!extendedType && (fieldNameLower.includes('phone') ||
@@ -2848,14 +2848,31 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
 
       if (isImage) {
         const raw = String(params.value).trim();
-        if (this.looksLikeImageUrl(raw)) {
-          const url = this.normalizeHref(raw);
-          const escaped = HighlightUtil.escapeHtml(url);
+        const src = CoerceImageSrc(raw);
+        if (src) {
+          const escaped = HighlightUtil.escapeHtml(src);
+          const img = `<img src="${escaped}" alt="" class="cell-image" width="28" height="28" style="width:28px;height:28px;max-width:28px;max-height:28px;object-fit:cover;object-position:center;border-radius:50%;display:block" />`;
+          const inner = src.startsWith('data:')
+            ? img
+            : `<a href="${escaped}" target="_blank" rel="noopener noreferrer" class="cell-image-link" onclick="event.stopPropagation()">${img}</a>`;
           return this.wrapWithStyle(
-            `<a href="${escaped}" target="_blank" rel="noopener noreferrer" class="cell-image-link" onclick="event.stopPropagation()"><img src="${escaped}" alt="" class="cell-image" width="28" height="28" style="width:28px;height:28px;max-width:28px;max-height:28px;object-fit:cover;object-position:center;border-radius:50%;display:block" /></a>`,
+            inner,
             customFormat?.cellStyle ? this.buildCssStyle(customFormat.cellStyle) : '',
           );
         }
+      }
+
+      if (isColor) {
+        const raw = String(params.value).trim();
+        const hex = ParseCssHexColor(raw);
+        const escaped = HighlightUtil.escapeHtml(raw);
+        const swatch = hex
+          ? `<span style="width:14px;height:14px;border-radius:3px;background:${HighlightUtil.escapeHtml(hex)};border:1px solid rgba(0,0,0,.2);display:inline-block;flex-shrink:0"></span>`
+          : '';
+        return this.wrapWithStyle(
+          `<span style="display:inline-flex;align-items:center;gap:6px">${swatch}${escaped}</span>`,
+          customFormat?.cellStyle ? this.buildCssStyle(customFormat.cellStyle) : '',
+        );
       }
 
       // Handle foreign key fields - render as clickable links
@@ -3031,21 +3048,7 @@ export class EntityDataGridComponent extends BaseAngularComponent implements OnI
     return `<span style="${style}">${content}</span>`;
   }
 
-  private looksLikeImageUrl(value: string): boolean {
-    const v = value.trim().toLowerCase();
-    if (v.startsWith('data:image/')) return true;
-    if (!/^https?:\/\//.test(v) && !v.startsWith('/')) return false;
-    return /\.(png|jpe?g|gif|webp|svg|avif)(\?|$)/i.test(v) ||
-           v.includes('dicebear.com') ||
-           v.includes('/photo') ||
-           v.includes('avatar');
-  }
 
-  private normalizeHref(value: string): string {
-    const v = value.trim();
-    if (/^https?:\/\//i.test(v) || v.startsWith('data:') || v.startsWith('/')) return v;
-    return 'https://' + v;
-  }
 
   /**
    * Build a CSS style string from a ColumnTextStyle object

--- a/packages/Angular/Generic/entity-viewer/src/lib/view-types/renderers/timeline-view-renderer.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/view-types/renderers/timeline-view-renderer.component.ts
@@ -641,22 +641,15 @@ export class TimelineViewRendererComponent
     return firstOther?.Name || null;
   }
 
-  /** Photo/logo/avatar URL field so timeline cards crop a thumbnail, same as grid/cards. */
+  /** Image field (ExtendedType='Image') so timeline cards crop a thumbnail, same as grid/cards. */
   private findImageField(): string | null {
     if (!this._entity) {
       return null;
     }
-    const keywords = ['photo', 'logo', 'avatar', 'thumbnail', 'picture', 'image'];
-    const fields = this._entity.Fields.filter(
-      (f) => f.TSType === EntityFieldTSType.String && !f.Name.startsWith('__mj_'),
+    const match = this._entity.Fields.find(
+      (f) => f.ExtendedType === 'Image' && f.TSType === EntityFieldTSType.String,
     );
-    for (const keyword of keywords) {
-      const match = fields.find((f) => f.Name.toLowerCase().includes(keyword));
-      if (match) {
-        return match.Name;
-      }
-    }
-    return null;
+    return match?.Name ?? null;
   }
 }
 

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -3421,13 +3421,9 @@ export class ManageMetadataBase {
    }
 
    /**
-    * Valid values for EntityField.ExtendedType, plus common LLM aliases mapped to valid values.
+    * Valid values for EntityField.ExtendedType. Domain lives on {@link EntityFieldInfo.ExtendedTypes}.
     */
-   private static readonly VALID_EXTENDED_TYPES = new Set<EntityFieldExtendedType>([
-      'Code', 'Color', 'Email', 'FaceTime', 'Geo', 'GeoLatitude', 'GeoLongitude', 'GeoCountry', 'GeoStateProvince',
-      'GeoCity', 'GeoPostalCode', 'GeoAddress', 'HTML', 'Icon', 'Image', 'JSON', 'Markdown',
-      'MSTeams', 'Other', 'SIP', 'SMS', 'Skype', 'Tel', 'URL', 'WhatsApp', 'ZoomMtg'
-   ]);
+   private static readonly VALID_EXTENDED_TYPES = new Set<EntityFieldExtendedType>(EntityFieldInfo.ExtendedTypes);
 
    private static readonly EXTENDED_TYPE_ALIASES: Record<string, EntityFieldExtendedType> = {
       'phone': 'Tel',

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -3223,15 +3223,15 @@ export class ManageMetadataBase {
       // Load VE EntityField rows from DB (we need the ID and auto-update flags)
       const schema = mj_core_schema();
       const fieldsSQL = `
-         SELECT ID, Name, Category, AutoUpdateCategory, AutoUpdateDisplayName, GeneratedFormSection, DisplayName, ExtendedType, CodeType
+         SELECT ID, Name, Category, AutoUpdateCategory, AutoUpdateDisplayName, AutoUpdateExtendedType, GeneratedFormSection, DisplayName, ExtendedType, CodeType
          FROM ${this.qs(schema, 'EntityField')}
          WHERE EntityID = '${entity.ID}'
       `;
       const fieldsResult = await this.runQuery(pool, fieldsSQL);
       const dbFields = fieldsResult.recordset as Array<{
          ID: string; Name: string; Category: string | null; AutoUpdateCategory: boolean; 
-         AutoUpdateDisplayName: boolean, GeneratedFormSection: string, DisplayName: string, 
-         ExtendedType: string, CodeType: string
+         AutoUpdateDisplayName: boolean; AutoUpdateExtendedType: boolean; GeneratedFormSection: string; DisplayName: string; 
+         ExtendedType: string; CodeType: string
       }>;
 
       if (dbFields.length === 0) return false;
@@ -3399,8 +3399,8 @@ export class ManageMetadataBase {
          const escapedDescription = fd.description.replace(/'/g, "''");
          let setClauses = `Description='${escapedDescription}'`;
 
-         // Apply extended type if provided and valid
-         if (fd.extendedType) {
+         // Apply extended type if provided, valid, and the field is not locked
+         if (fd.extendedType && field.AutoUpdateExtendedType) {
             const validExtendedType = this.validateExtendedType(fd.extendedType);
             if (validExtendedType) {
                setClauses += `, ExtendedType='${validExtendedType}'`;
@@ -3424,8 +3424,9 @@ export class ManageMetadataBase {
     * Valid values for EntityField.ExtendedType, plus common LLM aliases mapped to valid values.
     */
    private static readonly VALID_EXTENDED_TYPES = new Set<EntityFieldExtendedType>([
-      'Code', 'Email', 'FaceTime', 'Geo', 'GeoLatitude', 'GeoLongitude', 'GeoCountry', 'GeoStateProvince',
-      'GeoCity', 'GeoPostalCode', 'GeoAddress', 'MSTeams', 'Other', 'SIP', 'SMS', 'Skype', 'Tel', 'URL', 'WhatsApp', 'ZoomMtg'
+      'Code', 'Color', 'Email', 'FaceTime', 'Geo', 'GeoLatitude', 'GeoLongitude', 'GeoCountry', 'GeoStateProvince',
+      'GeoCity', 'GeoPostalCode', 'GeoAddress', 'HTML', 'Icon', 'Image', 'JSON', 'Markdown',
+      'MSTeams', 'Other', 'SIP', 'SMS', 'Skype', 'Tel', 'URL', 'WhatsApp', 'ZoomMtg'
    ]);
 
    private static readonly EXTENDED_TYPE_ALIASES: Record<string, EntityFieldExtendedType> = {
@@ -3457,6 +3458,17 @@ export class ManageMetadataBase {
       'zoom': 'ZoomMtg',
       'whatsapp': 'WhatsApp',
       'skype': 'Skype',
+      'image': 'Image',
+      'photo': 'Image',
+      'picture': 'Image',
+      'logo': 'Image',
+      'avatar': 'Image',
+      'thumbnail': 'Image',
+      'color': 'Color',
+      'colour': 'Color',
+      'hex': 'Color',
+      'json': 'JSON',
+      'jsonb': 'JSON',
    };
 
    /**
@@ -6807,6 +6819,10 @@ export class ManageMetadataBase {
                ef.AutoUpdateIncludeInUserSearchAPI,
                ef.AutoUpdateCategory,
                ef.AutoUpdateDisplayName,
+               ef.AutoUpdateExtendedType,
+               ef.ExtendedType,
+               ef.CodeType,
+               ef.GeneratedFormSection,
                ef.EntityIDFieldName,
                ef.RelatedEntity,
                ef.IsVirtual,
@@ -7704,7 +7720,7 @@ export class ManageMetadataBase {
    protected async applyFormLayout(
       pool: CodeGenConnection,
       entity: EntityInfo,
-      fields: Array<{ ID: string; Name: string; Category: string | null; AutoUpdateCategory: boolean; AutoUpdateDisplayName: boolean, GeneratedFormSection: string, DisplayName: string, ExtendedType: string, CodeType: string }>,
+      fields: Array<{ ID: string; Name: string; Category: string | null; AutoUpdateCategory: boolean; AutoUpdateDisplayName: boolean; AutoUpdateExtendedType: boolean; GeneratedFormSection: string; DisplayName: string; ExtendedType: string; CodeType: string }>,
       result: FormLayoutResult,
       isNewEntity: boolean = false
    ): Promise<void> {
@@ -7845,7 +7861,7 @@ export class ManageMetadataBase {
    protected async applyFieldCategories(
       pool: CodeGenConnection,
       entity: EntityInfo,
-      fields: Array<{ ID: string; Name: string; Category: string | null; AutoUpdateCategory: boolean; AutoUpdateDisplayName: boolean, GeneratedFormSection: string, DisplayName: string, ExtendedType: string, CodeType: string}>,
+      fields: Array<{ ID: string; Name: string; Category: string | null; AutoUpdateCategory: boolean; AutoUpdateDisplayName: boolean; AutoUpdateExtendedType: boolean; GeneratedFormSection: string; DisplayName: string; ExtendedType: string; CodeType: string}>,
       fieldCategories: Array<{
          fieldName: string;
          category: string;
@@ -7893,9 +7909,14 @@ export class ManageMetadataBase {
                setClauses.push(`DisplayName = '${fieldCategory.displayName.replace(/'/g, "''")}'`);
             }
 
-            if (fieldCategory.extendedType !== undefined && field.ExtendedType !== fieldCategory.extendedType) {
-               const extendedType = fieldCategory.extendedType === null ? 'NULL' : `'${String(fieldCategory.extendedType).replace(/'/g, "''")}'`;
-               setClauses.push(`ExtendedType = ${extendedType}`);
+            if (field.AutoUpdateExtendedType && fieldCategory.extendedType !== undefined && field.ExtendedType !== fieldCategory.extendedType) {
+               const valid = fieldCategory.extendedType == null
+                  ? null
+                  : this.validateExtendedType(String(fieldCategory.extendedType));
+               if (fieldCategory.extendedType == null || valid) {
+                  const extendedType = valid == null ? 'NULL' : `'${valid.replace(/'/g, "''")}'`;
+                  setClauses.push(`ExtendedType = ${extendedType}`);
+               }
             }
 
             if (fieldCategory.codeType !== undefined) {

--- a/packages/MJCore/src/__tests__/baseEntity.test.ts
+++ b/packages/MJCore/src/__tests__/baseEntity.test.ts
@@ -200,6 +200,32 @@ describe('EntityField', () => {
             expect(result.Success).toBe(true);
         });
 
+        it('JSON ExtendedType fails on invalid JSON and passes on valid JSON', () => {
+            const fieldInfo = createMockFieldInfo({ ExtendedType: 'JSON' });
+            const bad = new EntityField(fieldInfo, '{nope}');
+            expect(bad.Validate().Success).toBe(false);
+            const good = new EntityField(fieldInfo, '{"ok":true}');
+            expect(good.Validate().Success).toBe(true);
+        });
+
+        it('Color ExtendedType fails on non-colors and passes on hex', () => {
+            const fieldInfo = createMockFieldInfo({ ExtendedType: 'Color' });
+            const bad = new EntityField(fieldInfo, 'not-a-color');
+            expect(bad.Validate().Success).toBe(false);
+            const good = new EntityField(fieldInfo, '#aabbcc');
+            expect(good.Validate().Success).toBe(true);
+        });
+
+        it('Image ExtendedType rejects javascript: URLs and accepts data URIs and https', () => {
+            const fieldInfo = createMockFieldInfo({ ExtendedType: 'Image', MaxLength: 0 });
+            const bad = new EntityField(fieldInfo, 'javascript:alert(1)');
+            expect(bad.Validate().Success).toBe(false);
+            const url = new EntityField(fieldInfo, 'https://cdn.example.com/a.png');
+            expect(url.Validate().Success).toBe(true);
+            const data = new EntityField(fieldInfo, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+            expect(data.Validate().Success).toBe(true);
+        });
+
         // Active-status (deprecated/disabled) enforcement lives at BaseEntity.Get/Set/SetMany — NOT on
         // the low-level EntityField accessors. So EntityField.Value / Dirty / Validate must NEVER emit a
         // deprecation warning, even for a deprecated field: they are framework-internal value machinery.

--- a/packages/MJCore/src/__tests__/extendedTypeValue.test.ts
+++ b/packages/MJCore/src/__tests__/extendedTypeValue.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { EntityFieldInfo, EntityFieldExtendedTypes } from '../generic/entityInfo';
 import {
     CoerceImageSrc,
     CoerceRawImageBase64ToDataUri,
@@ -12,6 +13,13 @@ import {
     PrettyPrintJson,
     TryParseJsonText,
 } from '../generic/extendedTypeValue';
+
+describe('EntityFieldExtendedTypes', () => {
+    it('is the same array EntityFieldInfo.ExtendedTypes exposes', () => {
+        expect(EntityFieldInfo.ExtendedTypes).toBe(EntityFieldExtendedTypes);
+        expect(EntityFieldExtendedTypes).toEqual(expect.arrayContaining(['Image', 'Color', 'JSON', 'URL', 'Email', 'Icon']));
+    });
+});
 
 const PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
 

--- a/packages/MJCore/src/__tests__/extendedTypeValue.test.ts
+++ b/packages/MJCore/src/__tests__/extendedTypeValue.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+    CoerceImageSrc,
+    CoerceRawImageBase64ToDataUri,
+    FormatByteSize,
+    IsInlineImageDataUri,
+    IsPermittedImageFieldValue,
+    IsValidCssColor,
+    MaxInlineImageBytes,
+    MaxStoredImageChars,
+    ParseCssHexColor,
+    PrettyPrintJson,
+    TryParseJsonText,
+} from '../generic/extendedTypeValue';
+
+const PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+describe('Image ExtendedType helpers', () => {
+    it('detects data:image URIs', () => {
+        expect(IsInlineImageDataUri(`data:image/png;base64,${PNG_1X1}`)).toBe(true);
+        expect(IsInlineImageDataUri('data:text/html;base64,PHNjcmlwdD4=')).toBe(false);
+        expect(IsInlineImageDataUri('https://example.com/a.png')).toBe(false);
+    });
+
+    it('coerces raw PNG/JPEG base64 into a data URI', () => {
+        expect(CoerceRawImageBase64ToDataUri(PNG_1X1)).toBe(`data:image/png;base64,${PNG_1X1}`);
+        expect(CoerceRawImageBase64ToDataUri('/9j/abc')).toBeNull(); // too short
+        expect(CoerceRawImageBase64ToDataUri('not-base64!!!')).toBeNull();
+    });
+
+    it('CoerceImageSrc accepts URLs, data URIs, and raw base64; rejects dangerous schemes', () => {
+        expect(CoerceImageSrc(`data:image/png;base64,${PNG_1X1}`)).toBe(`data:image/png;base64,${PNG_1X1}`);
+        expect(CoerceImageSrc(PNG_1X1)).toBe(`data:image/png;base64,${PNG_1X1}`);
+        expect(CoerceImageSrc('https://cdn.example.com/photo.jpg')).toBe('https://cdn.example.com/photo.jpg');
+        expect(CoerceImageSrc('/assets/logo.png')).toBe('/assets/logo.png');
+        expect(CoerceImageSrc('photos/me.png')).toBe('photos/me.png');
+        expect(CoerceImageSrc('javascript:alert(1)')).toBeNull();
+        expect(CoerceImageSrc('data:text/html;base64,PHNjcmlwdD4=')).toBeNull();
+        expect(CoerceImageSrc('')).toBeNull();
+        expect(IsPermittedImageFieldValue('https://x.test/a')).toBe(true);
+    });
+
+    it('caps stored size at MaxLength when set, else a 1 MiB practical cap', () => {
+        expect(MaxStoredImageChars(500)).toBe(500);
+        expect(MaxInlineImageBytes(500)).toBe(Math.floor((500 - 32) * 3 / 4));
+        expect(MaxStoredImageChars(0)).toBeGreaterThan(1_000_000);
+        expect(FormatByteSize(500)).toBe('500 bytes');
+        expect(FormatByteSize(2048)).toBe('2.0 KB'); // 2.0 because values under 10 KB keep one decimal
+    });
+});
+
+describe('Color ExtendedType helpers', () => {
+    it('normalizes 3-digit and 8-digit hex to #rrggbb', () => {
+        expect(ParseCssHexColor('#abc')).toBe('#aabbcc');
+        expect(ParseCssHexColor('#AABBCC')).toBe('#aabbcc');
+        expect(ParseCssHexColor('#aabbccdd')).toBe('#aabbcc');
+        expect(ParseCssHexColor('red')).toBeNull();
+    });
+
+    it('accepts hex, rgb, hsl, and transparent', () => {
+        expect(IsValidCssColor('#fff')).toBe(true);
+        expect(IsValidCssColor('rgb(1, 2, 3)')).toBe(true);
+        expect(IsValidCssColor('rgba(1, 2, 3, 0.5)')).toBe(true);
+        expect(IsValidCssColor('hsl(120, 50%, 50%)')).toBe(true);
+        expect(IsValidCssColor('transparent')).toBe(true);
+        expect(IsValidCssColor('not-a-color')).toBe(false);
+        expect(IsValidCssColor('')).toBe(false);
+    });
+});
+
+describe('JSON ExtendedType helpers', () => {
+    it('parses and pretty-prints valid JSON, leaves invalid text alone', () => {
+        expect(TryParseJsonText('{"a":1}').ok).toBe(true);
+        expect(TryParseJsonText('{nope}').ok).toBe(false);
+        expect(PrettyPrintJson('{"a":1}')).toBe('{\n  "a": 1\n}');
+        expect(PrettyPrintJson('{nope}')).toBe('{nope}');
+    });
+});

--- a/packages/MJCore/src/generic/baseEntity.ts
+++ b/packages/MJCore/src/generic/baseEntity.ts
@@ -1,6 +1,7 @@
 import { IsMemberOverridden, MJEventType, MJGlobal, OptionalKeyedSpecialization, uuidv4, UUIDsEqual, WarningManager } from '@memberjunction/global';
 import { GetDataHooks, PreSaveHook } from './dataHooks';
 import { EntityFieldInfo, EntityInfo, EntityFieldTSType, EntityPermissionType, RecordChange, ValidationErrorInfo, ValidationResult, EntityRelationshipInfo } from './entityInfo';
+import { IsPermittedImageFieldValue, IsValidCssColor, TryParseJsonText } from './extendedTypeValue';
 import { EntityDeleteOptions, EntitySaveOptions, IEntityDataProvider, IMetadataProvider, IRunQueryProvider, IRunViewProvider, ProviderType, SimpleEmbeddingResult } from './interfaces';
 import { Metadata } from './metadata';
 import { RunView } from '../views/runView';
@@ -361,6 +362,36 @@ export class EntityField {
                 result.Success = false;
                 const nullNote: string = ef.AllowsNull ? ' (or null)' : '';
                 result.Errors.push(new ValidationErrorInfo(ef.Name, `${ef.DisplayNameOrName} must be one of: ${ef.ValueListValuesForDisplay}${nullNote}. Current value is '${this.Value}'`, this.Value));
+            }
+
+            // ExtendedType semantic checks (Image / Color / JSON). Empty values are handled by
+            // the AllowsNull rung above — only non-empty strings are inspected here.
+            if (ef.TSType === EntityFieldTSType.String && this.Value != null && this.Value !== '') {
+                const text = String(this.Value);
+                switch (ef.ExtendedType) {
+                    case 'JSON': {
+                        const parsed = TryParseJsonText(text);
+                        if (parsed.ok === false) {
+                            result.Success = false;
+                            result.Errors.push(new ValidationErrorInfo(ef.Name, `${ef.DisplayNameOrName} must be valid JSON. ${parsed.message}`, this.Value));
+                        }
+                        break;
+                    }
+                    case 'Color': {
+                        if (!IsValidCssColor(text)) {
+                            result.Success = false;
+                            result.Errors.push(new ValidationErrorInfo(ef.Name, `${ef.DisplayNameOrName} must be a CSS color (hex, rgb, or hsl)`, this.Value));
+                        }
+                        break;
+                    }
+                    case 'Image': {
+                        if (!IsPermittedImageFieldValue(text)) {
+                            result.Success = false;
+                            result.Errors.push(new ValidationErrorInfo(ef.Name, `${ef.DisplayNameOrName} must be an image URL or inline image (data URI / base64)`, this.Value));
+                        }
+                        break;
+                    }
+                }
             }
         }
 

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -21,13 +21,20 @@ import {
 
 /**
  * Valid values for EntityField.ExtendedType.
- * Defines semantic meaning beyond the SQL data type (e.g., a string field that holds an email, URL, or geo address).
+ * Defines semantic meaning beyond the SQL data type (e.g., a string field that holds an email, URL,
+ * inline image, CSS color, or JSON document).
+ *
+ * `Image` — the value is an image URL, a `data:image/...` URI, or raw image base64. UI surfaces
+ * render a thumbnail and (in edit mode) allow replacing it with an upload capped at the field's
+ * MaxLength.
+ * `Color` — the value is a CSS color (hex / rgb / hsl).
+ * `JSON` — the value is a JSON document; validated on save and pretty-printed in forms.
  */
 export type EntityFieldExtendedType =
-    | 'Code' | 'Email' | 'FaceTime' | 'Geo'
+    | 'Code' | 'Color' | 'Email' | 'FaceTime' | 'Geo'
     | 'GeoLatitude' | 'GeoLongitude' | 'GeoCountry' | 'GeoStateProvince'
     | 'GeoCity' | 'GeoPostalCode' | 'GeoAddress'
-    | 'HTML' | 'Icon' | 'Markdown'
+    | 'HTML' | 'Icon' | 'Image' | 'JSON' | 'Markdown'
     | 'MSTeams' | 'Other' | 'SIP' | 'SMS' | 'Skype' | 'Tel' | 'URL' | 'WhatsApp' | 'ZoomMtg';
 
 /**

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -20,9 +20,9 @@ import {
 } from "./entityConfiguration"
 
 /**
- * Valid values for EntityField.ExtendedType.
- * Defines semantic meaning beyond the SQL data type (e.g., a string field that holds an email, URL,
- * inline image, CSS color, or JSON document).
+ * Runtime domain for {@link EntityFieldInfo.ExtendedType}. This array is the single source of
+ * truth; {@link EntityFieldExtendedType} is derived from it. CodeGen validates LLM suggestions
+ * against {@link EntityFieldInfo.ExtendedTypes} rather than duplicating the list.
  *
  * `Image` — the value is an image URL, a `data:image/...` URI, or raw image base64. UI surfaces
  * render a thumbnail and (in edit mode) allow replacing it with an upload capped at the field's
@@ -30,12 +30,15 @@ import {
  * `Color` — the value is a CSS color (hex / rgb / hsl).
  * `JSON` — the value is a JSON document; validated on save and pretty-printed in forms.
  */
-export type EntityFieldExtendedType =
-    | 'Code' | 'Color' | 'Email' | 'FaceTime' | 'Geo'
-    | 'GeoLatitude' | 'GeoLongitude' | 'GeoCountry' | 'GeoStateProvince'
-    | 'GeoCity' | 'GeoPostalCode' | 'GeoAddress'
-    | 'HTML' | 'Icon' | 'Image' | 'JSON' | 'Markdown'
-    | 'MSTeams' | 'Other' | 'SIP' | 'SMS' | 'Skype' | 'Tel' | 'URL' | 'WhatsApp' | 'ZoomMtg';
+export const EntityFieldExtendedTypes = [
+    'Code', 'Color', 'Email', 'FaceTime', 'Geo',
+    'GeoLatitude', 'GeoLongitude', 'GeoCountry', 'GeoStateProvince',
+    'GeoCity', 'GeoPostalCode', 'GeoAddress',
+    'HTML', 'Icon', 'Image', 'JSON', 'Markdown',
+    'MSTeams', 'Other', 'SIP', 'SMS', 'Skype', 'Tel', 'URL', 'WhatsApp', 'ZoomMtg',
+] as const;
+
+export type EntityFieldExtendedType = typeof EntityFieldExtendedTypes[number];
 
 /**
  * The possible status values for a record change
@@ -630,6 +633,10 @@ export class EntityFieldInfo extends BaseInfo {
     DefaultValue: string = null
     AutoIncrement: boolean = null
     ValueListType: string = null
+    /**
+     * Runtime domain for {@link ExtendedType}. Same array as {@link EntityFieldExtendedTypes}.
+     */
+    static readonly ExtendedTypes: readonly EntityFieldExtendedType[] = EntityFieldExtendedTypes
     ExtendedType: EntityFieldExtendedType | null = null
     DefaultInView: boolean = null 
     ViewCellTemplate: string = null

--- a/packages/MJCore/src/generic/extendedTypeValue.ts
+++ b/packages/MJCore/src/generic/extendedTypeValue.ts
@@ -1,0 +1,137 @@
+/**
+ * Helpers for EntityField.ExtendedType values that carry structured content
+ * (Image, Color, JSON). Used by EntityField.Validate and by Angular form/grid UX.
+ */
+
+/** Practical cap for inline image payloads when the column is unlimited (nvarchar(max)). */
+export const DEFAULT_MAX_INLINE_IMAGE_BYTES = 1024 * 1024;
+
+const DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+(;[^,]*)?,/i;
+const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const RGB_COLOR_RE = /^rgba?\(\s*[\d.]+%?\s*,\s*[\d.]+%?\s*,\s*[\d.]+%?\s*(,\s*[\d.]+\s*)?\)$/i;
+const HSL_COLOR_RE = /^hsla?\(/i;
+const DANGEROUS_SCHEME_RE = /^(javascript|vbscript|file):/i;
+
+/**
+ * True when `value` is a `data:image/...` URI (base64 or utf-8 SVG).
+ */
+export function IsInlineImageDataUri(value: string): boolean {
+    if (!value) return false;
+    return DATA_IMAGE_RE.test(value.trim());
+}
+
+/**
+ * If `value` is raw base64 of a known image magic number (no data: prefix),
+ * return a data URI; otherwise null.
+ */
+export function CoerceRawImageBase64ToDataUri(value: string): string | null {
+    if (!value) return null;
+    const compact = value.trim().replace(/\s/g, '');
+    if (compact.length < 32) return null;
+    if (!/^[A-Za-z0-9+/]+=*$/.test(compact)) return null;
+    if (compact.startsWith('/9j/')) return `data:image/jpeg;base64,${compact}`;
+    if (compact.startsWith('iVBOR')) return `data:image/png;base64,${compact}`;
+    if (compact.startsWith('R0lGOD')) return `data:image/gif;base64,${compact}`;
+    if (compact.startsWith('UklGR')) return `data:image/webp;base64,${compact}`;
+    if (compact.startsWith('PHN2Zy') || compact.startsWith('PD94bW')) return `data:image/svg+xml;base64,${compact}`;
+    return null;
+}
+
+/**
+ * Normalize a stored Image-field value into something safe to put in `img src`.
+ * Accepts data URIs, raw image base64, http(s) URLs, and relative paths.
+ * Rejects javascript:/vbscript:/file: and non-image data: URIs.
+ */
+export function CoerceImageSrc(value: string): string | null {
+    if (value == null) return null;
+    const v = value.trim();
+    if (!v) return null;
+    if (IsInlineImageDataUri(v)) return v;
+    if (v.toLowerCase().startsWith('data:')) return null;
+    if (DANGEROUS_SCHEME_RE.test(v)) return null;
+
+    const raw = CoerceRawImageBase64ToDataUri(v);
+    if (raw) return raw;
+
+    if (/^https?:\/\//i.test(v) || v.startsWith('/')) return v;
+    // Scheme-less relative path (e.g. "photos/me.png") — permit. Unknown schemes — reject.
+    if (/^[a-z][a-z0-9+.-]*:/i.test(v)) return null;
+    return v;
+}
+
+export function IsPermittedImageFieldValue(value: string): boolean {
+    return CoerceImageSrc(value) != null;
+}
+
+export function NormalizeImageHref(value: string): string {
+    const v = value.trim();
+    if (/^https?:\/\//i.test(v) || v.startsWith('data:') || v.startsWith('/')) return v;
+    return 'https://' + v;
+}
+
+/**
+ * Max characters that may be stored for an Image field. `maxLength === 0` means unlimited
+ * (nvarchar(max)); then we apply {@link DEFAULT_MAX_INLINE_IMAGE_BYTES} as a practical cap.
+ */
+export function MaxStoredImageChars(maxLength: number): number {
+    if (maxLength > 0) return maxLength;
+    return Math.floor(DEFAULT_MAX_INLINE_IMAGE_BYTES * 4 / 3) + 64;
+}
+
+/** Decoded-byte budget implied by {@link MaxStoredImageChars} (data-URI overhead subtracted). */
+export function MaxInlineImageBytes(maxLength: number): number {
+    const chars = MaxStoredImageChars(maxLength);
+    return Math.max(0, Math.floor((chars - 32) * 3 / 4));
+}
+
+export function FormatByteSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} bytes`;
+    if (bytes < 1024 * 1024) {
+        const kb = bytes / 1024;
+        return `${kb < 10 ? kb.toFixed(1) : Math.round(kb)} KB`;
+    }
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Normalize a hex color to `#rrggbb` for `<input type="color">`.
+ * 3-digit hex is expanded; 8-digit hex drops alpha. Returns null if not hex.
+ */
+export function ParseCssHexColor(value: string): string | null {
+    if (!value) return null;
+    const v = value.trim();
+    const m = HEX_COLOR_RE.exec(v);
+    if (!m) return null;
+    const hex = m[1];
+    if (hex.length === 3) {
+        return `#${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`.toLowerCase();
+    }
+    return `#${hex.slice(0, 6)}`.toLowerCase();
+}
+
+export function IsValidCssColor(value: string): boolean {
+    if (!value) return false;
+    const v = value.trim();
+    if (v.toLowerCase() === 'transparent') return true;
+    if (HEX_COLOR_RE.test(v)) return true;
+    if (RGB_COLOR_RE.test(v)) return true;
+    if (HSL_COLOR_RE.test(v)) return true;
+    return false;
+}
+
+export function TryParseJsonText(value: string): { ok: true; value: unknown } | { ok: false; message: string } {
+    try {
+        return { ok: true, value: JSON.parse(value) };
+    } catch (e) {
+        const message = e instanceof Error ? e.message : 'Invalid JSON';
+        return { ok: false, message };
+    }
+}
+
+/** Pretty-print JSON when valid; otherwise return the original string. */
+export function PrettyPrintJson(value: string): string {
+    if (value == null || value.trim() === '') return value ?? '';
+    const parsed = TryParseJsonText(value);
+    if (!parsed.ok) return value;
+    return JSON.stringify(parsed.value, null, 2);
+}

--- a/packages/MJCore/src/index.ts
+++ b/packages/MJCore/src/index.ts
@@ -26,6 +26,7 @@ export * from "./generic/providerBase";
 export * from "./generic/baseRemotableOperation";
 export * from "./generic/remoteOperationDispatch";
 export * from "./generic/entityInfo";
+export * from "./generic/extendedTypeValue";
 export * from "./generic/entityConfiguration";
 export * from "./generic/externalDataSourceTypes";
 export * from "./generic/externalDataSourceReadRouter";

--- a/packages/MJCoreEntities/src/generated/entities/__mj.ts
+++ b/packages/MJCoreEntities/src/generated/entities/__mj.ts
@@ -18363,13 +18363,14 @@ export const MJEntityFieldSchema = z.object({
     *   * ListOrUserEntry
     *   * None
         * * Description: Possible Values of None, List, ListOrUserEntry - the last option meaning that the list of possible values are options, but a user can enter anything else desired too.`),
-    ExtendedType: z.union([z.literal('Code'), z.literal('Email'), z.literal('FaceTime'), z.literal('Geo'), z.literal('GeoAddress'), z.literal('GeoCity'), z.literal('GeoCountry'), z.literal('GeoLatitude'), z.literal('GeoLongitude'), z.literal('GeoPostalCode'), z.literal('GeoStateProvince'), z.literal('HTML'), z.literal('Icon'), z.literal('MSTeams'), z.literal('Markdown'), z.literal('Other'), z.literal('SIP'), z.literal('SMS'), z.literal('Skype'), z.literal('Tel'), z.literal('URL'), z.literal('WhatsApp'), z.literal('ZoomMtg')]).nullable().describe(`
+    ExtendedType: z.union([z.literal('Code'), z.literal('Color'), z.literal('Email'), z.literal('FaceTime'), z.literal('Geo'), z.literal('GeoAddress'), z.literal('GeoCity'), z.literal('GeoCountry'), z.literal('GeoLatitude'), z.literal('GeoLongitude'), z.literal('GeoPostalCode'), z.literal('GeoStateProvince'), z.literal('HTML'), z.literal('Icon'), z.literal('Image'), z.literal('JSON'), z.literal('MSTeams'), z.literal('Markdown'), z.literal('Other'), z.literal('SIP'), z.literal('SMS'), z.literal('Skype'), z.literal('Tel'), z.literal('URL'), z.literal('WhatsApp'), z.literal('ZoomMtg')]).nullable().describe(`
         * * Field Name: ExtendedType
         * * Display Name: Extended Type
         * * SQL Data Type: nvarchar(50)
     * * Value List Type: List
     * * Possible Values 
     *   * Code
+    *   * Color
     *   * Email
     *   * FaceTime
     *   * Geo
@@ -18382,6 +18383,8 @@ export const MJEntityFieldSchema = z.object({
     *   * GeoStateProvince
     *   * HTML
     *   * Icon
+    *   * Image
+    *   * JSON
     *   * MSTeams
     *   * Markdown
     *   * Other
@@ -18392,7 +18395,7 @@ export const MJEntityFieldSchema = z.object({
     *   * URL
     *   * WhatsApp
     *   * ZoomMtg
-        * * Description: Defines extended behaviors for a field such as Email, Web URLs, Code, Markdown, HTML, and Icon. When set to 'Icon', the field's values are treated as icon CSS classes (e.g. Font Awesome) for per-row display in the UI.`),
+        * * Description: Defines extended behaviors for a field such as Email, Web URLs, Code, Markdown, HTML, Icon, Image, Color, and JSON. When set to Image, the field holds an image URL or inline image (data URI / base64) and UI surfaces render a thumbnail. Color is a CSS color. JSON is a JSON document, validated on save.`),
     CodeType: z.union([z.literal('CSS'), z.literal('HTML'), z.literal('JavaScript'), z.literal('Other'), z.literal('SQL'), z.literal('TypeScript')]).nullable().describe(`
         * * Field Name: CodeType
         * * Display Name: Code Type
@@ -84008,6 +84011,7 @@ export class MJEntityFieldEntity extends BaseEntity<MJEntityFieldEntityType> {
     * * Value List Type: List
     * * Possible Values 
     *   * Code
+    *   * Color
     *   * Email
     *   * FaceTime
     *   * Geo
@@ -84020,6 +84024,8 @@ export class MJEntityFieldEntity extends BaseEntity<MJEntityFieldEntityType> {
     *   * GeoStateProvince
     *   * HTML
     *   * Icon
+    *   * Image
+    *   * JSON
     *   * MSTeams
     *   * Markdown
     *   * Other
@@ -84030,12 +84036,12 @@ export class MJEntityFieldEntity extends BaseEntity<MJEntityFieldEntityType> {
     *   * URL
     *   * WhatsApp
     *   * ZoomMtg
-    * * Description: Defines extended behaviors for a field such as Email, Web URLs, Code, Markdown, HTML, and Icon. When set to 'Icon', the field's values are treated as icon CSS classes (e.g. Font Awesome) for per-row display in the UI.
+    * * Description: Defines extended behaviors for a field such as Email, Web URLs, Code, Markdown, HTML, Icon, Image, Color, and JSON. When set to Image, the field holds an image URL or inline image (data URI / base64) and UI surfaces render a thumbnail. Color is a CSS color. JSON is a JSON document, validated on save.
     */
-    get ExtendedType(): 'Code' | 'Email' | 'FaceTime' | 'Geo' | 'GeoAddress' | 'GeoCity' | 'GeoCountry' | 'GeoLatitude' | 'GeoLongitude' | 'GeoPostalCode' | 'GeoStateProvince' | 'HTML' | 'Icon' | 'MSTeams' | 'Markdown' | 'Other' | 'SIP' | 'SMS' | 'Skype' | 'Tel' | 'URL' | 'WhatsApp' | 'ZoomMtg' | null {
+    get ExtendedType(): 'Code' | 'Color' | 'Email' | 'FaceTime' | 'Geo' | 'GeoAddress' | 'GeoCity' | 'GeoCountry' | 'GeoLatitude' | 'GeoLongitude' | 'GeoPostalCode' | 'GeoStateProvince' | 'HTML' | 'Icon' | 'Image' | 'JSON' | 'MSTeams' | 'Markdown' | 'Other' | 'SIP' | 'SMS' | 'Skype' | 'Tel' | 'URL' | 'WhatsApp' | 'ZoomMtg' | null {
         return this.Get('ExtendedType');
     }
-    set ExtendedType(value: 'Code' | 'Email' | 'FaceTime' | 'Geo' | 'GeoAddress' | 'GeoCity' | 'GeoCountry' | 'GeoLatitude' | 'GeoLongitude' | 'GeoPostalCode' | 'GeoStateProvince' | 'HTML' | 'Icon' | 'MSTeams' | 'Markdown' | 'Other' | 'SIP' | 'SMS' | 'Skype' | 'Tel' | 'URL' | 'WhatsApp' | 'ZoomMtg' | null) {
+    set ExtendedType(value: 'Code' | 'Color' | 'Email' | 'FaceTime' | 'Geo' | 'GeoAddress' | 'GeoCity' | 'GeoCountry' | 'GeoLatitude' | 'GeoLongitude' | 'GeoPostalCode' | 'GeoStateProvince' | 'HTML' | 'Icon' | 'Image' | 'JSON' | 'MSTeams' | 'Markdown' | 'Other' | 'SIP' | 'SMS' | 'Skype' | 'Tel' | 'URL' | 'WhatsApp' | 'ZoomMtg' | null) {
         this.Set('ExtendedType', value);
     }
 


### PR DESCRIPTION
## Summary
- Add `Image`, `Color`, and `JSON` to `EntityField.ExtendedType` (CHECK constraint, value list, TypeScript union).
- Forms: Image shows a thumbnail for URLs, `data:image` URIs, and raw image base64; in edit mode with write rights, upload/replace (capped at the field's MaxLength, with compress-to-fit) or paste a URL. Color is a swatch + hex picker. JSON is pretty-printed and validated on save. Does not change the HTML rich-text editor.
- Entity-viewer grid/cards/timeline key image cells off `ExtendedType='Image'` (User View `format.type: image` still overrides). Field-name heuristics are gone.
- Reclassify existing `PhotoURL` / `LogoURL` / `ImageURL` columns to `Image` and lock `AutoUpdateExtendedType` so CodeGen/LLM cannot overwrite them. CodeGen now honors that lock and accepts the new types.

## Test plan
- [x] MJCore unit tests for Image/Color/JSON helpers and `EntityField.Validate`
- [x] `mj-form-field` DOM tests: inline base64 thumbnail, URL thumbnail, upload/clear, color picker, JSON pretty-print
- [x] entity-viewer cards/grid DOM tests still pass
- [x] Migration applied on `bizapps_morecheese_20260903` (7 PhotoURL/LogoURL/ImageURL rows → Image, AutoUpdateExtendedType=0)
- [ ] CI unit tests for `@memberjunction/core`, `ng-base-forms`, `ng-entity-viewer`, `codegen-lib`
- [ ] Explorer: People PhotoURL and Organizations LogoURL render as thumbnails in the directory grid and on the record form
- [ ] Form edit: upload a small image into an Image field; oversize upload shows the max-size error; paste a URL still works
- [ ] Setting ExtendedType=Color / JSON on a test field shows swatch / pretty JSON