### PR TITLE
fix(integration-engine): PrefetchContentHashes must bypass the RunView cache

### DIFF
--- a/.changeset/prefetch-content-hashes-bypasscache.md
+++ b/.changeset/prefetch-content-hashes-bypasscache.md
@@ -1,0 +1,5 @@
+---
+'@memberjunction/integration-engine': patch
+---
+
+fix(integration-engine): PrefetchContentHashes must bypass the RunView cache. Every apply batch's ID set is a unique fingerprint, so the existence-check query can never be a cache hit — without BypassCache each call only deposits a dead cache entry and the RunView cache grows O(records processed) for the life of the process; a large drain (500k+ records) walks the sync host into the kernel OOM kill line through exactly this path. Same point-in-time-read reasoning as LoadAllRecordMaps' existing BypassCache.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -5361,6 +5361,12 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 // 2x margin defended by nothing is not a guard. Same reasoning as baseEngine's own
                 // IgnoreMaxRows use, and this file documents the identical trap on the push side.
                 IgnoreMaxRows: true,
+                // Every batch's ID set is a unique fingerprint, so this query can never be a cache
+                // HIT — without BypassCache each call only DEPOSITS a dead entry, and the RunView
+                // cache grows O(records processed) for the life of the process (a 500k+ record
+                // drain OOMs the host). Same reasoning as LoadAllRecordMaps' BypassCache: this is
+                // a point-in-time existence read, never a reusable result.
+                BypassCache: true,
             }, contextUser);
             if (!res.Success) return undefined;
             const Hashes = new Map<string, string>();

--- a/packages/Integration/engine/src/__tests__/PrefetchProvesAbsence.test.ts
+++ b/packages/Integration/engine/src/__tests__/PrefetchProvesAbsence.test.ts
@@ -179,4 +179,14 @@ describe('the prefetch is unbounded — its result is what absence proofs are ju
         await host.PrefetchContentHashes([created('x')], {});
         expect(lastRunViewParams.current?.['IgnoreMaxRows']).toBe(true);
     });
+
+    it('passes BypassCache so per-batch fingerprints never accumulate in the RunView cache', async () => {
+        // Every batch's ID set is a unique fingerprint, so this query can never be a cache HIT —
+        // without BypassCache each call only DEPOSITS a dead entry and the cache grows
+        // O(records processed) for the life of the process. Observed live: a 500k+ record drain
+        // grew the sync host to the kernel OOM kill line through exactly this path.
+        const host = makeHost([]);
+        await host.PrefetchContentHashes([created('x')], {});
+        expect(lastRunViewParams.current?.['BypassCache']).toBe(true);
+    });
 });


### PR DESCRIPTION
## Problem

`PrefetchContentHashes` issues one existence/content-hash `RunView` per apply batch, keyed by that batch's ID set. Every batch's ID set is a **unique fingerprint**, so this query can never be a cache HIT — without `BypassCache` each call only **deposits a dead cache entry**, and the RunView cache grows `O(records processed)` for the life of the process. Observed in production: a 500k+ record drain grew the sync host's memory to the kernel OOM kill line through exactly this path.

## Fix

One line: `BypassCache: true` on the prefetch's `RunView`, with a comment carrying the reasoning. This is the same point-in-time-read rationale as `LoadAllRecordMaps`' existing `BypassCache` ("sync decisions must reflect committed record-map state") — a per-batch existence read is never a reusable result.

## Test

`PrefetchProvesAbsence.test.ts` gains a `BypassCache` assertion beside the existing `IgnoreMaxRows` one, using the suite's captured-params harness. Red before the fix, green after — 12/12 pass.

## Changeset

`@memberjunction/integration-engine` patch.