### PR TITLE
feat(ng-entity-viewer): chrome workspace|embedded; drop hosted grid Search

### DIFF
--- a/.changeset/embedded-viewer-chrome.md
+++ b/.changeset/embedded-viewer-chrome.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/ng-entity-viewer": patch
+---
+
+Add EntityViewerConfig.chrome (`workspace` | `embedded`). Embedded hides filter, view-mode toggle, record count, and pagination, and seeds the Grid plug-in with toolbar and pager off. Hosted grids no longer show a second Search box — the container already owns filter text.

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.dom.test.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.dom.test.ts
@@ -23,7 +23,7 @@ const CHILDREN = [SwitcherStub, RecycleChipStub, StubEmptyStateComponent, StubLo
 const ENTITY = { Name: 'Accounts' } as unknown as EntityInfo;
 type OnInitProto = { ngOnInit: () => void };
 
-interface State { entity?: EntityInfo | null; IsLoading?: boolean; ShowRecycleBin?: boolean; records?: Record<string, unknown>[]; filteredCount?: number; totalCount?: number }
+interface State { entity?: EntityInfo | null; IsLoading?: boolean; ShowRecycleBin?: boolean; records?: Record<string, unknown>[]; filteredCount?: number; totalCount?: number; config?: Record<string, unknown> }
 function render(state: State = {}) {
   vi.spyOn(EntityViewerComponent.prototype as unknown as OnInitProto, 'ngOnInit').mockImplementation(() => undefined);
   return renderComponentFixture(EntityViewerComponent, {
@@ -31,12 +31,15 @@ function render(state: State = {}) {
     declarations: [EntityViewerComponent],
     inputs: { Records: state.records ?? [] },
     setup: (c) => {
-      const priv = c as unknown as { _entity: EntityInfo | null; IsLoading: boolean; ShowRecycleBin: boolean; FilteredRecordCount: number; TotalRecordCount: number };
+      const priv = c as unknown as { _entity: EntityInfo | null; IsLoading: boolean; ShowRecycleBin: boolean; FilteredRecordCount: number; TotalRecordCount: number; Config: Record<string, unknown> };
       priv._entity = state.entity ?? null;
       priv.IsLoading = state.IsLoading ?? false;
       priv.ShowRecycleBin = state.ShowRecycleBin ?? false;
       priv.FilteredRecordCount = state.filteredCount ?? 0;
       priv.TotalRecordCount = state.totalCount ?? 0;
+      if (state.config) {
+        priv.Config = state.config;
+      }
     },
   });
 }
@@ -51,6 +54,12 @@ describe('EntityViewerComponent (DOM)', () => {
 
   it('renders the header when an entity is set', () => {
     expect(query(render({ entity: ENTITY }), '.viewer-header')).not.toBeNull();
+  });
+
+  it('hides the header when chrome is embedded', () => {
+    const f = render({ entity: ENTITY, config: { chrome: 'embedded' } });
+    expect(query(f, '.viewer-header')).toBeNull();
+    expect(query(f, '.filter-input')).toBeNull();
   });
 
   it('renders the view-type switcher in the header for an entity', () => {

--- a/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/entity-viewer/entity-viewer.component.ts
@@ -10,7 +10,7 @@ import { PageChangeEvent } from '@memberjunction/ng-pagination';
 import { MJNotificationService } from '@memberjunction/ng-notifications';
 import {
   EntityViewerConfig,
-  DEFAULT_VIEWER_CONFIG,
+  ResolveViewerConfig,
   RecordSelectedEvent,
   RecordOpenedEvent,
   DataLoadedEvent,
@@ -788,7 +788,7 @@ export class EntityViewerComponent extends BaseAngularComponent implements OnIni
    * Get merged configuration with defaults
    */
   get EffectiveConfig(): Required<EntityViewerConfig> {
-    return { ...DEFAULT_VIEWER_CONFIG, ...this.Config };
+    return ResolveViewerConfig(this.Config);
   }
 
   /**
@@ -2030,11 +2030,27 @@ export class EntityViewerComponent extends BaseAngularComponent implements OnIni
    */
   private effectiveRendererConfig(option: ViewModeOption): Record<string, unknown> {
     const base = this.viewTypeConfigById.get(option.viewTypeId) ?? {};
+    const seeded = this.seedEmbeddedGridChrome(base);
     if (!option.descriptor.UsesCanonicalGridState) {
+      return seeded;
+    }
+    const gridState = this.resolveCanonicalGridState(seeded);
+    return gridState ? { ...seeded, gridState } : seeded;
+  }
+
+  /**
+   * Embedded chrome is a container concern: peek cards should not grow a grid toolbar or pager.
+   * Only fill keys the plug-in blob has not already set, so an explicit ViewTypeConfigs still wins.
+   */
+  private seedEmbeddedGridChrome(base: Record<string, unknown>): Record<string, unknown> {
+    if (this.EffectiveConfig.chrome !== 'embedded') {
       return base;
     }
-    const gridState = this.resolveCanonicalGridState(base);
-    return gridState ? { ...base, gridState } : base;
+    return {
+      ...base,
+      showToolbar: base['showToolbar'] ?? false,
+      showPager: base['showPager'] ?? false,
+    };
   }
 
   /**

--- a/packages/Angular/Generic/entity-viewer/src/lib/types.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/types.ts
@@ -218,9 +218,25 @@ export interface GridStateChangedEvent {
 }
 
 /**
+ * Chrome density for {@link EntityViewerConfig}.
+ *
+ * - `workspace` — Explorer record page: filter, view-mode toggle, count, pagination, grid toolbar.
+ * - `embedded` — dashboard / peek card: none of that chrome. Grid toolbar and pager are seeded off
+ *   as well so hosts do not have to know Grid's opaque view-type blob.
+ */
+export type EntityViewerChrome = 'workspace' | 'embedded';
+
+/**
  * Configuration options for the EntityViewer component
  */
 export interface EntityViewerConfig {
+  /**
+   * Chrome density. `embedded` fills in compact defaults (no filter, no view-mode toggle,
+   * no record count, no pagination, pageSize 8). Explicit booleans still win.
+   * @default 'workspace'
+   */
+  chrome?: EntityViewerChrome;
+
   /**
    * Whether to show the filter input box
    * @default true
@@ -442,6 +458,7 @@ export interface ViewSaveResult {
 }
 
 export const DEFAULT_VIEWER_CONFIG: Required<EntityViewerConfig> = {
+  chrome: 'workspace',
   showFilter: true,
   showViewModeToggle: true,
   selectionBehavior: 'emit-only',
@@ -467,3 +484,27 @@ export const DEFAULT_VIEWER_CONFIG: Required<EntityViewerConfig> = {
   defaultSortField: '',
   defaultSortDirection: 'asc'
 };
+
+/** Compact defaults applied when {@link EntityViewerConfig.chrome} is `embedded`. */
+export const EMBEDDED_VIEWER_CHROME: Partial<EntityViewerConfig> = {
+  showFilter: false,
+  showViewModeToggle: false,
+  showRecordCount: false,
+  showPagination: false,
+  pageSize: 8,
+};
+
+/**
+ * Merge viewer config: workspace defaults, then embedded preset when requested, then explicit fields.
+ * Explicit booleans always win over the chrome preset.
+ */
+export function ResolveViewerConfig(partial: Partial<EntityViewerConfig> = {}): Required<EntityViewerConfig> {
+  const chrome = partial.chrome ?? 'workspace';
+  const preset = chrome === 'embedded' ? EMBEDDED_VIEWER_CHROME : {};
+  return {
+    ...DEFAULT_VIEWER_CONFIG,
+    ...preset,
+    ...partial,
+    chrome,
+  };
+}

--- a/packages/Angular/Generic/entity-viewer/src/lib/types.viewer-config.test.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/types.viewer-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_VIEWER_CONFIG, ResolveViewerConfig } from './types';
+
+describe('ResolveViewerConfig', () => {
+  it('defaults to workspace chrome with the Explorer header on', () => {
+    const cfg = ResolveViewerConfig();
+    expect(cfg.chrome).toBe('workspace');
+    expect(cfg.showFilter).toBe(true);
+    expect(cfg.showViewModeToggle).toBe(true);
+    expect(cfg.showRecordCount).toBe(true);
+    expect(cfg.showPagination).toBe(true);
+    expect(cfg.pageSize).toBe(DEFAULT_VIEWER_CONFIG.pageSize);
+  });
+
+  it('embedded chrome turns off header filter, toggle, count, and pagination', () => {
+    const cfg = ResolveViewerConfig({ chrome: 'embedded' });
+    expect(cfg.showFilter).toBe(false);
+    expect(cfg.showViewModeToggle).toBe(false);
+    expect(cfg.showRecordCount).toBe(false);
+    expect(cfg.showPagination).toBe(false);
+    expect(cfg.pageSize).toBe(8);
+  });
+
+  it('explicit booleans win over the embedded preset', () => {
+    const cfg = ResolveViewerConfig({ chrome: 'embedded', showFilter: true, pageSize: 12 });
+    expect(cfg.showFilter).toBe(true);
+    expect(cfg.showPagination).toBe(false);
+    expect(cfg.pageSize).toBe(12);
+  });
+});

--- a/packages/Angular/Generic/entity-viewer/src/lib/view-types/renderers/grid-view-renderer.component.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/view-types/renderers/grid-view-renderer.component.ts
@@ -121,6 +121,7 @@ export interface GridViewConfig {
       [AllowLoad]="false"
       [AutoLoadEntityActions]="AutoLoadEntityActions"
       [ShowToolbar]="effectiveShowToolbar"
+      [ShowSearch]="effectiveShowSearch"
       [ToolbarConfig]="config.toolbarConfig ?? {}"
       [SelectionMode]="effectiveSelectionMode"
       [ShowAddToListButton]="effectiveShowAddToListButton"
@@ -311,6 +312,14 @@ export class GridViewRendererComponent extends BaseAngularComponent implements I
   /** Effective toolbar visibility — defaults to `true` when not set in config. */
   get effectiveShowToolbar(): boolean {
     return this.config.showToolbar ?? true;
+  }
+
+  /**
+   * Grid search defaults OFF when hosted in entity-viewer. The container already owns
+   * `filterText` ("Filter records..."). Opt in with `toolbarConfig.showSearch: true`.
+   */
+  get effectiveShowSearch(): boolean {
+    return this.config.toolbarConfig?.showSearch ?? false;
   }
 
   /** Effective selection mode — defaults to `'checkbox'` when not set in config. */


### PR DESCRIPTION
## Summary
- Adds `EntityViewerConfig.chrome`: `workspace` (Explorer default) or `embedded` (dashboard peek).
- `embedded` turns off filter, view-mode toggle, record count, and pagination (`pageSize: 8`). Explicit booleans still win.
- Embedded seeds the Grid plug-in with `showToolbar: false` and `showPager: false` unless the view-type blob already set them.
- Hosted grids no longer show a second Search box (`ShowSearch` is false unless `toolbarConfig.showSearch: true`). The container already owns filter text.

## Test plan
- [x] `ResolveViewerConfig` unit tests and DOM test that embedded hides `.viewer-header`.
- [ ] Directory dashboard Latest people / Latest relationships: no Filter records, no Search, no pager.
- [ ] Explorer entity workspace still has Filter records in the header (no second Search in the grid toolbar).