### PR TITLE
fix(codegen): scope pending EntityField discovery to includeSchemas

### DIFF
--- a/.changeset/codegen-pending-fields-schema-scope.md
+++ b/.changeset/codegen-pending-fields-schema-scope.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+Scope createNewEntityFieldsFromSchema to excludeSchemas (the compiled includeSchemas allow-list) so an Open App CodeGen run does not INSERT EntityField rows for sibling schemas.

--- a/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
+++ b/packages/CodeGenLib/src/Database/codeGenDatabaseProvider.ts
@@ -1380,7 +1380,7 @@ export abstract class CodeGenDatabaseProvider {
      *   avoid re-scanning the entire schema for entities that haven't changed. `undefined`
      *   or empty preserves the prior unscoped behavior.
      */
-    abstract getPendingEntityFieldsSQL(mjCoreSchema: string, entityIDs?: string[]): string;
+    abstract getPendingEntityFieldsSQL(mjCoreSchema: string, entityIDs?: string[], excludeSchemas?: string[]): string;
 
     /**
      * Returns an additional WHERE clause fragment for the check-constraints query.

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -4154,7 +4154,7 @@ export class ManageMetadataBase {
       // AN: 14-June-2025 - See note below about the new order of these steps, this must
       // happen before we update existing entity fields from schema.
       const step2StartTime: Date = new Date();
-      if (! await this.createNewEntityFieldsFromSchema(pool, scopedEntityIDs)) { // has its own internal filtering for exclude schema/table so don't pass in
+      if (! await this.createNewEntityFieldsFromSchema(pool, scopedEntityIDs, excludeSchemas)) {
          logError ('Error creating new entity fields from schema')
          bSuccess = false;
       }
@@ -4826,9 +4826,9 @@ export class ManageMetadataBase {
     *
     * @returns {string} - The SQL statement to retrieve pending entity fields.
     */
-   protected getPendingEntityFieldsSELECTSQL(entityIDs?: string[]): string {
+   protected getPendingEntityFieldsSELECTSQL(entityIDs?: string[], excludeSchemas?: string[]): string {
       const schema = mj_core_schema();
-      return this.dbProvider.getPendingEntityFieldsSQL(schema, entityIDs);
+      return this.dbProvider.getPendingEntityFieldsSQL(schema, entityIDs, excludeSchemas);
    }
 
    /**
@@ -4994,11 +4994,14 @@ export class ManageMetadataBase {
       return this.dbProvider.parseColumnDefaultValue(sqlDefaultValue) as string ?? null!;
    }
 
-   protected async createNewEntityFieldsFromSchema(pool: CodeGenConnection, entityIDs?: string[]): Promise<boolean> {
+   protected async createNewEntityFieldsFromSchema(pool: CodeGenConnection, entityIDs?: string[], excludeSchemas?: string[]): Promise<boolean> {
       try   {
          // entityIDs flows down to the provider's WHERE clause so the inline SELECT
-         // narrows to changed entities only when scoped.
-         const sSQL = this.getPendingEntityFieldsSELECTSQL(entityIDs);
+         // narrows to changed entities only when scoped. excludeSchemas is the compiled
+         // includeSchemas scope (out-of-allow-list schemas). Without it, Pass 1 inserts
+         // pending fields for every schema in the database (Forms CodeGen emitted Common
+         // Activity Files EntityField rows).
+         const sSQL = this.getPendingEntityFieldsSELECTSQL(entityIDs, excludeSchemas);
          const newEntityFieldsResult = await this.runQuery(pool, sSQL);
          const newEntityFields = newEntityFieldsResult.recordset;
          if (newEntityFields.length > 0) {

--- a/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/postgresql/PostgreSQLCodeGenProvider.ts
@@ -2104,9 +2104,9 @@ $if_view_exists$;
     // ─── METADATA MANAGEMENT: COMPLEX SQL GENERATION ─────────────────
 
     /** @inheritdoc */
-    getPendingEntityFieldsSQL(mjCoreSchema: string, entityIDs?: string[]): string {
+    getPendingEntityFieldsSQL(mjCoreSchema: string, entityIDs?: string[], excludeSchemas?: string[]): string {
         const qs = pgDialect.QuoteSchema.bind(pgDialect);
-        return this.buildPendingEntityFieldsQuery(mjCoreSchema, qs, entityIDs);
+        return this.buildPendingEntityFieldsQuery(mjCoreSchema, qs, entityIDs, excludeSchemas);
     }
 
     /** @inheritdoc */
@@ -2752,12 +2752,16 @@ WHERE p.prokind IN ('f', 'p')
     private buildPendingEntityFieldsQuery(
         schema: string,
         qs: (schema: string, name: string) => string,
-        entityIDs?: string[]
+        entityIDs?: string[],
+        excludeSchemas?: string[]
     ): string {
         // PG uses lowercase UUIDs; entity IDs from the metadata cache are already
         // normalized so direct string interpolation is safe (internal IDs, not user input).
         const scopeFilter = entityIDs && entityIDs.length > 0
             ? `AND sf."EntityID" IN (${entityIDs.map(id => `'${id}'`).join(',')})`
+            : '';
+        const schemaFilter = excludeSchemas && excludeSchemas.length > 0
+            ? `AND e."SchemaName" NOT IN (${excludeSchemas.map(s => `'${s.replace(/'/g, "''")}'`).join(',')})`
             : '';
         return `
 WITH fk_cache AS (
@@ -2830,6 +2834,7 @@ numbered_rows AS (
    WHERE
       "EntityFieldID" IS NULL
       ${scopeFilter}
+      ${schemaFilter}
 )
 SELECT *
 FROM numbered_rows

--- a/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
+++ b/packages/CodeGenLib/src/Database/providers/sqlserver/SQLServerCodeGenProvider.ts
@@ -1730,9 +1730,9 @@ ORDER BY
      *    PK, and unique key detection.
      * 3. **Cleanup**: Drops the temp tables.
      */
-    getPendingEntityFieldsSQL(mjCoreSchema: string, entityIDs?: string[]): string {
+    getPendingEntityFieldsSQL(mjCoreSchema: string, entityIDs?: string[], excludeSchemas?: string[]): string {
         return this.buildPendingFieldsTempTables(mjCoreSchema) +
-            this.buildPendingFieldsMainQuery(mjCoreSchema, entityIDs) +
+            this.buildPendingFieldsMainQuery(mjCoreSchema, entityIDs, excludeSchemas) +
             this.buildPendingFieldsCleanup();
     }
 
@@ -1768,12 +1768,18 @@ FROM [${schema}].[vwTableUniqueKeys];
      * Uses MaxSequences CTE to calculate proper field ordering and NumberedRows
      * CTE to deduplicate results.
      */
-    private buildPendingFieldsMainQuery(schema: string, entityIDs?: string[]): string {
+    private buildPendingFieldsMainQuery(schema: string, entityIDs?: string[], excludeSchemas?: string[]): string {
         // When scoped, narrow the scan to specific entities. SQL injection isn't a concern
         // here — entityIDs are MJ-internal UUIDs from the metadata cache, not user input —
         // but we quote each ID anyway for SQL Server's UUID literal syntax.
         const scopeFilter = entityIDs && entityIDs.length > 0
             ? `AND sf.EntityID IN (${entityIDs.map(id => `'${id}'`).join(',')})`
+            : '';
+        // includeSchemas is compiled into excludeSchemas before this query runs. Without this
+        // filter, Pass 1 (unscoped entityIDs) inserts pending fields for EVERY schema in the
+        // database — e.g. a Forms CodeGen run emitted Common Activity Files EntityField rows.
+        const schemaFilter = excludeSchemas && excludeSchemas.length > 0
+            ? `AND e.SchemaName NOT IN (${excludeSchemas.map(s => `'${s.replace(/'/g, "''")}'`).join(',')})`
             : '';
         return `WITH MaxSequences AS (
    SELECT
@@ -1841,6 +1847,7 @@ NumberedRows AS (
    WHERE
       EntityFieldID IS NULL
       ${scopeFilter}
+      ${schemaFilter}
    )
    SELECT *
    FROM NumberedRows

--- a/packages/CodeGenLib/src/__tests__/scoped-entity-fields.test.ts
+++ b/packages/CodeGenLib/src/__tests__/scoped-entity-fields.test.ts
@@ -42,6 +42,12 @@ describe('Phase A — scoped entity field plumbing', () => {
             expect(sql).toContain('EntityFieldID IS NULL');
             expect(sql).toMatch(/AND\s+sf\.EntityID\s+IN\b/);
         });
+
+        it('adds SchemaName NOT IN when excludeSchemas is supplied (includeSchemas compile)', () => {
+            const sql = provider.getPendingEntityFieldsSQL('__mj', undefined, ['__mj_BizAppsCommon', '__mj']);
+            expect(sql).toContain("e.SchemaName NOT IN ('__mj_BizAppsCommon','__mj')");
+            expect(sql).toContain('EntityFieldID IS NULL');
+        });
     });
 
     describe('PostgreSQLCodeGenProvider.getPendingEntityFieldsSQL', () => {


### PR DESCRIPTION
## Summary
- \`createNewEntityFieldsFromSchema\` ignored \`excludeSchemas\`. Pass 1 pending-fields SELECT returned every schema, so a Forms CodeGen run emitted Common \`Activity Files\` / \`Activity Links\` EntityField inserts.
- \`includeSchemas\` already compiled into \`excludeSchemas\` for SQL object generation; the pending-fields query now uses that list too (\`e.SchemaName NOT IN (...)\`).
- SQL Server + PostgreSQL providers. Unit test in \`scoped-entity-fields.test.ts\`.

Caught while authoring bizapps-forms#168 on a blank install.

## Test plan
- [x] Unit: pending-fields SQL includes SchemaName NOT IN when excludeSchemas is set
- [x] Forms CodeGen after this fix: emit has no \`MJ_BizApps_Common\` EntityField inserts