### PR TITLE
fix(installer): refuse archive entries that resolve outside the extraction directory (zip slip)

### DIFF
--- a/.changeset/installer-zip-slip.md
+++ b/.changeset/installer-zip-slip.md
@@ -1,0 +1,7 @@
+---
+"@memberjunction/installer": patch
+---
+
+Installer: refuse archive entries that resolve outside the extraction directory (zip slip, CWE-22).
+
+`FileSystemAdapter.ExtractZip` joined each archive entry name onto the target directory without checking the result, so a release archive carrying an entry such as `../../.bashrc` or an absolute path would have been written wherever it pointed, with the installer's privileges. Entries are now resolved against the target root and any that land outside it abort the extraction with a clear error. Well-formed archives, including GitHub zipballs with their single wrapper folder, extract exactly as before.

--- a/packages/MJInstaller/src/__tests__/FileSystemAdapter.test.ts
+++ b/packages/MJInstaller/src/__tests__/FileSystemAdapter.test.ts
@@ -129,7 +129,8 @@ describe('FileSystemAdapter', () => {
 
       await adapter.ExtractZip('/tmp/release.zip', '/new/path/target');
 
-      expect(mockFsPromises.mkdir).toHaveBeenCalledWith('/new/path/target', { recursive: true });
+      // The directory is created under its resolved name (a drive-letter path on Windows).
+      expect(mockFsPromises.mkdir).toHaveBeenCalledWith(path.resolve('/new/path/target'), { recursive: true });
     });
 
     describe('zip slip protection', () => {

--- a/packages/MJInstaller/src/__tests__/FileSystemAdapter.test.ts
+++ b/packages/MJInstaller/src/__tests__/FileSystemAdapter.test.ts
@@ -129,6 +129,80 @@ describe('FileSystemAdapter', () => {
 
       expect(mockFsPromises.mkdir).toHaveBeenCalledWith('/new/path/target', { recursive: true });
     });
+
+    describe('zip slip protection', () => {
+      function writtenPaths(): string[] {
+        return mockFsPromises.writeFile.mock.calls.map((c: [string, ...unknown[]]) => c[0]);
+      }
+
+      it('should refuse an entry that escapes the target directory with ..', async () => {
+        mockFsPromises.writeFile.mockClear();
+        mockGetEntries.mockReturnValue([
+          { entryName: 'safe.txt', isDirectory: false, getData: () => Buffer.from('ok') },
+          { entryName: '../escape.txt', isDirectory: false, getData: () => Buffer.from('evil') },
+        ]);
+
+        await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toThrow(
+          /resolves outside the target directory/
+        );
+        expect(writtenPaths().some((p) => p.includes('escape.txt'))).toBe(false);
+      });
+
+      it('should refuse an escaping entry hidden under a single root folder', async () => {
+        mockFsPromises.writeFile.mockClear();
+        mockGetEntries.mockReturnValue([
+          { entryName: 'MemberJunction-MJ-abc1234/', isDirectory: true, getData: () => Buffer.from('') },
+          { entryName: 'MemberJunction-MJ-abc1234/package.json', isDirectory: false, getData: () => Buffer.from('{}') },
+          { entryName: 'MemberJunction-MJ-abc1234/../../escape.txt', isDirectory: false, getData: () => Buffer.from('evil') },
+        ]);
+
+        await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toThrow(
+          /resolves outside the target directory/
+        );
+        expect(writtenPaths().some((p) => p.includes('escape.txt'))).toBe(false);
+      });
+
+      it('should refuse an absolute entry name', async () => {
+        mockFsPromises.writeFile.mockClear();
+        mockGetEntries.mockReturnValue([
+          { entryName: 'a.txt', isDirectory: false, getData: () => Buffer.from('a') },
+          { entryName: '/etc/passwd', isDirectory: false, getData: () => Buffer.from('evil') },
+        ]);
+
+        await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toThrow(
+          /resolves outside the target directory/
+        );
+        expect(writtenPaths().some((p) => p.includes('passwd'))).toBe(false);
+      });
+
+      it('should refuse an escaping directory entry before creating it', async () => {
+        mockFsPromises.mkdir.mockClear();
+        mockGetEntries.mockReturnValue([
+          { entryName: 'ok/', isDirectory: true, getData: () => Buffer.from('') },
+          { entryName: '../outside/', isDirectory: true, getData: () => Buffer.from('') },
+        ]);
+
+        await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toThrow(
+          /resolves outside the target directory/
+        );
+        const created: string[] = mockFsPromises.mkdir.mock.calls.map((c: [string, ...unknown[]]) => c[0]);
+        expect(created.some((p) => p.includes('outside'))).toBe(false);
+      });
+
+      it('should still extract well-formed entries that merely contain dots', async () => {
+        mockFsPromises.writeFile.mockClear();
+        mockGetEntries.mockReturnValue([
+          { entryName: 'a/', isDirectory: true, getData: () => Buffer.from('') },
+          { entryName: 'a/.env.example', isDirectory: false, getData: () => Buffer.from('x') },
+          { entryName: 'a/b..c/file.txt', isDirectory: false, getData: () => Buffer.from('y') },
+        ]);
+        mockFsPromises.readdir.mockResolvedValue(['a']);
+
+        await expect(adapter.ExtractZip('/tmp/ok.zip', '/target')).resolves.toEqual(['a']);
+        expect(writtenPaths().some((p) => p.includes('.env.example'))).toBe(true);
+        expect(writtenPaths().some((p) => p.includes('b..c'))).toBe(true);
+      });
+    });
   });
 
   describe('CreateDirectory', () => {

--- a/packages/MJInstaller/src/__tests__/FileSystemAdapter.test.ts
+++ b/packages/MJInstaller/src/__tests__/FileSystemAdapter.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 // ---------------------------------------------------------------------------
 // Mock node:fs/promises, node:fs, node:os, and adm-zip
 // ---------------------------------------------------------------------------
@@ -131,76 +133,99 @@ describe('FileSystemAdapter', () => {
     });
 
     describe('zip slip protection', () => {
+      beforeEach(() => {
+        mockFsPromises.writeFile.mockClear();
+        mockFsPromises.mkdir.mockClear();
+      });
+
+      function entry(entryName: string, isDirectory = false) {
+        return { entryName, isDirectory, getData: () => Buffer.from(isDirectory ? '' : 'data') };
+      }
       function writtenPaths(): string[] {
         return mockFsPromises.writeFile.mock.calls.map((c: [string, ...unknown[]]) => c[0]);
       }
 
-      it('should refuse an entry that escapes the target directory with ..', async () => {
-        mockFsPromises.writeFile.mockClear();
-        mockGetEntries.mockReturnValue([
-          { entryName: 'safe.txt', isDirectory: false, getData: () => Buffer.from('ok') },
-          { entryName: '../escape.txt', isDirectory: false, getData: () => Buffer.from('evil') },
-        ]);
+      it.each([
+        ['a leading ..', [entry('safe.txt'), entry('../escape.txt')]],
+        [
+          'an escape hidden under a single root folder',
+          [entry('MJ-abc/', true), entry('MJ-abc/package.json'), entry('MJ-abc/../../escape.txt')],
+        ],
+        ['an absolute entry name', [entry('a.txt'), entry('/etc/passwd')]],
+        ['an escaping directory entry', [entry('ok/', true), entry('../outside/', true)]],
+        ['a sibling directory sharing the target prefix', [entry('a.txt'), entry('../target2/x.txt')]],
+        ['an entry that is exactly ..', [entry('a.txt'), entry('..', true)]],
+        ['an archive whose only root is ..', [entry('../a.sh'), entry('../b.sh')]],
+        ['an archive whose every entry is absolute', [entry('/etc/passwd'), entry('/etc/shadow')]],
+      ])('should refuse %s without writing anything', async (_label, entries) => {
+        mockGetEntries.mockReturnValue(entries);
 
         await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toThrow(
           /resolves outside the target directory/
         );
-        expect(writtenPaths().some((p) => p.includes('escape.txt'))).toBe(false);
+        expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
+        expect(mockFsPromises.mkdir).not.toHaveBeenCalled();
       });
 
-      it('should refuse an escaping entry hidden under a single root folder', async () => {
-        mockFsPromises.writeFile.mockClear();
+      it('should refuse a hostile entry placed last before any earlier entry is written', async () => {
         mockGetEntries.mockReturnValue([
-          { entryName: 'MemberJunction-MJ-abc1234/', isDirectory: true, getData: () => Buffer.from('') },
-          { entryName: 'MemberJunction-MJ-abc1234/package.json', isDirectory: false, getData: () => Buffer.from('{}') },
-          { entryName: 'MemberJunction-MJ-abc1234/../../escape.txt', isDirectory: false, getData: () => Buffer.from('evil') },
+          entry('a/', true),
+          entry('a/one.txt'),
+          entry('a/two.txt'),
+          entry('a/../../late.txt'),
         ]);
 
         await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toThrow(
           /resolves outside the target directory/
         );
-        expect(writtenPaths().some((p) => p.includes('escape.txt'))).toBe(false);
-      });
-
-      it('should refuse an absolute entry name', async () => {
-        mockFsPromises.writeFile.mockClear();
-        mockGetEntries.mockReturnValue([
-          { entryName: 'a.txt', isDirectory: false, getData: () => Buffer.from('a') },
-          { entryName: '/etc/passwd', isDirectory: false, getData: () => Buffer.from('evil') },
-        ]);
-
-        await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toThrow(
-          /resolves outside the target directory/
-        );
-        expect(writtenPaths().some((p) => p.includes('passwd'))).toBe(false);
-      });
-
-      it('should refuse an escaping directory entry before creating it', async () => {
-        mockFsPromises.mkdir.mockClear();
-        mockGetEntries.mockReturnValue([
-          { entryName: 'ok/', isDirectory: true, getData: () => Buffer.from('') },
-          { entryName: '../outside/', isDirectory: true, getData: () => Buffer.from('') },
-        ]);
-
-        await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toThrow(
-          /resolves outside the target directory/
-        );
-        const created: string[] = mockFsPromises.mkdir.mock.calls.map((c: [string, ...unknown[]]) => c[0]);
-        expect(created.some((p) => p.includes('outside'))).toBe(false);
+        expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
+        expect(mockFsPromises.mkdir).not.toHaveBeenCalled();
       });
 
       it('should still extract well-formed entries that merely contain dots', async () => {
-        mockFsPromises.writeFile.mockClear();
+        // Two top-level names, so the single-root-folder stripping does not apply.
         mockGetEntries.mockReturnValue([
-          { entryName: 'a/', isDirectory: true, getData: () => Buffer.from('') },
-          { entryName: 'a/.env.example', isDirectory: false, getData: () => Buffer.from('x') },
-          { entryName: 'a/b..c/file.txt', isDirectory: false, getData: () => Buffer.from('y') },
+          entry('README.md'),
+          entry('a/', true),
+          entry('a/.env.example'),
+          entry('a/b..c/file.txt'),
+          entry('a/..hidden/x'),
         ]);
-        mockFsPromises.readdir.mockResolvedValue(['a']);
+        mockFsPromises.readdir.mockResolvedValue(['README.md', 'a']);
 
-        await expect(adapter.ExtractZip('/tmp/ok.zip', '/target')).resolves.toEqual(['a']);
-        expect(writtenPaths().some((p) => p.includes('.env.example'))).toBe(true);
-        expect(writtenPaths().some((p) => p.includes('b..c'))).toBe(true);
+        await expect(adapter.ExtractZip('/tmp/ok.zip', '/target')).resolves.toEqual(['README.md', 'a']);
+        expect(writtenPaths()).toEqual([
+          path.resolve('/target', 'README.md'),
+          path.resolve('/target', 'a/.env.example'),
+          path.resolve('/target', 'a/b..c/file.txt'),
+          path.resolve('/target', 'a/..hidden/x'),
+        ]);
+      });
+
+      it('should extract into a filesystem root without refusing anything', async () => {
+        mockGetEntries.mockReturnValue([entry('README.md'), entry('a/', true), entry('a/file.txt')]);
+        mockFsPromises.readdir.mockResolvedValue(['README.md', 'a']);
+
+        await expect(adapter.ExtractZip('/tmp/ok.zip', '/')).resolves.toEqual(['README.md', 'a']);
+        expect(writtenPaths()).toEqual([path.resolve('/', 'README.md'), path.resolve('/', 'a/file.txt')]);
+      });
+
+      it('should not leak control characters from a hostile entry name into the error message', async () => {
+        mockGetEntries.mockReturnValue([entry('a.txt'), entry('../x\u001b[2K\u001b[1AExtraction complete\n')]);
+
+        await expect(adapter.ExtractZip('/tmp/evil.zip', '/target')).rejects.toSatisfy((err: Error) => {
+          expect(err.message).toContain('resolves outside the target directory');
+          expect(err.message).not.toMatch(/[\u0000-\u001f\u007f]/);
+          return true;
+        });
+      });
+
+      it('should skip entries that resolve to the target directory itself', async () => {
+        mockGetEntries.mockReturnValue([entry('.'), entry('./', true), entry('a.txt')]);
+        mockFsPromises.readdir.mockResolvedValue(['a.txt']);
+
+        await expect(adapter.ExtractZip('/tmp/ok.zip', '/target')).resolves.toEqual(['a.txt']);
+        expect(writtenPaths()).toEqual([path.resolve('/target', 'a.txt')]);
       });
     });
   });

--- a/packages/MJInstaller/src/__tests__/ScaffoldPhase.test.ts
+++ b/packages/MJInstaller/src/__tests__/ScaffoldPhase.test.ts
@@ -4,6 +4,7 @@ import { createMockEmitter, emittedEvents } from './mocks/emitter.js';
 import { sampleVersionInfo } from './mocks/fixtures.js';
 import type { ScaffoldContext } from '../phases/ScaffoldPhase.js';
 import { InstallerError } from '../errors/InstallerError.js';
+import { ArchiveEntryRefusedError } from '../errors/ArchiveEntryRefusedError.js';
 import type { VersionInfo } from '../models/VersionInfo.js';
 import type { SparseFetchResult } from '../adapters/RepoFetcher.js';
 import type { WriteOp } from '../distribution/DistributionAssembler.js';
@@ -364,6 +365,23 @@ describe('ScaffoldPhase', () => {
         expect((err as InstallerError).Code).toBe('EXTRACT_FAILED');
         expect((err as InstallerError).message).toContain('Corrupt ZIP');
       }
+    });
+
+    it('should throw ARCHIVE_REFUSED, not EXTRACT_FAILED, when the archive contains an escaping entry', async () => {
+      mockFs.ExtractZip.mockRejectedValue(new ArchiveEntryRefusedError('MJ-abc/../../.bashrc'));
+      try {
+        await phase.Run(monorepoCtx());
+        throw new Error('expected Run to throw');
+      } catch (err) {
+        const error = err as InstallerError;
+        expect(error.Code).toBe('ARCHIVE_REFUSED');
+        expect(error.message).toContain('MJ-abc/../../.bashrc');
+        // The remediation must not tell the user to extract by hand the archive that was just refused.
+        expect(error.SuggestedFix).not.toMatch(/extract it into the target directory/);
+        expect(error.SuggestedFix).toMatch(/Do not extract this archive by hand/);
+      }
+      // The hostile download must not be left behind in the temp dir.
+      expect(mockFs.RemoveFile).toHaveBeenCalledWith(expect.stringContaining('v5.2.0.zip'));
     });
 
     it('should call RemoveFile for the temp zip after successful extraction', async () => {

--- a/packages/MJInstaller/src/adapters/FileSystemAdapter.ts
+++ b/packages/MJInstaller/src/adapters/FileSystemAdapter.ts
@@ -27,6 +27,7 @@ import fsSync from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import AdmZip from 'adm-zip';
+import { ArchiveEntryRefusedError } from '../errors/ArchiveEntryRefusedError.js';
 
 /**
  * File system adapter providing all I/O operations needed by installer phases.
@@ -50,11 +51,18 @@ export class FileSystemAdapter {
    * a single root folder is detected, its contents are extracted directly
    * into `targetDir` without the wrapper folder.
    *
+   * Entries are written by hand rather than through adm-zip's `extractAllTo` /
+   * `extractEntryTo` on purpose: those sanitize an escaping entry by silently
+   * relocating it under the target, and a tampered release must fail, not be
+   * quietly repaired. Do not substitute them for the loop below.
+   *
    * @param zipPath - Absolute path to the ZIP file.
    * @param targetDir - Directory to extract into (created if it doesn't exist).
    * @returns List of top-level entry names in the target directory after extraction.
-   * @throws Error if the ZIP file is corrupt or unreadable, or if any entry would be written
-   *   outside `targetDir` (a "zip slip" archive — see {@link resolveWithinTarget}).
+   * @throws Error if the ZIP file is corrupt or unreadable.
+   * @throws {ArchiveEntryRefusedError} if any entry would be written outside `targetDir` (a
+   *   "zip slip" archive). Entries are validated before anything is written, so a refused
+   *   archive leaves the target directory untouched.
    *
    * @example
    * ```typescript
@@ -65,20 +73,24 @@ export class FileSystemAdapter {
   async ExtractZip(zipPath: string, targetDir: string): Promise<string[]> {
     const zip = new AdmZip(zipPath);
     const entries = zip.getEntries();
-
-    // Determine if ZIP has a single root folder (common for GitHub zipballs)
-    const topLevelNames = new Set<string>();
-    for (const entry of entries) {
-      const firstSegment = entry.entryName.split('/')[0];
-      topLevelNames.add(firstSegment);
-    }
-
-    const hasSingleRoot = topLevelNames.size === 1;
-    const rootPrefix = hasSingleRoot ? [...topLevelNames][0] + '/' : '';
-
-    await fs.mkdir(targetDir, { recursive: true });
     const root = path.resolve(targetDir);
 
+    // Determine if ZIP has a single root folder (common for GitHub zipballs). A sole "root"
+    // of '', '.' or '..' means every entry is absolute or a traversal, not a wrapper folder:
+    // it is never stripped, so the containment check below refuses the archive instead of
+    // silently relocating it.
+    const topLevelNames = new Set<string>();
+    for (const entry of entries) {
+      topLevelNames.add(entry.entryName.split('/')[0]);
+    }
+    const [soleRoot] = topLevelNames;
+    const hasSingleRoot =
+      topLevelNames.size === 1 && soleRoot !== '' && soleRoot !== '.' && soleRoot !== '..';
+    const rootPrefix = hasSingleRoot ? soleRoot + '/' : '';
+
+    // Resolve and validate every entry BEFORE touching the file system, so a hostile entry
+    // anywhere in the archive refuses the whole archive and nothing is written.
+    const planned: Array<{ entry: AdmZip.IZipEntry; fullPath: string }> = [];
     for (const entry of entries) {
       let relativePath = entry.entryName;
 
@@ -91,8 +103,17 @@ export class FileSystemAdapter {
         continue;
       }
 
-      const fullPath = resolveWithinTarget(root, relativePath, entry.entryName);
+      const fullPath = FileSystemAdapter.resolveWithinRoot(root, relativePath, entry.entryName);
+      if (fullPath === root) {
+        // '.', './' or 'wrapper/.' — the target directory itself; nothing to create.
+        continue;
+      }
+      planned.push({ entry, fullPath });
+    }
 
+    await fs.mkdir(root, { recursive: true });
+
+    for (const { entry, fullPath } of planned) {
       if (entry.isDirectory) {
         await fs.mkdir(fullPath, { recursive: true });
       } else {
@@ -102,8 +123,34 @@ export class FileSystemAdapter {
     }
 
     // Return the list of top-level items in the target dir after extraction
-    const extracted = await fs.readdir(targetDir);
+    const extracted = await fs.readdir(root);
     return extracted;
+  }
+
+  /**
+   * Resolve an archive entry against the extraction root and refuse any entry that would land
+   * outside it.
+   *
+   * Archive entry names are attacker-controlled: an entry named `../../.bashrc` or an absolute
+   * path would otherwise be written with the installer's privileges (CWE-22, "zip slip").
+   * The check is lexical — it never consults the file system — so it does not defend against
+   * a symbolic link that already exists under the target directory.
+   *
+   * @param root - The absolute, already-resolved extraction directory.
+   * @param relativePath - The entry name after any single-root-folder stripping.
+   * @param entryName - The original entry name, for the error message.
+   * @returns The absolute path to write, guaranteed (lexically) to be `root` or inside it.
+   * @throws {ArchiveEntryRefusedError} if the resolved path is not inside `root`.
+   */
+  private static resolveWithinRoot(root: string, relativePath: string, entryName: string): string {
+    const fullPath = path.resolve(root, relativePath);
+    const relative = path.relative(root, fullPath);
+    const escapes =
+      relative === '..' || relative.startsWith('..' + path.sep) || path.isAbsolute(relative);
+    if (escapes) {
+      throw new ArchiveEntryRefusedError(entryName);
+    }
+    return fullPath;
   }
 
   /**
@@ -391,25 +438,4 @@ export class FileSystemAdapter {
       // skip directories we can't read
     }
   }
-}
-
-/**
- * Resolves an archive entry against the extraction root and refuses any entry that would land
- * outside it. Archive entry names are attacker-controlled: an entry named `../../.bashrc` or an
- * absolute path would otherwise be written with the installer's privileges (CWE-22, "zip slip").
- *
- * @param root - The absolute, already-resolved extraction directory.
- * @param relativePath - The entry name after any single-root-folder stripping.
- * @param entryName - The original entry name, for the error message.
- * @returns The absolute path to write, guaranteed to be `root` or inside it.
- * @throws Error if the resolved path is not inside `root`.
- */
-function resolveWithinTarget(root: string, relativePath: string, entryName: string): string {
-  const fullPath = path.resolve(root, relativePath);
-  if (fullPath !== root && !fullPath.startsWith(root + path.sep)) {
-    throw new Error(
-      `ExtractZip: archive entry '${entryName}' resolves outside the target directory and was refused.`
-    );
-  }
-  return fullPath;
 }

--- a/packages/MJInstaller/src/adapters/FileSystemAdapter.ts
+++ b/packages/MJInstaller/src/adapters/FileSystemAdapter.ts
@@ -53,7 +53,8 @@ export class FileSystemAdapter {
    * @param zipPath - Absolute path to the ZIP file.
    * @param targetDir - Directory to extract into (created if it doesn't exist).
    * @returns List of top-level entry names in the target directory after extraction.
-   * @throws Error if the ZIP file is corrupt or unreadable.
+   * @throws Error if the ZIP file is corrupt or unreadable, or if any entry would be written
+   *   outside `targetDir` (a "zip slip" archive — see {@link resolveWithinTarget}).
    *
    * @example
    * ```typescript
@@ -76,6 +77,7 @@ export class FileSystemAdapter {
     const rootPrefix = hasSingleRoot ? [...topLevelNames][0] + '/' : '';
 
     await fs.mkdir(targetDir, { recursive: true });
+    const root = path.resolve(targetDir);
 
     for (const entry of entries) {
       let relativePath = entry.entryName;
@@ -89,7 +91,7 @@ export class FileSystemAdapter {
         continue;
       }
 
-      const fullPath = path.join(targetDir, relativePath);
+      const fullPath = resolveWithinTarget(root, relativePath, entry.entryName);
 
       if (entry.isDirectory) {
         await fs.mkdir(fullPath, { recursive: true });
@@ -389,4 +391,25 @@ export class FileSystemAdapter {
       // skip directories we can't read
     }
   }
+}
+
+/**
+ * Resolves an archive entry against the extraction root and refuses any entry that would land
+ * outside it. Archive entry names are attacker-controlled: an entry named `../../.bashrc` or an
+ * absolute path would otherwise be written with the installer's privileges (CWE-22, "zip slip").
+ *
+ * @param root - The absolute, already-resolved extraction directory.
+ * @param relativePath - The entry name after any single-root-folder stripping.
+ * @param entryName - The original entry name, for the error message.
+ * @returns The absolute path to write, guaranteed to be `root` or inside it.
+ * @throws Error if the resolved path is not inside `root`.
+ */
+function resolveWithinTarget(root: string, relativePath: string, entryName: string): string {
+  const fullPath = path.resolve(root, relativePath);
+  if (fullPath !== root && !fullPath.startsWith(root + path.sep)) {
+    throw new Error(
+      `ExtractZip: archive entry '${entryName}' resolves outside the target directory and was refused.`
+    );
+  }
+  return fullPath;
 }

--- a/packages/MJInstaller/src/errors/ArchiveEntryRefusedError.ts
+++ b/packages/MJInstaller/src/errors/ArchiveEntryRefusedError.ts
@@ -1,0 +1,23 @@
+/**
+ * Thrown by `FileSystemAdapter.ExtractZip` when an archive entry would be written outside the
+ * target directory (CWE-22, "zip slip"). Kept distinct from a corrupt or unreadable archive so
+ * callers can give the right advice: such an archive must not be extracted by hand either.
+ *
+ * Lives in its own module rather than beside the adapter so that tests which mock the adapter
+ * module wholesale can still construct and match the real error.
+ *
+ * @module errors/ArchiveEntryRefusedError
+ */
+export class ArchiveEntryRefusedError extends Error {
+  /** The offending entry name exactly as it appears in the archive. */
+  public readonly EntryName: string;
+
+  constructor(entryName: string) {
+    // The name is attacker-controlled and this message is printed to a terminal: strip control
+    // characters (ANSI/OSC escapes, newlines) so it cannot rewrite the line that reports it.
+    const printable = entryName.replace(/[\u0000-\u001f\u007f]/g, '?');
+    super(`ExtractZip: archive entry '${printable}' resolves outside the target directory and was refused.`);
+    this.name = 'ArchiveEntryRefusedError';
+    this.EntryName = entryName;
+  }
+}

--- a/packages/MJInstaller/src/phases/ScaffoldPhase.ts
+++ b/packages/MJInstaller/src/phases/ScaffoldPhase.ts
@@ -25,6 +25,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { InstallerEventEmitter } from '../events/InstallerEvents.js';
 import { InstallerError } from '../errors/InstallerError.js';
+import { ArchiveEntryRefusedError } from '../errors/ArchiveEntryRefusedError.js';
 import { GitHubReleaseProvider } from '../adapters/GitHubReleaseProvider.js';
 import { FileSystemAdapter } from '../adapters/FileSystemAdapter.js';
 import { RepoFetcher, type SparseFetchResult } from '../adapters/RepoFetcher.js';
@@ -111,6 +112,8 @@ export class ScaffoldPhase {
    * @throws {InstallerError} With code `NO_RELEASES` if no releases are found on GitHub.
    * @throws {InstallerError} With code `DOWNLOAD_FAILED` if the ZIP download fails.
    * @throws {InstallerError} With code `EXTRACT_FAILED` if ZIP extraction fails.
+   * @throws {InstallerError} With code `ARCHIVE_REFUSED` if the archive contains an entry that would
+   *   be written outside the target directory; nothing is extracted in that case.
    * @throws {InstallerError} With code `USER_CANCELLED` if the user declines the non-empty directory prompt.
    */
   async Run(context: ScaffoldContext): Promise<ScaffoldResult> {
@@ -251,6 +254,17 @@ export class ScaffoldPhase {
     try {
       await this.fileSystem.ExtractZip(zipPath, context.Dir);
     } catch (err) {
+      await this.removeTempZip(zipPath);
+      if (err instanceof ArchiveEntryRefusedError) {
+        // Nothing was written: ExtractZip validates every entry before the first write.
+        throw new InstallerError(
+          'scaffold',
+          'ARCHIVE_REFUSED',
+          `The release archive was refused: ${err.message}`,
+          'Do not extract this archive by hand. Delete the download, fetch the release again from ' +
+            'GitHub, and report it to the MemberJunction team if the same archive is refused twice.'
+        );
+      }
       throw new InstallerError(
         'scaffold',
         'EXTRACT_FAILED',
@@ -268,11 +282,15 @@ export class ScaffoldPhase {
       });
     }
 
-    // Clean up temp ZIP (non-critical).
+    await this.removeTempZip(zipPath);
+  }
+
+  /** Removes the downloaded release ZIP. Non-critical: the temp dir is reclaimed by the OS. */
+  private async removeTempZip(zipPath: string): Promise<void> {
     try {
       await this.fileSystem.RemoveFile(zipPath);
     } catch {
-      // ignore — temp dir is reclaimed by the OS
+      // ignore
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the one exploitable finding from the first full CodeQL scan of `next`: [alert #298, js/zipslip](https://github.com/MemberJunction/MJ/security/code-scanning/298) in `@memberjunction/installer`.

`FileSystemAdapter.ExtractZip` joined each archive entry name onto the target directory without checking the result. An archive entry named `../../.bashrc`, or an absolute path, would have been written wherever it pointed, with the installer's privileges (CWE-22). Exposure requires a tampered release archive, which is exactly what an installer should defend against.

## Change

Entries are resolved against the extraction root, and any that land outside it abort the extraction with a clear error before any file or directory is created for them. `path.resolve` rather than `path.join` also covers absolute entry names. GitHub zipballs with their single wrapper folder extract exactly as before.

## Adversarial review (second commit)

The first commit was reviewed adversarially after opening. Findings taken, all in the second commit:

- **Filesystem-root target was refused entirely.** The hand-built `root + sep` prefix became `//` (or `C:\\`) because a resolved root already ends in a separator, so every entry of a well-formed archive was rejected when installing into `/` or `D:\`. Containment now uses `path.relative`.
- **Refusal was not atomic.** Validation ran inside the write loop, so entries before the hostile one were already on disk (and the scaffold phase's `install.config.json` restore never ran). Every entry is now resolved and validated before the first `mkdir`; a refused archive leaves the target untouched.
- **All-traversal or all-absolute archives were silently relocated.** Single-root detection treated `..` or `` as a wrapper folder and stripped it. Those are no longer stripped, so such archives are refused.
- **Entries resolving to the root itself** (`.`, `./`, `wrapper/.`) are skipped rather than reaching `writeFile` on a directory.
- **Dedicated error and correct advice.** `ArchiveEntryRefusedError` (own module, so tests that mock the adapter can still match it) maps to a new `ARCHIVE_REFUSED` installer code. The old remediation told the user to extract the refused archive by hand. The temp ZIP is now removed on the refusal path too.
- **Terminal injection.** Control characters in a hostile entry name are stripped from the error message.
- **Documented, not solved:** the check is lexical and does not defend against a symlink that already exists under the target. The JSDoc also records why adm-zip's own extractors are not used: they relocate escaping entries instead of failing.

## Tests

Refusal cases are table-driven and assert nothing at all was written. Cases: leading `..`, escape under a single root folder, absolute entry, escaping directory, sibling directory sharing the target prefix, entry exactly `..`, all-traversal archive, all-absolute archive, hostile entry placed last, filesystem-root target, entries resolving to the root, control characters in the name, and well-formed names containing dots. `ScaffoldPhase` gains a case for `ARCHIVE_REFUSED` with temp-ZIP cleanup.

```
Test Files  29 passed (29)
     Tests  686 passed (686)
```

Package builds clean. Changeset included (patch). The deterministic integration tier was not run for this PR: the installer is not exercised by that suite and the branch carries no migration or metadata.

## Note on the CodeQL check

The installer is in the js-rest analysis set, which runs weekly and on dispatch rather than on pull requests, so this PR's own CodeQL run will not show alert #298 closing. It closes on the next scheduled or dispatched run on `next` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
