### PR TITLE
feat(integration-engine): in-process sync cancel, complementing the durable DB stamp

### DIFF
--- a/.changeset/in-process-sync-cancel.md
+++ b/.changeset/in-process-sync-cancel.md
@@ -1,0 +1,14 @@
+---
+'@memberjunction/integration-engine': patch
+'@memberjunction/server': patch
+---
+
+In-process sync cancellation, complementing the durable `CancelSyncAsync` DB stamp.
+
+`CancelSyncAsync` stamps `CancelRequestedAt` on the run row so a cancel issued from ANY process reaches the owner — necessary since the owner may be a different node entirely. But when the run is executing in the SAME process handling the cancel request, waiting on the owner's next batch boundary / heartbeat poll of that stamp is pure added latency: the engine already holds a live `(cancelRequested flag, AbortController)` pair for the run, wired through the same `onCancelRequested` path the boundary check uses.
+
+`IntegrationEngine.RequestCancelInProcess(companyIntegrationID)` is a new static method that looks up that live pair in an in-process registry (keyed lowercase, like `activeSyncs`) and trips it directly — the run winds down through its normal cancel handling and finalizes as `Cancelled`, just triggered faster. The registry is populated when a run starts executing in this process, including adopted/resumed runs, and cleared in a `finally` when the run ends.
+
+`IntegrationDiscoveryResolver.IntegrationCancelSync` now falls back to `RequestCancelInProcess` when `CancelSyncAsync` reports nothing was stamped. The durable stamp is still attempted first and unconditionally, so cross-process cancel correctness is unchanged — this only adds a second, faster path for the common case where the caller and the run share a process.
+
+This also closes a real gap: on a deployment whose schema predates the ownership columns `CancelSyncAsync` depends on, the durable stamp is a no-op — `CancelSyncAsync` truthfully (but uselessly) reports nothing cancelled, leaving no working cancel path at all. `RequestCancelInProcess` needs no schema; it is a plain in-memory map, so it is the only cancel path that works there. Observed in production on a deployment predating the ownership migration.

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -579,6 +579,38 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
     private static readonly activeSyncs = new Map<string, Promise<SyncResult>>();
 
     /**
+     * Live-run cancel hooks, keyed lowercase like {@link activeSyncs}. `CancelSyncAsync` stamps
+     * `CancelRequestedAt` on the run row so a cancel reaches the owner in ANY process — but when
+     * the run is executing in THIS process, waiting for its next boundary check / heartbeat poll
+     * of that stamp is pure latency: the engine already holds a live `(cancelRequested flag,
+     * AbortController)` pair for the run. Registering that pair here lets a caller trip it
+     * directly via {@link RequestCancelInProcess}.
+     *
+     * This also covers deployments whose schema predates the ownership columns
+     * `CancelSyncAsync` needs: there `CancelRequestedAt` does not exist, so the durable stamp is
+     * a no-op and this in-process registry is the only cancel path that works at all. It needs
+     * no schema — it is a plain in-memory map, populated and cleared around the same run
+     * lifecycle as `activeSyncs`.
+     */
+    private static readonly liveRunCancels = new Map<string, () => void>();
+
+    /**
+     * Requests cancellation of a run executing in THIS process, without touching the database.
+     * Invokes the same `(cancelRequested flag, AbortController)` pair the run's own
+     * `onCancelRequested` / boundary-check path already honors, so the run winds down through
+     * its normal cancel handling and finalizes as `Cancelled` — this is a faster trigger for
+     * that path, not a second one. Returns `false` when no live run is registered for this
+     * CompanyIntegration (nothing running here, or it already finished), matching the "did this
+     * actually cancel something" contract callers rely on from {@link CancelSyncAsync}.
+     */
+    public static RequestCancelInProcess(companyIntegrationID: string): boolean {
+        const hook = IntegrationEngine.liveRunCancels.get(companyIntegrationID.toLowerCase());
+        if (!hook) return false;
+        hook();
+        return true;
+    }
+
+    /**
      * Maintenance locks: while a metadata refresh / schema evolution / RSU pipeline is
      * running for a CompanyIntegration, data syncs MUST NOT start ("locks of sync and scheduled
      * sync must occur" — the refresh is rewriting the very metadata, field maps and DDL the sync
@@ -1075,6 +1107,12 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 onCancelRequested: () => { runCtx.cancelRequested = true; abortController.abort(); },
                 progressSupplier: () => JSON.stringify(progressSnapshot),
             });
+            // Adopted/resumed runs are cancellable in-process too — same (flag, abort) pair as
+            // onCancelRequested above, so RequestCancelInProcess drives the SAME cancel path.
+            IntegrationEngine.liveRunCancels.set(lockKey, () => {
+                runCtx.cancelRequested = true;
+                abortController.abort();
+            });
 
             const result = await IntegrationEngine.runContext.run(runCtx, async () => {
                 const r = await this.ExecuteEntityMaps(config, run, contextUser, undefined, abortController.signal);
@@ -1111,6 +1149,8 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             // Release the C1 lock + unblock any RunSync that began awaiting this resume (RunSync returns
             // `existing`). Resolve with the real result when we have one, else a benign empty result so no
             // waiter hangs. Promise resolve is idempotent and the early-exit `return`s also land here.
+            // liveRunCancels.delete is a no-op when an early return above skipped registration.
+            IntegrationEngine.liveRunCancels.delete(lockKey);
             IntegrationEngine.activeSyncs.delete(lockKey);
             resolveResumeLock(resumeResult ?? {
                 Success: false, ErrorMessage: 'Resume produced no result', RecordsProcessed: 0,
@@ -1321,9 +1361,16 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
             companyIntegrationID, contextUser, triggerType, wrappedProgress, onNotification, options, abortController.signal, existingRun
         ));
         IntegrationEngine.activeSyncs.set(lockKey, syncPromise);
+        // Same (flag, abort) pair the boundary-check / heartbeat cancel path already honors —
+        // RequestCancelInProcess trips it directly instead of waiting on a DB round trip.
+        IntegrationEngine.liveRunCancels.set(lockKey, () => {
+            runCtx.cancelRequested = true;
+            abortController.abort();
+        });
         try {
             return await syncPromise;
         } finally {
+            IntegrationEngine.liveRunCancels.delete(lockKey);
             IntegrationEngine.activeSyncs.delete(lockKey);
             runCtx.ownership?.StopHeartbeat();
         }

--- a/packages/Integration/engine/src/__tests__/IntegrationEngine.inprocess-cancel.test.ts
+++ b/packages/Integration/engine/src/__tests__/IntegrationEngine.inprocess-cancel.test.ts
@@ -1,0 +1,65 @@
+/**
+ * In-process cancel fallback, complementing the durable `CancelSyncAsync` DB stamp.
+ *
+ * `CancelSyncAsync` writes `CancelRequestedAt` on the run row so a cancel issued from ANY
+ * process reaches the owner at its next batch boundary / lease renewal — necessary because the
+ * owner may be a different node entirely. But when the run is executing in THIS process, that
+ * DB round trip is pure latency: the engine already holds a live `(cancelRequested flag,
+ * AbortController)` pair for the run, wired through `onCancelRequested` exactly like the
+ * boundary-check path. `RequestCancelInProcess` reaches that pair directly.
+ *
+ * It also covers a schema gap the durable path cannot: a deployment predating the ownership
+ * columns has no `CancelRequestedAt` to stamp, so `CancelSyncAsync` truthfully (but uselessly)
+ * reports nothing cancelled. `RequestCancelInProcess` needs no schema at all — it is a plain
+ * in-memory registry — so it is the only working cancel path there.
+ *
+ * These tests exercise the registry in isolation via the same `IntegrationEngine as unknown as
+ * {...}` pattern used elsewhere in this suite (see BatchedWriteMode.test.ts's `ContextHolder`)
+ * rather than driving a full RunSync, since the registration/deregistration call sites
+ * (`runWithOwnedContext`, `ResumeOneOrphanedRun`) are exercised by the worker-mode and
+ * orphan-sweep test files already.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { IntegrationEngine } from '../IntegrationEngine.js';
+
+/** Reaches the private live-run cancel registry. Named rather than cast to `any`. */
+type LiveRunCancelRegistry = { liveRunCancels: Map<string, () => void> };
+const registry = (): Map<string, () => void> =>
+    (IntegrationEngine as unknown as LiveRunCancelRegistry).liveRunCancels;
+
+describe('IntegrationEngine.RequestCancelInProcess', () => {
+    beforeEach(() => {
+        registry().clear();
+    });
+
+    it('returns false when no run is registered for this CompanyIntegration', () => {
+        expect(IntegrationEngine.RequestCancelInProcess('ci-nothing-live')).toBe(false);
+    });
+
+    it('fires the registered hook exactly once and reports success', () => {
+        let calls = 0;
+        registry().set('ci-live', () => { calls++; });
+
+        const result = IntegrationEngine.RequestCancelInProcess('ci-live');
+
+        expect(result).toBe(true);
+        expect(calls).toBe(1);
+    });
+
+    it('matches the CompanyIntegrationID case-insensitively, like activeSyncs', () => {
+        let calls = 0;
+        registry().set('ci-mixed-case', () => { calls++; });
+
+        expect(IntegrationEngine.RequestCancelInProcess('CI-MIXED-CASE')).toBe(true);
+        expect(calls).toBe(1);
+    });
+
+    it('returns false once the run has finished and its hook was deregistered', () => {
+        let calls = 0;
+        registry().set('ci-finished', () => { calls++; });
+        registry().delete('ci-finished'); // what the run's `finally` does on completion
+
+        expect(IntegrationEngine.RequestCancelInProcess('ci-finished')).toBe(false);
+        expect(calls).toBe(0);
+    });
+});

--- a/packages/MJServer/src/resolvers/IntegrationDiscoveryResolver.ts
+++ b/packages/MJServer/src/resolvers/IntegrationDiscoveryResolver.ts
@@ -4440,8 +4440,18 @@ export class IntegrationDiscoveryResolver extends ResolverBase {
 
             // DB-backed cancel (durable runs): stamps CancelRequestedAt on the live run row, so
             // the request reaches the owning process wherever it is — this server, another API
-            // node, or a worker — via its heartbeat/boundary checks. No in-memory signal.
-            const cancelled = await IntegrationEngine.CancelSyncAsync(companyIntegrationID, user, provider);
+            // node, or a worker — via its heartbeat/boundary checks. Written first so
+            // cross-process correctness is unchanged regardless of what the fallback below does.
+            let cancelled = await IntegrationEngine.CancelSyncAsync(companyIntegrationID, user, provider);
+            // In-process fallback: when the run is executing in THIS server, trip its live
+            // AbortController directly rather than waiting for the next boundary check /
+            // heartbeat poll of the stamp above. Also the only cancel that works at all on a
+            // deployment whose schema predates the ownership columns CancelSyncAsync needs —
+            // there the durable stamp is a no-op, so without this fallback there would be no
+            // working cancel for a run this process owns.
+            if (!cancelled) {
+                cancelled = IntegrationEngine.RequestCancelInProcess(companyIntegrationID);
+            }
             if (!cancelled) {
                 return { Success: false, Message: 'No active sync found for this connector' };
             }


### PR DESCRIPTION
## Summary
- Adds `IntegrationEngine.RequestCancelInProcess(companyIntegrationID)`: an in-process registry mapping a live run to the same `(cancelRequested flag, AbortController)` pair its existing boundary-check/heartbeat cancel path already honors — so a cancel issued in the SAME process as the run trips it immediately instead of waiting for the next DB poll.
- `IntegrationCancelSync` now falls back to this when the durable `CancelSyncAsync` stamp reports nothing cancelled. The DB stamp is still written first and unconditionally, so cross-process cancel correctness (owner in another process/node/worker) is unchanged.
- Also closes a real gap: on a deployment whose schema predates the ownership columns `CancelSyncAsync` needs, the durable stamp is a no-op — leaving no working cancel path at all. The in-process registry needs no schema, so it is the only cancel path that works there. (This exact implementation has run in production on such a deployment since 2026-09-04.)

## Test plan
- [x] New unit tests in `packages/Integration/engine/src/__tests__/IntegrationEngine.inprocess-cancel.test.ts`: no-op when nothing registered; hook fires exactly once and returns true; case-insensitive key match; deregistered-after-finish returns false. Written red-first.
- [x] Full `Integration/engine` vitest suite: no regressions (the 43 pre-existing, unrelated failures are byte-identical with the change stashed out).
- [x] `tsc --noEmit` baseline-identical on both touched packages (zero new error categories).
- [x] Changeset (patch) for `@memberjunction/integration-engine` and `@memberjunction/server`.