### PR TITLE
fix(forms): re-resolve the section rail when field visibility changes

### DIFF
--- a/.changeset/rail-refresh-on-field-visibility.md
+++ b/.changeset/rail-refresh-on-field-visibility.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/ng-base-forms": patch
+---
+
+Forms: the section rail now refreshes when Edit mode or Show Empty Fields changes.
+
+A panel whose fields are all blank gets the `mj-panel-empty` host class in read-only mode, and `domPanelSnapshots()` deliberately skips those panels so the rail doesn't advertise an empty section. The panel itself recomputes live, but `scheduleChromeResolve()` only ran on structural changes (content children, slot remounts, chrome rules, section reorder) — never when field visibility changed. So once a section dropped out of the rail while read-only, switching to Edit brought the panel back but left its nav entry missing until something else forced a resolve.
+
+`MjRecordFormContainerComponent` now watches the effective Edit-mode and Show-Empty-Fields values in `ngDoCheck` and re-resolves the rail when either flips. Watching the values rather than hooking `OnEditModeChange` matters because the toolbar is not the only writer: `SaveRecord()` and `CancelEdit()` call `EndEditMode()` straight on the form component and never reach that handler, so a save used to leave the reverse staleness behind. The existing resolve is already debounced through a zero-delay timer, so a change to both flags in one tick still costs one resolve.

--- a/packages/Angular/Generic/base-forms/src/lib/container/__tests__/rail-refresh-on-field-visibility.test.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/container/__tests__/rail-refresh-on-field-visibility.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The section rail is resolved from a DOM snapshot that skips panels flagged
+ * `mj-panel-empty`, so a section whose fields are all blank loses its nav entry
+ * in read-only mode. Edit mode and Show Empty Fields both un-hide those fields,
+ * which means the rail has to be re-resolved when either flips — from ANY
+ * writer, including `SaveRecord()` / `CancelEdit()` calling `EndEditMode()`
+ * straight on the form component.
+ *
+ * `MjRecordFormContainerComponent.ngDoCheck` is the watcher. It is exercised
+ * here against the real prototype (real `EffectiveEditMode` /
+ * `EffectiveShowEmptyFields` getters) with a stand-in form component.
+ */
+// The container's import graph reaches partially-compiled Angular libraries
+// (@angular/common), which need the JIT compiler present under the node preset.
+import '@angular/compiler';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MjRecordFormContainerComponent } from '../record-form-container.component';
+import type { BaseFormComponent } from '../../base-form-component';
+
+type FormStub = { EditMode: boolean; showEmptyFields: boolean };
+
+interface Harness {
+  Container: MjRecordFormContainerComponent;
+  Form: FormStub;
+  ResolveCount: () => number;
+}
+
+function makeHarness(): Harness {
+  const form: FormStub = { EditMode: false, showEmptyFields: false };
+  let resolveCount = 0;
+  const container = Object.create(MjRecordFormContainerComponent.prototype) as MjRecordFormContainerComponent;
+  container.FormComponent = form as unknown as BaseFormComponent;
+  container.EditMode = false;
+  Object.assign(container, {
+    lastRailEditMode: false,
+    lastRailShowEmptyFields: false,
+    scheduleChromeResolve: () => {
+      resolveCount++;
+    },
+  });
+  return { Container: container, Form: form, ResolveCount: () => resolveCount };
+}
+
+describe('MjRecordFormContainerComponent rail refresh on field-visibility changes', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness();
+  });
+
+  it('does not re-resolve the rail while nothing changes', () => {
+    h.Container.ngDoCheck();
+    h.Container.ngDoCheck();
+    h.Container.ngDoCheck();
+    expect(h.ResolveCount()).toBe(0);
+  });
+
+  it('re-resolves the rail when edit mode is entered', () => {
+    h.Container.ngDoCheck();
+    h.Form.EditMode = true;
+    h.Container.ngDoCheck();
+    expect(h.ResolveCount()).toBe(1);
+  });
+
+  it('re-resolves the rail when edit mode ends without the toolbar handler (save/cancel path)', () => {
+    h.Form.EditMode = true;
+    h.Container.ngDoCheck();
+    h.Form.EditMode = false; // what EndEditMode() does from SaveRecord()/CancelEdit()
+    h.Container.ngDoCheck();
+    expect(h.ResolveCount()).toBe(2);
+  });
+
+  it('re-resolves the rail when Show Empty Fields is toggled', () => {
+    h.Container.ngDoCheck();
+    h.Form.showEmptyFields = true;
+    h.Container.ngDoCheck();
+    h.Form.showEmptyFields = false;
+    h.Container.ngDoCheck();
+    expect(h.ResolveCount()).toBe(2);
+  });
+
+  it('re-resolves once when both flags change together', () => {
+    h.Container.ngDoCheck();
+    h.Form.EditMode = true;
+    h.Form.showEmptyFields = true;
+    h.Container.ngDoCheck();
+    h.Container.ngDoCheck();
+    expect(h.ResolveCount()).toBe(1);
+  });
+
+  it('re-resolves for a form that starts in edit mode', () => {
+    h.Form.EditMode = true;
+    h.Container.ngDoCheck();
+    expect(h.ResolveCount()).toBe(1);
+  });
+
+  it('falls back to the standalone EditMode input when no form component is bound', () => {
+    h.Container.FormComponent = null;
+    h.Container.ngDoCheck();
+    expect(h.ResolveCount()).toBe(0);
+
+    h.Container.EditMode = true;
+    h.Container.ngDoCheck();
+    expect(h.ResolveCount()).toBe(1);
+  });
+});

--- a/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.ts
@@ -1,7 +1,7 @@
 import {
   Component, Input, Output, EventEmitter,
   ChangeDetectionStrategy, ChangeDetectorRef, inject, NgZone,
-  ContentChildren, QueryList, AfterContentInit, OnDestroy,
+  ContentChildren, QueryList, AfterContentInit, DoCheck, OnDestroy,
   ViewChild, ViewEncapsulation, ElementRef
 } from '@angular/core';
 import { BaseEntity, CompositeKey, EntityInfo, Metadata, RunView, type FormChromeRule, type FormInclusion } from '@memberjunction/core';
@@ -113,7 +113,7 @@ export interface VariantPickerItem {
   // related-entity grids and slot-mounted panels can inject them.
   providers: [FormSlotCoordinator, FormChromeCoordinator, FormRecordRefreshCoordinator],
 })
-export class MjRecordFormContainerComponent extends BaseAngularComponent implements AfterContentInit, OnDestroy  {
+export class MjRecordFormContainerComponent extends BaseAngularComponent implements AfterContentInit, DoCheck, OnDestroy  {
   private cdr = inject(ChangeDetectorRef);
   private ngZone = inject(NgZone);
   private notificationService = inject(MJNotificationService);
@@ -124,6 +124,9 @@ export class MjRecordFormContainerComponent extends BaseAngularComponent impleme
   private destroy$ = new Subject<void>();
   private panelNavReset$ = new Subject<void>();
   private chromeResolveTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Last values `ngDoCheck` resolved the rail for — see that method. */
+  private lastRailEditMode = false;
+  private lastRailShowEmptyFields = false;
   private chromeRules: FormChromeRule[] = [];
   private chromeRulesForEntityId: string | null = null;
 
@@ -662,6 +665,26 @@ export class MjRecordFormContainerComponent extends BaseAngularComponent impleme
 
     // Watch for changes to record dirty state
     this.watchRecordChanges();
+  }
+
+  /**
+   * Edit mode and Show Empty Fields both flip `mj-panel-empty` on a panel whose
+   * fields are all blank (see `MjFormFieldComponent.ShouldHideField`), and
+   * `domPanelSnapshots()` drops those panels from the rail. The panel itself
+   * recomputes live, but the rail is only resolved on structural changes — so
+   * without this the nav entry never comes back on switching to edit.
+   *
+   * Watched here rather than in `OnEditModeChange` because the toolbar is not
+   * the only writer: `SaveRecord()` and `CancelEdit()` call `EndEditMode()` on
+   * the form component directly, bypassing that handler entirely.
+   */
+  ngDoCheck(): void {
+    const editMode = this.EffectiveEditMode;
+    const showEmptyFields = this.EffectiveShowEmptyFields;
+    if (editMode === this.lastRailEditMode && showEmptyFields === this.lastRailShowEmptyFields) return;
+    this.lastRailEditMode = editMode;
+    this.lastRailShowEmptyFields = showEmptyFields;
+    this.scheduleChromeResolve();
   }
 
   ngOnDestroy(): void {

--- a/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.ts
+++ b/packages/Angular/Generic/base-forms/src/lib/container/record-form-container.component.ts
@@ -4,10 +4,10 @@ import {
   ContentChildren, QueryList, AfterContentInit, DoCheck, OnDestroy,
   ViewChild, ViewEncapsulation, ElementRef
 } from '@angular/core';
-import { BaseEntity, CompositeKey, EntityInfo, Metadata, RunView, type FormChromeRule, type FormInclusion } from '@memberjunction/core';
+import { BaseEntity, CompositeKey, EntityInfo, RunView, type FormChromeRule, type FormInclusion } from '@memberjunction/core';
 import { UUIDsEqual } from '@memberjunction/global';
 import { BaseAngularComponent } from '@memberjunction/ng-base-types';
-import { UserInfoEngine, FileStorageEngineBase } from '@memberjunction/core-entities';
+import { UserInfoEngine } from '@memberjunction/core-entities';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { FormToolbarConfig, DEFAULT_TOOLBAR_CONFIG } from '../types/toolbar-config';


### PR DESCRIPTION
## No GitHub issue

There is no MJ issue for this. It was found while fixing [bc-aidp-next-golive#184](https://github.com/MemberJunction/bc-aidp-next-golive/issues/184) downstream in `bizapps-orders`: an empty-hidden panel never regains its rail entry when the user switches to Edit. That work is app-side; this half of the fix has to live in MJ core, so it ships on its own rather than being bundled into the app PR. Filing a placeholder issue after the fact seemed like less signal than this paragraph — happy to open one if the process prefers it.

## The defect

`mj-collapsible-panel` already implements hide-when-empty: a panel whose fields are all blank gets the `mj-panel-empty` host class in read-only mode (`collapsible-panel.component.ts` `hasRenderableContent()` → `HostClass`), and the container's `domPanelSnapshots()` deliberately skips those panels so the rail doesn't advertise a section with nothing in it.

The panel side is live — `HostClass` is a host-binding getter, and `FormContext` changes identity every CD cycle, so visibility recomputes on its own. The rail side is not. `scheduleChromeResolve()` is called from `ngAfterContentInit`, `Panels.changes`, `slots.changes`, the chrome-rule load and the section-order handlers — all **structural** triggers. Nothing re-resolves it when field visibility changes.

Consequence: a section that dropped out of the rail while read-only stays out after the user clicks Edit. The panel comes back; its nav entry doesn't, until some unrelated structural change forces a resolve.

## The fix

`MjRecordFormContainerComponent` now implements `DoCheck` and re-resolves the rail when either flag that drives `ShouldHideField` changes:

```ts
ngDoCheck(): void {
  const editMode = this.EffectiveEditMode;
  const showEmptyFields = this.EffectiveShowEmptyFields;
  if (editMode === this.lastRailEditMode && showEmptyFields === this.lastRailShowEmptyFields) return;
  this.lastRailEditMode = editMode;
  this.lastRailShowEmptyFields = showEmptyFields;
  this.scheduleChromeResolve();
}
```

**Reviewer note — why `ngDoCheck` and not one line in `OnEditModeChange`.** That was the obvious one-liner and it is a symptom patch. The toolbar is not the only writer of edit mode: `BaseFormComponent.SaveRecord()` (with `StopEditModeAfterSave`) and `CancelEdit()` both call `EndEditMode()` directly on the form component and never reach the container's handler. Patching the handler would fix entering edit and leave the reverse staleness — panels that go empty again on save keep their rail entries. `EffectiveShowEmptyFields` has the same shape of problem via `OnShowEmptyFieldsChange`. Watching the two effective values covers every writer in one place. This is the one MJ-Angular case where `ngDoCheck` is the right hook rather than a setter: neither value is an `@Input()` on this component — both are read off the `FormComponent` delegate, which exposes no change notification.

Cost is two boolean reads per CD cycle; `scheduleChromeResolve()` is only called on an actual transition, and it already debounces through a zero-delay timer, so both flags changing in one tick still costs one resolve. Ordering works out because the resolve runs as a macrotask after the tick that updated the panels' host classes, so `domPanelSnapshots()` reads the fresh DOM.

## Testing

`packages/Angular/Generic/base-forms/src/lib/container/__tests__/rail-refresh-on-field-visibility.test.ts` — 7 vitest cases against the real prototype (real `EffectiveEditMode` / `EffectiveShowEmptyFields` getters, stand-in form component): no resolve while nothing changes, resolve on entering edit, resolve on the save/cancel exit path, resolve on Show-Empty-Fields both ways, one resolve when both flags change together, resolve for a form that opens in edit mode, and the standalone `EditMode` input fallback when no `FormComponent` is bound. Verified they fail against the unpatched component.

The test needs `import '@angular/compiler';` at the top: the container's import graph reaches partially-compiled Angular libraries that need JIT under the node vitest preset. It's in `__tests__/`, so it stays on the node project and out of the DOM project, per the package's dual-preset config.

- `pnpm test` in `base-forms`: **348 passed / 27 files**, including the existing
`showEmptyFields` default assertions in `base-forms.test.ts`.
- `pnpm run build` (ngc) and `pnpm run test:types`: clean.
- `npm run check:changeset`: passes; patch bump for `@memberjunction/ng-base-forms`.

## Not in scope

Contributed panels that nest their `mj-form-field`s inside a child component's view are invisible to the panel's `@ContentChildren`, so `hasRenderableContent()` returns `true` and they are never flagged empty in the first place. That's the other half of #184 and is being handled app-side in `bizapps-orders`. No schema change, no migration, no CodeGen output here.

## Unrelated change in this PR

Second commit (`5ba92f7`) drops two dead imports from `record-form-container.component.ts`: `Metadata` from `@memberjunction/core` and `FileStorageEngineBase` from `@memberjunction/core-entities`. Neither has a bare reference in the component or its template — the near-misses are `reg.Metadata`, `RunView.FromMetadataProvider(...)` and the `FormPanelRegistrationMetadata` type. Both were already unused before this branch; nothing in the package's ngc/tsc config flags unused imports, so only the IDE surfaced them. No module-load side effect is lost either way, since another live symbol is imported from each of those two modules on the same line. Split into its own commit so it can be dropped if you'd rather it went in separately.

