### PR TITLE
fix(mcp-server): only redirect authorize errors to a validated redirect_uri

### DIFF
--- a/.changeset/mcp-oauth-authorize-error-handling.md
+++ b/.changeset/mcp-oauth-authorize-error-handling.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/ai-mcp-server": patch
+---
+
+Harden `/oauth/authorize` error handling in the MCP OAuth proxy, per RFC 6749 §4.1.2.1 and the OAuth 2.0 Security BCP.
+
+An error may only be reported by redirecting to a request's `redirect_uri` once that URI has been matched against a registered client. Several checks in the authorize handler ran before that match was possible and still reported themselves as an error redirect to the request-supplied URI.
+
+The handler now identifies the client and validates the redirect URI first, and answers every failure in that stage with a locally rendered error page. Only after the match succeeds does a redirectable binding come into scope, so no earlier branch can redirect to a caller-supplied URI however it fails. `sendAuthorizationError()` now requires a redirect URI rather than accepting `undefined`, which makes an unvalidated call a compile error rather than a silent fallback.
+
+Behavior after validation is unchanged and pinned by tests: an unsupported `response_type`, a missing PKCE challenge, or a non-S256 challenge method still redirect to the registered URI carrying `error`, `error_description` and `state`, and a valid request still redirects to the upstream provider.

--- a/packages/AI/MCPServer/src/__tests__/OAuthProxyAuthorizeErrors.test.ts
+++ b/packages/AI/MCPServer/src/__tests__/OAuthProxyAuthorizeErrors.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for how /oauth/authorize reports errors.
+ *
+ * The rule under test is RFC 6749 section 4.1.2.1 / the OAuth 2.0 Security BCP: an error may only
+ * be reported by redirecting to a redirect_uri once that redirect_uri is known to belong to a known
+ * client. Before that point the server has no basis for trusting the URI, so the error has to be
+ * rendered locally. After that point the error redirect is the correct, spec-mandated behavior and
+ * must not regress into an error page.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+
+// ScopeService reaches into @memberjunction/server (and from there into database config) at import
+// time. The authorize endpoint never touches it, so stub it out rather than booting a server config.
+vi.mock('../auth/ScopeService.js', () => ({
+  loadActiveScopes: async () => [],
+  getDefaultScopes: async () => ['openid'],
+}));
+
+const REGISTERED_REDIRECT = 'http://localhost:9999/callback';
+const UNREGISTERED_REDIRECT = 'https://unregistered.example.com/callback';
+const CODE_CHALLENGE = 'x'.repeat(43);
+
+let server: Server;
+let baseUrl: string;
+let registeredClientId: string;
+
+beforeAll(async () => {
+  const { default: express } = await import('express');
+  const { createOAuthProxyRouter } = await import('../auth/OAuthProxyRouter');
+
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createOAuthProxyRouter({
+      baseUrl: 'http://127.0.0.1',
+      upstream: {
+        authorizationEndpoint: 'https://upstream.example.com/oauth2/authorize',
+        tokenEndpoint: 'https://upstream.example.com/oauth2/token',
+        clientId: 'upstream-client',
+        scopes: ['openid', 'profile', 'email'],
+        providerName: 'test',
+      },
+      enableDynamicRegistration: true,
+    }),
+  );
+
+  server = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+  const registration = await fetch(`${baseUrl}/oauth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ redirect_uris: [REGISTERED_REDIRECT], client_name: 'test-client' }),
+  });
+  registeredClientId = ((await registration.json()) as { client_id: string }).client_id;
+  expect(registeredClientId).toBeTruthy();
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+/** Issues an authorize request without following redirects. */
+async function authorize(params: Record<string, string>): Promise<Response> {
+  return fetch(`${baseUrl}/oauth/authorize?${new URLSearchParams(params)}`, { redirect: 'manual' });
+}
+
+describe('GET /oauth/authorize - errors BEFORE the redirect_uri is validated', () => {
+  it('renders an error page for an unknown client_id instead of redirecting to the supplied URI', async () => {
+    const res = await authorize({
+      client_id: 'mcp_no_such_client',
+      redirect_uri: UNREGISTERED_REDIRECT,
+      response_type: 'code',
+      state: 'caller-state',
+      code_challenge: CODE_CHALLENGE,
+      code_challenge_method: 'S256',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('location')).toBeNull();
+    await expect(res.text()).resolves.toContain('Unknown client_id');
+  });
+
+  it('renders an error page when the redirect_uri is not registered for the client', async () => {
+    const res = await authorize({
+      client_id: registeredClientId,
+      redirect_uri: UNREGISTERED_REDIRECT,
+      response_type: 'code',
+      state: 'caller-state',
+      code_challenge: CODE_CHALLENGE,
+      code_challenge_method: 'S256',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('location')).toBeNull();
+    await expect(res.text()).resolves.toContain('not registered');
+  });
+
+  it('validates the redirect_uri before the response_type, so a bad response_type cannot redirect either', async () => {
+    const res = await authorize({
+      client_id: registeredClientId,
+      redirect_uri: UNREGISTERED_REDIRECT,
+      response_type: 'token',
+      state: 'caller-state',
+      code_challenge: CODE_CHALLENGE,
+      code_challenge_method: 'S256',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('renders an error page when client_id is missing entirely', async () => {
+    const res = await authorize({ redirect_uri: UNREGISTERED_REDIRECT, response_type: 'code' });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('renders an error page when redirect_uri is missing entirely', async () => {
+    const res = await authorize({ client_id: registeredClientId, response_type: 'code' });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('location')).toBeNull();
+  });
+});
+
+describe('GET /oauth/authorize - errors AFTER the redirect_uri is validated (unchanged)', () => {
+  it('redirects a missing PKCE challenge back to the registered redirect_uri, with state', async () => {
+    const res = await authorize({
+      client_id: registeredClientId,
+      redirect_uri: REGISTERED_REDIRECT,
+      response_type: 'code',
+      state: 'caller-state',
+    });
+
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location') ?? '');
+    expect(location.origin + location.pathname).toBe(REGISTERED_REDIRECT);
+    expect(location.searchParams.get('error')).toBe('invalid_request');
+    expect(location.searchParams.get('error_description')).toContain('code_challenge');
+    expect(location.searchParams.get('state')).toBe('caller-state');
+  });
+
+  it('redirects an unsupported response_type back to the registered redirect_uri', async () => {
+    const res = await authorize({
+      client_id: registeredClientId,
+      redirect_uri: REGISTERED_REDIRECT,
+      response_type: 'token',
+      state: 'caller-state',
+      code_challenge: CODE_CHALLENGE,
+      code_challenge_method: 'S256',
+    });
+
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location') ?? '');
+    expect(location.origin + location.pathname).toBe(REGISTERED_REDIRECT);
+    expect(location.searchParams.get('error')).toBe('unsupported_response_type');
+  });
+
+  it('redirects an unsupported code_challenge_method back to the registered redirect_uri', async () => {
+    const res = await authorize({
+      client_id: registeredClientId,
+      redirect_uri: REGISTERED_REDIRECT,
+      response_type: 'code',
+      code_challenge: CODE_CHALLENGE,
+      code_challenge_method: 'plain',
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain(REGISTERED_REDIRECT);
+  });
+});
+
+describe('GET /oauth/authorize - a fully valid request still reaches the upstream provider', () => {
+  it('redirects to the configured upstream authorization endpoint', async () => {
+    const res = await authorize({
+      client_id: registeredClientId,
+      redirect_uri: REGISTERED_REDIRECT,
+      response_type: 'code',
+      state: 'caller-state',
+      code_challenge: CODE_CHALLENGE,
+      code_challenge_method: 'S256',
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('https://upstream.example.com/oauth2/authorize');
+  });
+});

--- a/packages/AI/MCPServer/src/auth/OAuthProxyRouter.ts
+++ b/packages/AI/MCPServer/src/auth/OAuthProxyRouter.ts
@@ -224,7 +224,9 @@ function handleAuthorizeEndpoint(
 ): void {
   const {
     client_id,
-    redirect_uri,
+    // Deliberately not named redirect_uri: nothing may redirect to the request's own URI until it
+    // has been matched against a registered client, and a name this ugly is hard to use by accident.
+    redirect_uri: untrustedRedirectUri,
     response_type,
     state,
     scope,
@@ -233,44 +235,50 @@ function handleAuthorizeEndpoint(
     nonce,
   } = req.query as Record<string, string | undefined>;
 
-  // Validate required parameters
+  // Identify the client FIRST. RFC 6749 section 4.1.2.1 (and the OAuth 2.0 Security BCP): when the
+  // client identifier or the redirect URI is missing, invalid or mismatched, the authorization
+  // server MUST NOT redirect the user-agent to the supplied redirection URI - it has no basis for
+  // trusting it yet, so an error redirect would forward the browser wherever the request asked.
+  // Everything in this block therefore answers with a locally rendered error page.
   if (!client_id) {
-    sendAuthorizationError(res, redirect_uri, 'invalid_request', 'client_id is required', state);
+    sendErrorPage(res, 'Invalid Request', 'client_id is required');
     return;
   }
 
-  if (!redirect_uri) {
-    // Cannot redirect if no redirect_uri - show error page
+  if (!untrustedRedirectUri) {
     sendErrorPage(res, 'Invalid Request', 'redirect_uri is required');
     return;
   }
 
-  if (response_type !== 'code') {
-    sendAuthorizationError(res, redirect_uri, 'unsupported_response_type', 'Only code response type is supported', state);
-    return;
-  }
-
-  // Validate client
   const client = clientRegistry.getClient(client_id);
   if (!client) {
-    sendAuthorizationError(res, redirect_uri, 'invalid_client', 'Unknown client_id', state);
+    sendErrorPage(res, 'Invalid Request', 'Unknown client_id');
     return;
   }
 
-  // Validate redirect URI
-  if (!clientRegistry.validateRedirectUri(client, redirect_uri)) {
-    sendAuthorizationError(res, redirect_uri, 'invalid_request', 'redirect_uri not registered for this client', state);
+  if (!clientRegistry.validateRedirectUri(client, untrustedRedirectUri)) {
+    sendErrorPage(res, 'Invalid Request', 'redirect_uri not registered for this client');
+    return;
+  }
+
+  // The URI is registered to this client. This binding is the only redirectable handle in the
+  // function, and it does not exist above this line - so no earlier branch can redirect to it,
+  // however it fails. Errors below report themselves the spec's way, by redirecting here.
+  const redirectUri = untrustedRedirectUri;
+
+  if (response_type !== 'code') {
+    sendAuthorizationError(res, redirectUri, 'unsupported_response_type', 'Only code response type is supported', state);
     return;
   }
 
   // OAuth 2.1 requires PKCE
   if (!code_challenge) {
-    sendAuthorizationError(res, redirect_uri, 'invalid_request', 'code_challenge is required (PKCE)', state);
+    sendAuthorizationError(res, redirectUri, 'invalid_request', 'code_challenge is required (PKCE)', state);
     return;
   }
 
   if (code_challenge_method && code_challenge_method !== 'S256') {
-    sendAuthorizationError(res, redirect_uri, 'invalid_request', 'Only S256 code_challenge_method is supported', state);
+    sendAuthorizationError(res, redirectUri, 'invalid_request', 'Only S256 code_challenge_method is supported', state);
     return;
   }
 
@@ -281,7 +289,7 @@ function handleAuthorizeEndpoint(
   // Create state for tracking this authorization flow
   const proxyState = stateManager.createState({
     clientId: client_id,
-    redirectUri: redirect_uri,
+    redirectUri,
     originalState: state,
     codeChallenge: code_challenge,
     codeChallengeMethod: code_challenge_method ?? 'S256',
@@ -942,19 +950,18 @@ function isValidRedirectUri(uri: string): boolean {
 
 /**
  * Sends an OAuth authorization error redirect.
+ *
+ * `redirectUri` is required and MUST already have been matched against the registered client -
+ * redirecting to an unvalidated URI is an open redirect. Callers that fail before that match is
+ * possible use {@link sendErrorPage} instead, which is why this no longer accepts `undefined`.
  */
 function sendAuthorizationError(
   res: Response,
-  redirectUri: string | undefined,
+  redirectUri: string,
   error: string,
   errorDescription: string,
   state: string | undefined
 ): void {
-  if (!redirectUri) {
-    sendErrorPage(res, 'Authorization Error', errorDescription);
-    return;
-  }
-
   const url = new URL(redirectUri);
   url.searchParams.set('error', error);
   url.searchParams.set('error_description', errorDescription);


### PR DESCRIPTION
## What

`/oauth/authorize` in the MCP OAuth proxy reported some errors by redirecting to the `redirect_uri` the request supplied, before that URI had been matched against a registered client. RFC 6749 §4.1.2.1 and the OAuth 2.0 Security BCP are explicit that this is the one thing the authorization endpoint must not do: until the redirect URI is known to belong to a known client, the server has no basis for sending a browser to it, and the error has to be rendered locally instead.

I audited every error exit in the authorize flow rather than only the branches I first noticed. Three of them were reachable before the client and redirect URI were validated.

| Authorize error branch | Stage | Before | After |
|---|---|---|---|
| `client_id` missing | pre-validation | redirect to the supplied URI | local error page |
| `redirect_uri` missing | pre-validation | local error page | local error page (unchanged) |
| `response_type` not `code` | pre-validation (ran before the client lookup) | redirect to the supplied URI | moved after validation — redirects to the registered URI |
| unknown `client_id` | pre-validation | redirect to the supplied URI | local error page |
| `redirect_uri` not registered for the client | pre-validation | redirect to the supplied URI | local error page |
| `code_challenge` missing (PKCE) | post-validation | redirect to the registered URI | unchanged |
| `code_challenge_method` not `S256` | post-validation | redirect to the registered URI | unchanged |
| callback: no code from the provider | post-validation (uses the stored state's URI) | redirect to the registered URI | unchanged |
| callback: upstream token exchange failed | post-validation (uses the stored state's URI) | redirect to the registered URI | unchanged |

The remaining error exits in the flow — an upstream provider error, a missing or expired `state` on the callback, a user who fails authorization, an expired consent session — already rendered locally and were never redirect-shaped.

## The fix

Structural rather than per-branch, so a future branch added above the validation cannot reintroduce it. The handler identifies the client and validates the redirect URI first, and everything in that stage answers with `sendErrorPage`. The query parameter is destructured under a deliberately unusable name, and the redirectable binding is only created after the match succeeds — so no branch above that line has a URI it could redirect to, however it fails. `sendAuthorizationError()` now takes a required redirect URI rather than `string | undefined`, which deletes its silent error-page fallback and makes an unvalidated call a type error.

The one behavioral change beyond error rendering: `response_type` is now checked after the client and redirect URI rather than before, so an invalid `response_type` on a *valid* client reports itself as an `unsupported_response_type` redirect to the registered URI, which is what the spec asks for and what it did before whenever the URI happened to be registered.

## Verification

Nine new tests in `src/__tests__/OAuthProxyAuthorizeErrors.test.ts`, driving the real router over a real HTTP listener on an ephemeral port with redirects unfollowed. Five pin the pre-validation branches as `400` with no `Location` header; three pin each post-validation branch as a `302` back to the registered URI carrying `error`, `error_description` and `state`; one pins that a fully valid request still redirects to the upstream provider.

Against the pre-fix handler, exactly the four pre-validation assertions fail (`302`, `Location` pointing at the request's own URI) and the five post-validation and success pins pass — so the suite fails on the behavior being fixed and on nothing else. With the fix: 9 passed, and the package's full suite is 140 passing. Package builds clean; ESLint on the touched file goes from 41 pre-existing errors to 40, with none added (the file's existing Prettier drift is left alone rather than reformatted into this diff).

## Notes for the reviewer

No GitHub issue — this came out of a local security review of the OAuth proxy while enabling it against a Cognito pool, not from a report. I have kept the description to the shape of the defect rather than how it would be used.

I have a second, unrelated PR open against the same package (#4266, Cognito upstream endpoints). The two branches are independent and touch different files; this one is off `next` and does not depend on it.

No schema change, no migration, no metadata, no CodeGen output. Changeset is `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
