### PR TITLE
feat(geo,sync): writable-geo write path, isolated parallel providers, skipGeoCoding

### DIFF
--- a/.changeset/geo-write-vs-read-and-isolated-sync.md
+++ b/.changeset/geo-write-vs-read-and-isolated-sync.md
@@ -1,0 +1,14 @@
+---
+"@memberjunction/core": patch
+"@memberjunction/generic-database-provider": patch
+"@memberjunction/sqlserver-dataprovider": patch
+"@memberjunction/postgresql-dataprovider": patch
+"@memberjunction/metadata-sync": patch
+"@memberjunction/codegen-lib": patch
+"@memberjunction/actions": patch
+"@memberjunction/ng-map-view": patch
+"@memberjunction/ng-entity-viewer": patch
+"@memberjunction/geo-core": patch
+---
+
+Split geo **read** (`SupportsGeoCoding`, maps, distance, virtual PrimaryAddress / `__mj_Latitude_{FK}`) from geo **write** (GeoCodeSyncService only when 1+ writable Geo* fields exist; skip provider when native lat/lng already set). mj-sync `push.skipGeoCoding` per entity. Parallel push default 10 uses `CreateIndependentInstance()` (shared pool, own TX) instead of defaulting to 1. Durable AfterCreate without a queue submitter defers until transaction depth is 0 (fire-and-forget), not nested in the save.

--- a/guides/TRANSACTIONS_AND_BATCHING_GUIDE.md
+++ b/guides/TRANSACTIONS_AND_BATCHING_GUIDE.md
@@ -80,8 +80,11 @@ disagree. If you called any of them, switch to `BeginEntityTransaction()` — or
 
 > **Concurrency note.** The ambient transaction lives on the *provider instance*, not a global.
 > MJServer builds per-request providers, so an ambient transaction is effectively request-scoped.
-> Long-lived single-provider processes (CLI tools, workers) must not run concurrent transactional
-> work on one provider instance.
+> Long-lived CLI tools (`mj sync push`) must not share one provider across parallel Saves.
+> `DatabaseProviderBase.CreateIndependentInstance()` forks a provider that **shares the connection
+> pool and metadata cache** but has its own transaction stack (SQL Server and PostgreSQL). Default
+> `--parallel-batch-size` is 10. Do not default to 1 to paper over a shared provider.
+> `ReleaseIndependentInstance()` must not close the pool.
 
 ### Client-side
 

--- a/packages/Actions/Engine/src/__tests__/EntityActionInvocation.workflow.test.ts
+++ b/packages/Actions/Engine/src/__tests__/EntityActionInvocation.workflow.test.ts
@@ -34,6 +34,7 @@ vi.mock('@memberjunction/global', async (importOriginal) => ({
 
 vi.mock('@memberjunction/core', () => ({
     BaseEntity: class {},
+    DatabaseProviderBase: class { TransactionDepth = 0; },
     Metadata: vi.fn(),
     RunView: vi.fn(),
     LogError: vi.fn(),
@@ -76,7 +77,9 @@ vi.mock('@memberjunction/actions-base', () => ({
     IsEntityActionInScope: mockIsEntityActionInScope,
     // The real resolver factory reads the global ClassFactory; the invocation layer only passes it
     // through to IsEntityActionInScope, which is stubbed here, so an identity stand-in is enough.
-    ResolveEntityActionScopeResolver: vi.fn(() => ({ IsInScope: vi.fn() }))
+    ResolveEntityActionScopeResolver: vi.fn(() => ({ IsInScope: vi.fn() })),
+    DurableEntityActionRegistry: { Instance: { Submitter: null, Register: vi.fn() } },
+    RedactParamsToJSON: vi.fn(() => '{}'),
 }));
 
 vi.mock('../generic/ActionEngine', () => ({
@@ -363,5 +366,26 @@ describe('InvokeAction — the change context reaches the filter layer', () => {
         await invocation.InvokeAction(invocationParams());
         const runArgs = mockRunAction.mock.calls[0][0] as { EntityChange?: unknown };
         expect(runArgs.EntityChange).toBeUndefined();
+    });
+});
+
+describe('Durable AfterCreate without a queue submitter', () => {
+    const invocation = new EntityActionInvocationSingleRecord();
+
+    it('defers locally instead of nesting in the caller transaction', async () => {
+        const entity = new RecordLikeEntity({ ID: 'rec-1', Amount: 42 }) as unknown as Record<string, unknown>;
+        (entity as { ProviderToUse: { TransactionDepth: number } }).ProviderToUse = { TransactionDepth: 0 };
+        (entity as { EntityInfo: { ID: string; Name: string } }).EntityInfo = { ID: TARGET_ENTITY_ID, Name: 'People' };
+        await invocation.InvokeAction(invocationParams({
+            InvocationType: { ID: INVOCATION_TYPE_ID, Name: 'AfterCreate' },
+            EntityAction: { ...invocationParams().EntityAction, RunMode: 'Durable' },
+            EntityObject: entity,
+        }));
+        const runArgs = mockRunAction.mock.calls[0][0] as {
+            DeferExecution?: (p: unknown) => Promise<{ ResultCode: string }>;
+        };
+        expect(typeof runArgs.DeferExecution).toBe('function');
+        const simple = await runArgs.DeferExecution!(runArgs);
+        expect(simple.ResultCode).toBe('DEFERRED_LOCAL');
     });
 });

--- a/packages/Actions/Engine/src/entity-actions/EntityActionInvocationTypes.ts
+++ b/packages/Actions/Engine/src/entity-actions/EntityActionInvocationTypes.ts
@@ -1,6 +1,6 @@
 import { MJGlobal, MJLruCache, RegisterClass, SafeJSONParse, UUIDsEqual } from "@memberjunction/global";
 import { MJActionFilterEntity, MJActionParamEntity, MJEntityActionParamEntity } from "@memberjunction/core-entities";
-import { BaseEntity, LogError, Metadata, RunView } from "@memberjunction/core";
+import { BaseEntity, DatabaseProviderBase, LogError, Metadata, RunView } from "@memberjunction/core";
 import {
     ActionInvocationProvenance,
     ActionParam,
@@ -195,11 +195,13 @@ export class EntityActionInvocationSingleRecord extends EntityActionInvocationBa
     /**
      * The deferral that hands this run to the durable substrate, or `undefined` to execute normally.
      *
-     * Returns undefined for every case that must stay inline: a binding that did not opt in, a
-     * lifecycle event that participates in the save, or a host with no submitter registered. The
-     * last is a fallback rather than a refusal — `RunMode='Durable'` asks for the work to be harder
-     * to lose, so declining to run it where the durable path is unavailable would make the opt-in
-     * less reliable than leaving it off.
+     * Returns undefined for every case that must stay inline: a binding that did not opt in, or a
+     * lifecycle event that participates in the save (Validate / Before*).
+     *
+     * After* + Durable with no queue submitter (CLI `mj sync push`): do **not** nest in the
+     * caller's EntityTransactionScope. Defer until TransactionDepth is 0, then fire-and-forget.
+     * Dropping the work would make Durable worse than leaving it off; nesting it is what blew
+     * up cheese (LogActivity inside Person.Save on a shared provider).
      */
     protected BuildDurableDeferral(
         params: EntityActionInvocationParams,
@@ -215,7 +217,14 @@ export class EntityActionInvocationSingleRecord extends EntityActionInvocationBa
         }
         const submitter = DurableEntityActionRegistry.Instance.Submitter;
         if (!submitter) {
-            return undefined;
+            return async (runParams: RunActionParams): Promise<ActionResultSimple | null> => {
+                this.scheduleDurableLocalRun(params, action, runParams);
+                return {
+                    Success: true,
+                    ResultCode: 'DEFERRED_LOCAL',
+                    Message: 'Durable action deferred until the ambient transaction settles (no queue submitter in this process).',
+                };
+            };
         }
 
         return async (runParams: RunActionParams): Promise<ActionResultSimple | null> => {
@@ -252,6 +261,33 @@ export class EntityActionInvocationSingleRecord extends EntityActionInvocationBa
             );
             return null;
         };
+    }
+
+    /**
+     * CLI / no-queue Durable fallback: wait until the save's transaction has settled, then run
+     * the action without DeferExecution. Errors are logged; the originating Save already succeeded.
+     */
+    private scheduleDurableLocalRun(
+        params: EntityActionInvocationParams,
+        action: MJActionEntityExtended,
+        runParams: RunActionParams,
+    ): void {
+        const provider = params.EntityObject?.ProviderToUse as unknown as DatabaseProviderBase | undefined;
+        const tick = () => {
+            const depth = provider?.TransactionDepth ?? 0;
+            if (depth > 0) {
+                setImmediate(tick);
+                return;
+            }
+            const { DeferExecution: _d, ...rest } = runParams;
+            ActionEngineServer.Instance.RunAction(rest).catch((e: unknown) => {
+                LogError(
+                    `Durable entity action ${params.EntityAction.ID} (${action.Name}) failed after deferral: ` +
+                    `${e instanceof Error ? e.message : String(e)}`,
+                );
+            });
+        };
+        setImmediate(tick);
     }
 
     /**

--- a/packages/Actions/Engine/src/entity-actions/EntityActionInvocationTypes.ts
+++ b/packages/Actions/Engine/src/entity-actions/EntityActionInvocationTypes.ts
@@ -198,10 +198,11 @@ export class EntityActionInvocationSingleRecord extends EntityActionInvocationBa
      * Returns undefined for every case that must stay inline: a binding that did not opt in, or a
      * lifecycle event that participates in the save (Validate / Before*).
      *
-     * After* + Durable with no queue submitter (CLI `mj sync push`): do **not** nest in the
-     * caller's EntityTransactionScope. Defer until TransactionDepth is 0, then fire-and-forget.
-     * Dropping the work would make Durable worse than leaving it off; nesting it is what blew
-     * up cheese (LogActivity inside Person.Save on a shared provider).
+     * After* + Durable with no queue submitter (local / no-queue process — e.g. CLI
+     * `mj sync push`): do **not** nest in the caller's EntityTransactionScope. Defer until
+     * TransactionDepth is 0, then fire-and-forget. Dropping the work would make Durable worse
+     * than leaving it off; nesting it is what blew up cheese (LogActivity inside Person.Save
+     * on a shared provider).
      */
     protected BuildDurableDeferral(
         params: EntityActionInvocationParams,
@@ -264,10 +265,11 @@ export class EntityActionInvocationSingleRecord extends EntityActionInvocationBa
     }
 
     /**
-     * CLI / no-queue Durable fallback: wait until the save's transaction has settled, then run
-     * the action without DeferExecution. Errors are logged; the originating Save already succeeded.
+     * Local / no-queue Durable fallback (CLI `mj sync push` is one host): wait until the save's
+     * transaction has settled, then run the action without DeferExecution. Errors are logged; the
+     * originating Save already succeeded. Protected so subclasses can replace the wait/run policy.
      */
-    private scheduleDurableLocalRun(
+    protected scheduleDurableLocalRun(
         params: EntityActionInvocationParams,
         action: MJActionEntityExtended,
         runParams: RunActionParams,

--- a/packages/Angular/Generic/entity-viewer/src/lib/view-types/descriptors/map-view-type.ts
+++ b/packages/Angular/Generic/entity-viewer/src/lib/view-types/descriptors/map-view-type.ts
@@ -1,13 +1,14 @@
 import { Type } from '@angular/core';
-import { EntityInfo, IMetadataProvider } from '@memberjunction/core';
+import { EntityHasMapCoordinates, EntityInfo, IMetadataProvider } from '@memberjunction/core';
 import { RegisterClass } from '@memberjunction/global';
 import { BaseViewTypeDescriptor } from '../view-type.contracts';
 import { MapViewRendererComponent } from '../renderers/map-view-renderer.component';
 
 /**
  * Map view type — renders geocoded records as markers on an interactive map. Available
- * only for entities that support geocoding (lifted from the host's `updateGeoCodingSupport`
- * logic, which checks `entity.SupportsGeoCoding`).
+ * when `SupportsGeoCoding` is on **or** the entity has GeoLatitude/GeoLongitude (including
+ * virtual display fields such as PrimaryAddressLatitude). GeoCodeSyncService is a separate
+ * write-side gate (writable Geo* only).
  *
  * Registration key (`DriverClass`) matches the `MJ: View Types` metadata seed:
  * `metadata/view-types/.view-types.json` → "MapViewType".
@@ -20,7 +21,7 @@ export class MapViewType extends BaseViewTypeDescriptor {
   readonly RendererComponent: Type<unknown> = MapViewRendererComponent;
 
   override IsAvailableFor(entity: EntityInfo, _provider?: IMetadataProvider): boolean {
-    return !!(entity && entity.SupportsGeoCoding);
+    return !!(entity && EntityHasMapCoordinates(entity));
   }
 }
 

--- a/packages/Angular/Generic/ng-map-view/src/lib/map-view.component.ts
+++ b/packages/Angular/Generic/ng-map-view/src/lib/map-view.component.ts
@@ -13,7 +13,7 @@ import {
     AfterViewInit,
     inject
 } from '@angular/core';
-import { EntityInfo } from '@memberjunction/core';
+import { EntityInfo, ResolveMapLatitudeField, ResolveMapLongitudeField } from '@memberjunction/core';
 import { GeoDataEngine } from '@memberjunction/core-entities';
 import { MapRenderMode, MapDisplayState, MapMarkerClickEvent, MapRegionClickEvent } from './map-view.types';
 import * as MapCore from '@memberjunction/geo-maps';
@@ -114,19 +114,13 @@ export class MapViewComponent implements OnInit, AfterViewInit, OnDestroy, OnCha
      * Resolve a lat/lng field name. Explicit override wins; otherwise picks the
      * field tagged with the matching `ExtendedType` on `Entity`.
      */
-    private resolveGeoField(input: string, defaultName: string, extendedType: 'GeoLatitude' | 'GeoLongitude'): string {
-        if (input && input !== defaultName) return input; // explicit override
-        if (this.Entity) {
-            const tagged = this.Entity.Fields.find(f => f.ExtendedType === extendedType);
-            if (tagged) return tagged.Name;
-        }
-        return input || defaultName;
-    }
     private get effectiveLatitudeField(): string {
-        return this.resolveGeoField(this.LatitudeField, '__mj_Latitude', 'GeoLatitude');
+        if (!this.Entity) return this.LatitudeField || '__mj_Latitude';
+        return ResolveMapLatitudeField(this.Entity, this.LatitudeField);
     }
     private get effectiveLongitudeField(): string {
-        return this.resolveGeoField(this.LongitudeField, '__mj_Longitude', 'GeoLongitude');
+        if (!this.Entity) return this.LongitudeField || '__mj_Longitude';
+        return ResolveMapLongitudeField(this.Entity, this.LongitudeField);
     }
 
     ngOnInit(): void {

--- a/packages/CodeGenLib/src/Database/sql_codegen.ts
+++ b/packages/CodeGenLib/src/Database/sql_codegen.ts
@@ -1,4 +1,4 @@
-import { EntityInfo, EntityFieldInfo, EntityPermissionInfo, Metadata, UserInfo } from '@memberjunction/core';
+import { EntityInfo, EntityFieldInfo, EntityPermissionInfo, Metadata, UserInfo, ShouldJoinRecordGeoCodes, HasNativeLatLngFields, NativeLatitudeField, NativeLongitudeField, ListEmbeddedGeoSpecs } from '@memberjunction/core';
 import { logError, logStatus, logWarning, startSpinner, updateSpinner, succeedSpinner, failSpinner } from '../Misc/status_logging';
 import * as fs from 'fs';
 import path from 'path';
@@ -1847,16 +1847,21 @@ export class SQLCodeGenBase {
         let relatedFieldsString: string = await this.generateBaseViewRelatedFieldsString(pool, entity.Fields);
         const relatedFieldsJoinString: string = this.generateBaseViewJoins(entity, entity.Fields);
 
-        // Geo support: add __mj_Latitude and __mj_Longitude virtual fields for geo-enabled entities
-        // Skip for Record Geo Codes itself to avoid circular self-reference in the view
+        // Geo WRITE source: native lat/lng aliases, or RecordGeoCode JOIN when the entity
+        // has writable Geo* fields and no native coords. Display-only entities (Person/Org
+        // virtual PrimaryAddress*) do not get a RecordGeoCode join on their own ID.
         if (entity.SupportsGeoCoding && entity.Name.trim().toLowerCase() !== 'mj: record geo codes') {
             const qi = this._dbProvider.Dialect.QuoteIdentifier.bind(this._dbProvider.Dialect);
-            const geoFieldsSelect = this.hasNativeGeoFields(entity.Fields)
+            const geoFieldsSelect = HasNativeLatLngFields(entity.Fields)
                 ? this.generateNativeGeoFields(entity.Fields, classNameFirstChar, qi)
-                : this.generateRecordGeoCodeFields(qi);
+                : (ShouldJoinRecordGeoCodes(entity) ? this.generateRecordGeoCodeFields(qi) : '');
             if (geoFieldsSelect) {
                 relatedFieldsString += (relatedFieldsString ? ',\n' : '') + geoFieldsSelect;
             }
+        }
+        const embeddedGeo = this.generateEmbeddedGeoSelect(entity, classNameFirstChar);
+        if (embeddedGeo.select) {
+            relatedFieldsString += (relatedFieldsString ? ',\n' : '') + embeddedGeo.select;
         }
         // GRANTs target the PUBLIC view (BaseView), not the one this method generates. For a
         // LAYERED entity those are different objects, and the outer one may not exist yet: the
@@ -1981,10 +1986,9 @@ export class SQLCodeGenBase {
             }
         }
 
-        // Geo support: add LEFT JOIN to vwRecordGeoCodes for entities with SupportsGeoCoding = 1
-        // that don't have native GeoLatitude/GeoLongitude fields (those get aliased directly).
-        // Skip for Record Geo Codes itself to avoid circular self-reference in the view.
-        if (entity.SupportsGeoCoding && !this.hasNativeGeoFields(entityFields) && entity.Name.trim().toLowerCase() !== 'mj: record geo codes') {
+        // Geo WRITE source: RecordGeoCode JOIN only when there are writable Geo* fields
+        // and no native lat/lng. Display-only entities skip this join.
+        if (ShouldJoinRecordGeoCodes(entity)) {
             const dialect = this._dbProvider.Dialect;
             const qi = dialect.QuoteIdentifier.bind(dialect);
             const qs = dialect.QuoteSchema.bind(dialect);
@@ -2012,6 +2016,8 @@ export class SQLCodeGenBase {
             sOutput += `LEFT OUTER JOIN\n    ${qs(mjCoreSchema, 'vwRecordGeoCodes')} AS __mj_rgc\n  ON\n    __mj_rgc.${qi('EntityID')} = '${entity.ID}'\n    AND __mj_rgc.${qi('RecordID')} = ${recordIdExpr}\n    AND __mj_rgc.${qi('LocationType')} = 'Primary'`;
         }
 
+        sOutput += this.generateEmbeddedGeoJoins(entity, classNameFirstChar);
+
         return sOutput;
     }
 
@@ -2029,9 +2035,7 @@ export class SQLCodeGenBase {
      * on any geo-eligible entity whose RecordGeoCode-based view ran once.
      */
     protected hasNativeGeoFields(entityFields: EntityFieldInfo[]): boolean {
-        const hasLat = entityFields.some(f => f.ExtendedType === 'GeoLatitude' && !f.IsVirtual);
-        const hasLng = entityFields.some(f => f.ExtendedType === 'GeoLongitude' && !f.IsVirtual);
-        return hasLat && hasLng;
+        return HasNativeLatLngFields(entityFields);
     }
 
     /**
@@ -2043,10 +2047,43 @@ export class SQLCodeGenBase {
         classNameFirstChar: string,
         qi: (name: string) => string
     ): string {
-        const latField = entityFields.find(f => f.ExtendedType === 'GeoLatitude' && !f.IsVirtual);
-        const lngField = entityFields.find(f => f.ExtendedType === 'GeoLongitude' && !f.IsVirtual);
+        const latField = NativeLatitudeField(entityFields);
+        const lngField = NativeLongitudeField(entityFields);
         if (!latField || !lngField) return '';
         return `    ${qi(classNameFirstChar)}.${qi(latField.Name)} AS ${qi('__mj_Latitude')},\n    ${qi(classNameFirstChar)}.${qi(lngField.Name)} AS ${qi('__mj_Longitude')}`;
+    }
+
+    /**
+     * Bubble lat/lng from EmbeddedRecord peers as `__mj_Latitude_{FK}`.
+     * Geocode lives on the Address (or other source); the parent only displays it.
+     */
+    protected generateEmbeddedGeoSelect(entity: EntityInfo, classNameFirstChar: string): { select: string; joins: string } {
+        const specs = ListEmbeddedGeoSpecs(entity.Fields);
+        if (specs.length === 0) return { select: '', joins: '' };
+        const md = new Metadata();
+        const qi = this._dbProvider.Dialect.QuoteIdentifier.bind(this._dbProvider.Dialect);
+        const qs = this._dbProvider.Dialect.QuoteSchema.bind(this._dbProvider.Dialect);
+        const selects: string[] = [];
+        const joins: string[] = [];
+        for (const spec of specs) {
+            const related = md.Entities.find(e => e.ID.toLowerCase() === spec.relatedEntityID.toLowerCase());
+            if (!related) continue;
+            const latF = NativeLatitudeField(related.Fields) ?? related.Fields.find(f => f.Name === '__mj_Latitude' || f.Name === 'PrimaryAddressLatitude');
+            const lngF = NativeLongitudeField(related.Fields) ?? related.Fields.find(f => f.Name === '__mj_Longitude' || f.Name === 'PrimaryAddressLongitude');
+            if (!latF || !lngF) continue;
+            const alias = `__mj_emb_${spec.foreignKeyField}`;
+            const schema = spec.relatedSchemaName || related.SchemaName;
+            const table = spec.relatedBaseTable || related.BaseTable;
+            const joinKind = spec.allowsNull ? 'LEFT OUTER' : 'INNER';
+            joins.push(`${joinKind} JOIN\n    ${qs(schema, table)} AS ${alias}\n  ON\n    ${qi(classNameFirstChar)}.${qi(spec.foreignKeyField)} = ${alias}.${qi(related.FirstPrimaryKey.Name)}`);
+            selects.push(`    ${alias}.${qi(latF.Name)} AS ${qi(spec.lat)},\n    ${alias}.${qi(lngF.Name)} AS ${qi(spec.lng)}`);
+        }
+        return { select: selects.join(',\n'), joins: joins.join('\n') };
+    }
+
+    protected generateEmbeddedGeoJoins(entity: EntityInfo, classNameFirstChar: string): string {
+        const { joins } = this.generateEmbeddedGeoSelect(entity, classNameFirstChar);
+        return joins ? ((entity.Fields.length ? '\n' : '') + joins) : '';
     }
 
     /**

--- a/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
+++ b/packages/GenericDatabaseProvider/src/GenericDatabaseProvider.ts
@@ -126,12 +126,6 @@ export interface ExecuteSQLBatchOptions {
  * Platform-specific providers should extend this class instead of DatabaseProviderBase
  * to inherit these shared behaviors.
  */
-/** ExtendedType values that indicate a geo-relevant field */
-const GEO_EXTENDED_TYPES = new Set([
-    'Geo', 'GeoAddress', 'GeoCity', 'GeoStateProvince',
-    'GeoCountry', 'GeoPostalCode', 'GeoLatitude', 'GeoLongitude'
-]);
-
 /**
  * Thrown when a nested savepoint fails because the ambient physical transaction
  * was already rolled back by the server (mssql ENOTBEGUN/EABORT, pg 25P01).
@@ -636,16 +630,28 @@ export abstract class GenericDatabaseProvider extends DatabaseProviderBase {
         if (options.SkipEntityAIActions !== true)
             await this.HandleEntityAIActions(entity, 'save', true, user);
 
-        // Flag geo sync needed in the SaveContext state bag.
-        // Check: entity supports geocoding AND (new record OR any geo field was dirty).
-        // SkipGeoCoding: a sync's writes arrive pre-formed from the source system — the per-write
-        // geocode lookup is suppressed for those saves only; interactive saves still geocode.
-        if (entity.EntityInfo.SupportsGeoCoding && options.SkipGeoCoding !== true) {
-            const needsGeoSync = context.IsNew || context.Fields.some(
-                (f: SaveContextField) => f.WasDirty && f.FieldInfo.ExtendedType != null && GEO_EXTENDED_TYPES.has(f.FieldInfo.ExtendedType)
-            );
-            if (needsGeoSync) {
-                context.State['geoSyncNeeded'] = true;
+        // GeoCodeSyncService is the WRITE path. SupportsGeoCoding also means maps/distance
+        // (read). The service only runs when there is at least one writable Geo* field.
+        // Virtual PrimaryAddress* / __mj_Latitude never invoke the provider.
+        // SkipGeoCoding: per-save (mj-sync push.skipGeoCoding, integration sync).
+        // Native lat/lng already populated (sample data, pasted coords) → do not call the API.
+        if (
+            entity.EntityInfo.SupportsGeoCoding &&
+            options.SkipGeoCoding !== true &&
+            entity.EntityInfo.HasWritableGeoSourceFields
+        ) {
+            const lat = entity.EntityInfo.Fields.find(f => f.IsNativeLatitudeField);
+            const lng = entity.EntityInfo.Fields.find(f => f.IsNativeLongitudeField);
+            const latVal = lat ? entity.Get(lat.Name) : null;
+            const lngVal = lng ? entity.Get(lng.Name) : null;
+            const coordsAlreadySet = latVal != null && latVal !== '' && lngVal != null && lngVal !== '';
+            if (!coordsAlreadySet) {
+                const needsGeoSync = context.IsNew || context.Fields.some(
+                    (f: SaveContextField) => f.WasDirty && f.FieldInfo.IsWritableGeoField
+                );
+                if (needsGeoSync) {
+                    context.State['geoSyncNeeded'] = true;
+                }
             }
         }
     }

--- a/packages/GenericDatabaseProvider/src/__tests__/skip-side-effects.test.ts
+++ b/packages/GenericDatabaseProvider/src/__tests__/skip-side-effects.test.ts
@@ -11,7 +11,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { GenericDatabaseProvider } from '../GenericDatabaseProvider.js';
-import type { BaseEntity, UserInfo, EntitySaveOptions } from '@memberjunction/core';
+import { EntityFieldInfo, EntityInfo, type BaseEntity, type UserInfo, type EntitySaveOptions } from '@memberjunction/core';
 
 type SaveContextLike = { IsNew: boolean; Fields: unknown[]; State: Record<string, unknown> };
 type Host = {
@@ -26,20 +26,62 @@ function makeHost(): Host {
     return host as unknown as Host;
 }
 
-const geoEntity = { EntityInfo: { SupportsGeoCoding: true } } as unknown as BaseEntity;
+function geoEntity(opts: {
+    writable?: boolean;
+    lat?: number | null;
+    lng?: number | null;
+    virtualOnly?: boolean;
+}): BaseEntity {
+    const lat = new EntityFieldInfo();
+    Object.assign(lat, {
+        Name: opts.virtualOnly ? 'PrimaryAddressLatitude' : 'Latitude',
+        ExtendedType: 'GeoLatitude',
+        IsVirtual: !!opts.virtualOnly,
+        AllowUpdateAPI: !opts.virtualOnly,
+    });
+    const lng = new EntityFieldInfo();
+    Object.assign(lng, {
+        Name: opts.virtualOnly ? 'PrimaryAddressLongitude' : 'Longitude',
+        ExtendedType: 'GeoLongitude',
+        IsVirtual: !!opts.virtualOnly,
+        AllowUpdateAPI: !opts.virtualOnly,
+    });
+    const info = new EntityInfo();
+    info.Name = opts.virtualOnly ? 'People' : 'Addresses';
+    info.SupportsGeoCoding = true;
+    Object.defineProperty(info, 'Fields', { get: () => [lat, lng], configurable: true });
+    const values: Record<string, unknown> = { Latitude: opts.lat ?? null, Longitude: opts.lng ?? null };
+    return {
+        EntityInfo: info,
+        Get: (n: string) => values[n],
+    } as unknown as BaseEntity;
+}
+
 const user = {} as UserInfo;
 const newRecordCtx = (): SaveContextLike => ({ IsNew: true, Fields: [], State: {} });
 
 describe('geocoding is suppressed per SAVE, not per entity', () => {
-    it('a normal save on a geo entity flags the geo sync', async () => {
+    it('a normal save on a writable-geo entity without coords flags the geo sync', async () => {
         const ctx = newRecordCtx();
-        await makeHost().OnBeforeSaveExecute(geoEntity, user, {} as EntitySaveOptions, ctx);
+        await makeHost().OnBeforeSaveExecute(geoEntity({}), user, {} as EntitySaveOptions, ctx);
         expect(ctx.State['geoSyncNeeded']).toBe(true);
     });
 
     it('the SAME save with SkipGeoCoding does not — entity flag untouched, other writers unaffected', async () => {
         const ctx = newRecordCtx();
-        await makeHost().OnBeforeSaveExecute(geoEntity, user, { SkipGeoCoding: true } as EntitySaveOptions, ctx);
+        await makeHost().OnBeforeSaveExecute(geoEntity({}), user, { SkipGeoCoding: true } as EntitySaveOptions, ctx);
+        expect(ctx.State['geoSyncNeeded']).toBeUndefined();
+    });
+
+    it('virtual-only Geo* (Person PrimaryAddress) never flags geo sync', async () => {
+        const ctx = newRecordCtx();
+        await makeHost().OnBeforeSaveExecute(geoEntity({ virtualOnly: true }), user, {} as EntitySaveOptions, ctx);
+        expect(ctx.State['geoSyncNeeded']).toBeUndefined();
+    });
+
+    it('native lat/lng already set does not call the provider', async () => {
+        const ctx = newRecordCtx();
+        await makeHost().OnBeforeSaveExecute(geoEntity({ lat: 38.2, lng: -122.6 }), user, {} as EntitySaveOptions, ctx);
         expect(ctx.State['geoSyncNeeded']).toBeUndefined();
     });
 });

--- a/packages/MJCore/src/__tests__/geoFields.test.ts
+++ b/packages/MJCore/src/__tests__/geoFields.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { EntityFieldInfo, EntityInfo } from '../generic/entityInfo';
+import {
+    ShouldJoinRecordGeoCodes,
+    EmbeddedGeoVirtualNames,
+    ListEmbeddedGeoSpecs,
+    ResolveMapLatitudeField,
+    EntityHasMapCoordinates,
+    HasNativeLatLngFields,
+} from '../generic/geoFields';
+
+function field(partial: Partial<EntityFieldInfo> & { Name: string }): EntityFieldInfo {
+    const f = new EntityFieldInfo();
+    Object.assign(f, {
+        IsVirtual: false,
+        AllowUpdateAPI: true,
+        AllowsNull: true,
+        ExtendedType: null,
+        ...partial,
+    });
+    return f;
+}
+
+function entity(name: string, fields: EntityFieldInfo[], supports = true): EntityInfo {
+    const e = new EntityInfo();
+    e.Name = name;
+    e.SupportsGeoCoding = supports;
+    (e as unknown as { _Fields: EntityFieldInfo[] })._Fields = fields;
+    // EntityInfo.Fields getter — set via Init if needed
+    Object.defineProperty(e, 'Fields', { get: () => fields, configurable: true });
+    return e;
+}
+
+describe('writable vs display Geo*', () => {
+    it('virtual PrimaryAddressLatitude is Geo but not writable', () => {
+        const f = field({ Name: 'PrimaryAddressLatitude', ExtendedType: 'GeoLatitude', IsVirtual: true, AllowUpdateAPI: false });
+        expect(f.IsGeoExtendedType).toBe(true);
+        expect(f.IsWritableGeoField).toBe(false);
+        expect(f.IsNativeLatitudeField).toBe(false);
+    });
+
+    it('Address.Latitude ExtendedType=Geo is native writable lat', () => {
+        const f = field({ Name: 'Latitude', ExtendedType: 'Geo', IsVirtual: false, AllowUpdateAPI: true });
+        expect(f.IsWritableGeoField).toBe(true);
+        expect(f.IsNativeLatitudeField).toBe(true);
+    });
+
+    it('HasWritableGeoSourceFields is false for Person-like entities', () => {
+        const e = entity('MJ_BizApps_Common: People', [
+            field({ Name: 'FirstName', ExtendedType: null }),
+            field({ Name: 'PrimaryAddressLatitude', ExtendedType: 'GeoLatitude', IsVirtual: true, AllowUpdateAPI: false }),
+            field({ Name: '__mj_Latitude', ExtendedType: 'GeoLatitude', IsVirtual: true, AllowUpdateAPI: false }),
+        ]);
+        expect(e.HasWritableGeoSourceFields).toBe(false);
+    });
+});
+
+describe('ShouldJoinRecordGeoCodes', () => {
+    it('is false for Person-like (no writable geo)', () => {
+        expect(ShouldJoinRecordGeoCodes(entity('People', [
+            field({ Name: 'PrimaryAddressLatitude', ExtendedType: 'GeoLatitude', IsVirtual: true, AllowUpdateAPI: false }),
+        ]))).toBe(false);
+    });
+
+    it('is false when native lat/lng exist', () => {
+        expect(ShouldJoinRecordGeoCodes(entity('Addresses', [
+            field({ Name: 'Latitude', ExtendedType: 'GeoLatitude' }),
+            field({ Name: 'Longitude', ExtendedType: 'GeoLongitude' }),
+            field({ Name: 'Line1', ExtendedType: 'GeoAddress' }),
+        ]))).toBe(false);
+        expect(HasNativeLatLngFields(entity('Addresses', [
+            field({ Name: 'Latitude', ExtendedType: 'GeoLatitude' }),
+            field({ Name: 'Longitude', ExtendedType: 'GeoLongitude' }),
+        ]).Fields)).toBe(true);
+    });
+
+    it('is true when writable street exists without native lat/lng', () => {
+        expect(ShouldJoinRecordGeoCodes(entity('Sites', [
+            field({ Name: 'Street', ExtendedType: 'GeoAddress' }),
+        ]))).toBe(true);
+    });
+});
+
+describe('embedded geo names', () => {
+    it('ShipToAddressID → __mj_Latitude_ShipToAddressID', () => {
+        expect(EmbeddedGeoVirtualNames('ShipToAddressID')).toEqual({
+            lat: '__mj_Latitude_ShipToAddressID',
+            lng: '__mj_Longitude_ShipToAddressID',
+        });
+    });
+
+    it('lists specs from EmbeddedRecord FKs', () => {
+        const specs = ListEmbeddedGeoSpecs([
+            field({
+                Name: 'ShipToAddressID',
+                EmbeddedRecord: '{}',
+                RelatedEntityID: 'addr-id',
+                RelatedEntity: 'MJ_BizApps_Common: Addresses',
+                RelatedEntitySchemaName: '__mj_BizAppsCommon',
+                RelatedEntityBaseTable: 'Address',
+            }),
+        ]);
+        expect(specs).toHaveLength(1);
+        expect(specs[0].lat).toBe('__mj_Latitude_ShipToAddressID');
+    });
+});
+
+describe('map field resolution', () => {
+    it('prefers PrimaryAddressLatitude over __mj_Latitude', () => {
+        const e = entity('People', [
+            field({ Name: '__mj_Latitude', ExtendedType: 'GeoLatitude', IsVirtual: true, AllowUpdateAPI: false }),
+            field({ Name: 'PrimaryAddressLatitude', ExtendedType: 'GeoLatitude', IsVirtual: true, AllowUpdateAPI: false }),
+        ]);
+        expect(ResolveMapLatitudeField(e)).toBe('PrimaryAddressLatitude');
+    });
+
+    it('prefers writable native over PrimaryAddress', () => {
+        const e = entity('Addresses', [
+            field({ Name: 'Latitude', ExtendedType: 'GeoLatitude' }),
+            field({ Name: 'PrimaryAddressLatitude', ExtendedType: 'GeoLatitude', IsVirtual: true, AllowUpdateAPI: false }),
+        ]);
+        expect(ResolveMapLatitudeField(e)).toBe('Latitude');
+    });
+
+    it('EntityHasMapCoordinates is true with only virtual GeoLatitude', () => {
+        const e = entity('People', [
+            field({ Name: 'PrimaryAddressLatitude', ExtendedType: 'GeoLatitude', IsVirtual: true, AllowUpdateAPI: false }),
+        ], false);
+        expect(EntityHasMapCoordinates(e)).toBe(true);
+    });
+});

--- a/packages/MJCore/src/generic/databaseProviderBase.ts
+++ b/packages/MJCore/src/generic/databaseProviderBase.ts
@@ -186,6 +186,32 @@ export abstract class DatabaseProviderBase extends ProviderBase {
         return this.CurrentTransactionDepth;
     }
 
+    /**
+     * Independent instance that **shares the connection pool and metadata cache**
+     * but has its own transaction stack. Same pattern MJAPI uses for per-request
+     * providers. Used by `mj sync push` so `--parallel-batch-size` (default 10)
+     * does not interleave `EntityTransactionScope`s on one provider.
+     *
+     * Not SQL Server-specific: each concrete provider implements this against
+     * its own pool. {@link ReleaseIndependentInstance} must NOT close the pool.
+     */
+    public async CreateIndependentInstance(): Promise<DatabaseProviderBase> {
+        throw new Error(`${this.constructor.name} does not implement CreateIndependentInstance`);
+    }
+
+    /**
+     * Drop this instance's transaction handle. Must not close the shared pool.
+     */
+    public async ReleaseIndependentInstance(): Promise<void> {
+        if (this.TransactionDepth > 0) {
+            try {
+                await this.RollbackTransaction();
+            } catch {
+                await this.ResetTransactionState();
+            }
+        }
+    }
+
     /** @deprecated Use {@link TransactionDepth}. */
     public get transactionDepth(): number {
         return this.TransactionDepth;

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -1499,6 +1499,42 @@ export class EntityFieldInfo extends BaseInfo {
     }
 
     /**
+     * True when {@link ExtendedType} is any Geo* tag (`Geo`, `GeoLatitude`, `GeoAddress`, …).
+     * Used by maps, distance, and GeoCodeSyncService. Display-only virtuals still count.
+     */
+    get IsGeoExtendedType(): boolean {
+        const t = this.ExtendedType;
+        return typeof t === 'string' && t.startsWith('Geo');
+    }
+
+    /**
+     * A Geo* field that can be written on Save. GeoCodeSyncService only runs when the
+     * entity has at least one of these. Virtual / AllowUpdateAPI=0 fields (PrimaryAddress*,
+     * `__mj_Latitude`, embedded `__mj_Latitude_{FK}`) are display-only — maps still use them.
+     */
+    get IsWritableGeoField(): boolean {
+        return this.IsGeoExtendedType && !this.IsVirtual && !!this.AllowUpdateAPI;
+    }
+
+    /**
+     * Native (table) latitude column — `ExtendedType=GeoLatitude`, or legacy `Geo` named Latitude.
+     */
+    get IsNativeLatitudeField(): boolean {
+        if (this.IsVirtual) return false;
+        if (this.ExtendedType === 'GeoLatitude') return true;
+        return this.ExtendedType === 'Geo' && /^lat(itude)?$/i.test(this.Name);
+    }
+
+    /**
+     * Native (table) longitude column — `ExtendedType=GeoLongitude`, or legacy `Geo` named Long*.
+     */
+    get IsNativeLongitudeField(): boolean {
+        if (this.IsVirtual) return false;
+        if (this.ExtendedType === 'GeoLongitude') return true;
+        return this.ExtendedType === 'Geo' && /^(lng|lon|long|longitude)$/i.test(this.Name);
+    }
+
+    /**
      * Helper method that returns true if the field is one of the special reserved MJ date fields for tracking CreatedAt and UpdatedAt timestamps as well as the DeletedAt timestamp used for entities that
      * have DeleteType=Soft. This is only used when the entity has TrackRecordChanges=1 or for entities where DeleteType=Soft
      */
@@ -2126,11 +2162,19 @@ export class EntityInfo extends BaseInfo {
      */
     FullTextSearchFunctionGenerated: boolean = true
     /**
-     * When true, this entity supports geocoding — CodeGen generates geo-aware subclass code,
-     * adds __mj_Latitude/__mj_Longitude virtual fields to the base view, and the UI shows
-     * a map view toggle. Auto-set by CodeGen when LLM detects geo-capable fields.
+     * When true, this entity participates in geo **read** features: map view, distance
+     * calculations, and similar. That is independent of whether GeoCodeSyncService runs
+     * on Save — the service only fires when {@link HasWritableGeoSourceFields} is true.
+     * Auto-set by CodeGen when LLM detects geo-capable fields.
      */
     SupportsGeoCoding: boolean = false
+    /**
+     * True when at least one field is a writable Geo* source (street and/or native lat/lng).
+     * Person/Org PrimaryAddress* are virtual display fields and do **not** count.
+     */
+    get HasWritableGeoSourceFields(): boolean {
+        return (this.Fields ?? []).some(f => f.IsWritableGeoField);
+    }
     /**
      * When true (default), CodeGen can automatically set SupportsGeoCoding based on
      * LLM analysis of entity fields. Set to false to lock the value.

--- a/packages/MJCore/src/generic/geoFields.ts
+++ b/packages/MJCore/src/generic/geoFields.ts
@@ -13,14 +13,20 @@
  */
 import { EntityFieldInfo, EntityInfo } from './entityInfo';
 
+/**
+ * True when the entity has a native (table) latitude **and** longitude column.
+ * Virtual `__mj_Latitude` / PrimaryAddress* do not count.
+ */
 export function HasNativeLatLngFields(fields: EntityFieldInfo[]): boolean {
     return fields.some(f => f.IsNativeLatitudeField) && fields.some(f => f.IsNativeLongitudeField);
 }
 
+/** First native latitude column, or undefined. */
 export function NativeLatitudeField(fields: EntityFieldInfo[]): EntityFieldInfo | undefined {
     return fields.find(f => f.IsNativeLatitudeField);
 }
 
+/** First native longitude column, or undefined. */
 export function NativeLongitudeField(fields: EntityFieldInfo[]): EntityFieldInfo | undefined {
     return fields.find(f => f.IsNativeLongitudeField);
 }
@@ -45,6 +51,7 @@ export function EmbeddedGeoVirtualNames(foreignKeyField: string): { lat: string;
     };
 }
 
+/** One EmbeddedRecord FK that should bubble lat/lng onto the parent view. */
 export type EmbeddedGeoSpec = {
     foreignKeyField: string;
     relatedEntityID: string;
@@ -57,6 +64,10 @@ export type EmbeddedGeoSpec = {
     allowsNull: boolean;
 };
 
+/**
+ * EmbeddedRecord foreign keys on `fields` that CodeGen should JOIN for
+ * `__mj_Latitude_{FK}` / `__mj_Longitude_{FK}` display columns.
+ */
 export function ListEmbeddedGeoSpecs(fields: EntityFieldInfo[]): EmbeddedGeoSpec[] {
     const out: EmbeddedGeoSpec[] = [];
     for (const f of fields) {
@@ -86,10 +97,16 @@ export function ResolveMapLatitudeField(entity: EntityInfo, override?: string | 
     return resolveCoordField(entity, override, '__mj_Latitude', 'PrimaryAddressLatitude', f => f.IsNativeLatitudeField || f.ExtendedType === 'GeoLatitude' || (f.ExtendedType === 'Geo' && /^lat/i.test(f.Name)));
 }
 
+/** Same resolution order as {@link ResolveMapLatitudeField} for longitude. */
 export function ResolveMapLongitudeField(entity: EntityInfo, override?: string | null): string {
     return resolveCoordField(entity, override, '__mj_Longitude', 'PrimaryAddressLongitude', f => f.IsNativeLongitudeField || f.ExtendedType === 'GeoLongitude' || (f.ExtendedType === 'Geo' && /^(lng|lon|long)/i.test(f.Name)));
 }
 
+/**
+ * Shared lat/lng picker. `override` wins when it is not the MJ default name;
+ * otherwise prefers writable native, then PrimaryAddress*, then `__mj_*_{FK}`,
+ * then `__mj_*`, then any matching Geo* field.
+ */
 function resolveCoordField(
     entity: EntityInfo,
     override: string | null | undefined,

--- a/packages/MJCore/src/generic/geoFields.ts
+++ b/packages/MJCore/src/generic/geoFields.ts
@@ -1,0 +1,124 @@
+/**
+ * Geo field helpers shared by GeoCodeSyncService (write), maps/distance (read),
+ * and CodeGen (view SQL).
+ *
+ * **Write vs read:** `SupportsGeoCoding` means the entity can show a map and
+ * participate in geo calcs. GeoCodeSyncService only runs when there is at least
+ * one **writable** Geo* field. Virtual display fields (PrimaryAddressLatitude,
+ * `__mj_Latitude`, `__mj_Latitude_{FK}`) never invoke the provider.
+ *
+ * **Anti-patterns:** do not author RecordGeoCode JSON + SHA to skip import
+ * geocoding; do not treat Person/Org primary address as EmbeddedRecord (that is
+ * AddressLink + layered view → PrimaryAddressLatitude).
+ */
+import { EntityFieldInfo, EntityInfo } from './entityInfo';
+
+export function HasNativeLatLngFields(fields: EntityFieldInfo[]): boolean {
+    return fields.some(f => f.IsNativeLatitudeField) && fields.some(f => f.IsNativeLongitudeField);
+}
+
+export function NativeLatitudeField(fields: EntityFieldInfo[]): EntityFieldInfo | undefined {
+    return fields.find(f => f.IsNativeLatitudeField);
+}
+
+export function NativeLongitudeField(fields: EntityFieldInfo[]): EntityFieldInfo | undefined {
+    return fields.find(f => f.IsNativeLongitudeField);
+}
+
+/**
+ * RecordGeoCode JOIN belongs on entities that are geo **sources** without native
+ * lat/lng columns. Display-only entities (Person/Org with virtual PrimaryAddress*)
+ * must not join vwRecordGeoCodes on their own ID.
+ */
+export function ShouldJoinRecordGeoCodes(entity: Pick<EntityInfo, 'SupportsGeoCoding' | 'Name'> & { Fields: EntityFieldInfo[] }): boolean {
+    if (!entity.SupportsGeoCoding) return false;
+    if (entity.Name.trim().toLowerCase() === 'mj: record geo codes') return false;
+    if (HasNativeLatLngFields(entity.Fields)) return false;
+    return entity.Fields.some(f => f.IsWritableGeoField);
+}
+
+/** Embedded bubble virtuals: `__mj_Latitude_ShipToAddressID`. */
+export function EmbeddedGeoVirtualNames(foreignKeyField: string): { lat: string; lng: string } {
+    return {
+        lat: `__mj_Latitude_${foreignKeyField}`,
+        lng: `__mj_Longitude_${foreignKeyField}`,
+    };
+}
+
+export type EmbeddedGeoSpec = {
+    foreignKeyField: string;
+    relatedEntityID: string;
+    relatedEntityName: string | null;
+    relatedSchemaName: string | null;
+    relatedBaseTable: string | null;
+    relatedBaseView: string | null;
+    lat: string;
+    lng: string;
+    allowsNull: boolean;
+};
+
+export function ListEmbeddedGeoSpecs(fields: EntityFieldInfo[]): EmbeddedGeoSpec[] {
+    const out: EmbeddedGeoSpec[] = [];
+    for (const f of fields) {
+        if (!f.EmbeddedRecord || !f.RelatedEntityID) continue;
+        const names = EmbeddedGeoVirtualNames(f.Name);
+        out.push({
+            foreignKeyField: f.Name,
+            relatedEntityID: f.RelatedEntityID,
+            relatedEntityName: f.RelatedEntity ?? null,
+            relatedSchemaName: f.RelatedEntitySchemaName ?? null,
+            relatedBaseTable: f.RelatedEntityBaseTable ?? null,
+            relatedBaseView: f.RelatedEntityBaseView ?? null,
+            lat: names.lat,
+            lng: names.lng,
+            allowsNull: !!f.AllowsNull,
+        });
+    }
+    return out;
+}
+
+/**
+ * Map / distance lat field. Override wins; otherwise:
+ * writable native → PrimaryAddressLatitude → `__mj_Latitude_{FK}` → `__mj_Latitude`
+ * → first GeoLatitude / Geo-named Latitude.
+ */
+export function ResolveMapLatitudeField(entity: EntityInfo, override?: string | null): string {
+    return resolveCoordField(entity, override, '__mj_Latitude', 'PrimaryAddressLatitude', f => f.IsNativeLatitudeField || f.ExtendedType === 'GeoLatitude' || (f.ExtendedType === 'Geo' && /^lat/i.test(f.Name)));
+}
+
+export function ResolveMapLongitudeField(entity: EntityInfo, override?: string | null): string {
+    return resolveCoordField(entity, override, '__mj_Longitude', 'PrimaryAddressLongitude', f => f.IsNativeLongitudeField || f.ExtendedType === 'GeoLongitude' || (f.ExtendedType === 'Geo' && /^(lng|lon|long)/i.test(f.Name)));
+}
+
+function resolveCoordField(
+    entity: EntityInfo,
+    override: string | null | undefined,
+    mjDefault: string,
+    primaryAddress: string,
+    isCoord: (f: EntityFieldInfo) => boolean,
+): string {
+    if (override && override !== mjDefault) return override;
+    const fields = entity.Fields ?? [];
+    const writable = fields.find(f => isCoord(f) && f.IsWritableGeoField);
+    if (writable) return writable.Name;
+    const primary = fields.find(f => f.Name === primaryAddress && isCoord(f));
+    if (primary) return primary.Name;
+    const embedded = fields.find(f => f.Name.startsWith(mjDefault + '_') && isCoord(f));
+    if (embedded) return embedded.Name;
+    const mj = fields.find(f => f.Name === mjDefault);
+    if (mj) return mj.Name;
+    const tagged = fields.find(isCoord);
+    if (tagged) return tagged.Name;
+    return mjDefault;
+}
+
+/** Map toggle: SupportsGeoCoding OR any coordinate Geo* field (including virtual display). */
+export function EntityHasMapCoordinates(entity: EntityInfo): boolean {
+    if (entity.SupportsGeoCoding) return true;
+    return (entity.Fields ?? []).some(f =>
+        f.ExtendedType === 'GeoLatitude' ||
+        f.ExtendedType === 'GeoLongitude' ||
+        f.IsNativeLatitudeField ||
+        f.IsNativeLongitudeField
+    );
+}

--- a/packages/MJCore/src/index.ts
+++ b/packages/MJCore/src/index.ts
@@ -26,6 +26,7 @@ export * from "./generic/providerBase";
 export * from "./generic/baseRemotableOperation";
 export * from "./generic/remoteOperationDispatch";
 export * from "./generic/entityInfo";
+export * from "./generic/geoFields";
 export * from "./generic/extendedTypeValue";
 export * from "./generic/entityConfiguration";
 export * from "./generic/externalDataSourceTypes";

--- a/packages/MetadataSync/README.md
+++ b/packages/MetadataSync/README.md
@@ -1349,9 +1349,16 @@ The pull command supports smart update capabilities with extensive configuration
     },
     "ignoreNullFields": false,
     "ignoreVirtualFields": false
+  },
+  "push": {
+    "skipGeoCoding": true
   }
 }
 ```
+
+`push.skipGeoCoding` maps to `EntitySaveOptions.SkipGeoCoding` for this entity only. Use it on display-only geo entities (People/Organizations whose coords are virtual `PrimaryAddressLatitude`). Do **not** use a global CLI `--skip-geocode` as the only control. Addresses with native lat/lng already set do not call the provider even without this flag.
+
+Parallel `--parallel-batch-size` defaults to **10**. Each record is saved on `CreateIndependentInstance()` (shared pool, own transaction stack), the same pattern MJAPI uses per request. Durable AfterCreate actions without a queue submitter fire after that instance's transaction depth is 0 — they must not nest in the caller's `EntityTransactionScope`.
 
 ### Pull Configuration Options
 
@@ -1522,10 +1529,10 @@ Records are automatically grouped into dependency levels:
 - **Level 1**: Records that depend only on Level 0 records
 - **Level 2**: Records that depend on Level 0 or Level 1 records
 
-Records within the same dependency level can be safely processed in parallel.
+Records within the same dependency level are processed in parallel. Each record uses `CreateIndependentInstance()` so nested `EntityTransactionScope`s cannot interleave on one provider. Default batch size is **10** (do not default to 1 to paper over a shared provider).
 
 ```bash
-# Default processing
+# Default processing (batch size 10, isolated providers)
 mj sync push
 
 # Process 20 records in parallel

--- a/packages/MetadataSync/src/__tests__/skip-geocoding-config.test.ts
+++ b/packages/MetadataSync/src/__tests__/skip-geocoding-config.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import type { EntityConfig } from '../config';
+
+describe('EntityConfig.push.skipGeoCoding', () => {
+    it('is a per-entity push option, not a global CLI flag', () => {
+        const cfg: EntityConfig = {
+            entity: 'MJ_BizApps_Common: People',
+            filePattern: '**/.*.json',
+            push: { skipGeoCoding: true },
+        };
+        expect(cfg.push?.skipGeoCoding).toBe(true);
+    });
+});

--- a/packages/MetadataSync/src/config.ts
+++ b/packages/MetadataSync/src/config.ts
@@ -292,11 +292,16 @@ export interface EntityConfig {
     ignoreVirtualFields?: boolean;
   };
   /**
-   * Push-specific options. `skipGeoCoding` maps to `EntitySaveOptions.SkipGeoCoding`
-   * so sample data with pre-filled lat/lng (or display-only geo entities) does not
-   * call the geocoding provider. Per-entity, not a global CLI kill switch.
+   * Push-specific options for this entity directory. Applied only on `mj sync push`
+   * (not pull). Add new per-save / per-entity push knobs here rather than as global
+   * CLI flags so each entity can opt in independently.
    */
   push?: {
+    /**
+     * Maps to `EntitySaveOptions.SkipGeoCoding` so sample data with pre-filled
+     * lat/lng (or display-only geo entities) does not call the geocoding provider.
+     * Per-entity, not a global CLI kill switch.
+     */
     skipGeoCoding?: boolean;
   };
   /**

--- a/packages/MetadataSync/src/config.ts
+++ b/packages/MetadataSync/src/config.ts
@@ -292,6 +292,14 @@ export interface EntityConfig {
     ignoreVirtualFields?: boolean;
   };
   /**
+   * Push-specific options. `skipGeoCoding` maps to `EntitySaveOptions.SkipGeoCoding`
+   * so sample data with pre-filled lat/lng (or display-only geo entities) does not
+   * call the geocoding provider. Per-entity, not a global CLI kill switch.
+   */
+  push?: {
+    skipGeoCoding?: boolean;
+  };
+  /**
    * Whether to emit __mj_sync_notes in record files during push operations.
    * When enabled, resolution information for @lookup and @parent references is written to files.
    * If not specified, inherits from root .mj-sync.json. Defaults to false if not set anywhere.

--- a/packages/MetadataSync/src/services/PushService.ts
+++ b/packages/MetadataSync/src/services/PushService.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import fastGlob from 'fast-glob';
 import chalk from 'chalk';
-import { BaseEntity, Metadata, UserInfo, EntitySaveOptions, IsVerboseLoggingEnabled } from '@memberjunction/core';
+import { BaseEntity, Metadata, UserInfo, EntitySaveOptions, IsVerboseLoggingEnabled, DatabaseProviderBase, IMetadataProvider } from '@memberjunction/core';
 import { UUIDsEqual } from '@memberjunction/global';
 import { IsStringSQLType } from '@memberjunction/sql-dialect';
 import { SyncEngine, RecordData, DeferrableLookupError, SyncResolutionCollector, BatchContext } from '../lib/sync-engine';
@@ -23,14 +23,10 @@ import { DeletionReportGenerator } from '../lib/deletion-report-generator';
 import { SyncStateManager } from '../lib/sync-state-manager';
 import type { GenericDatabaseProvider, SqlLoggingSession } from '@memberjunction/generic-database-provider';
 
-// Configuration for parallel processing.
-// The side-effect-as-data pattern (processFlattenedRecord returns mutations instead of
-// mutating shared state) makes parallel execution safe from a sync-engine perspective.
-// However, entity Save() overrides (e.g., MJActionEntityServer, MJAIPromptEntityServer)
-// may start transactions, do check-then-create patterns, or interact with shared singletons
-// that assume sequential execution. Default stays at 1 for safety; users can opt in to
-// higher values via --parallel-batch-size after verifying their entity subclasses are safe.
-const PARALLEL_BATCH_SIZE = 1;
+// Parallelism is safe when each record gets its own provider instance (shared pool,
+// own transaction stack) — the same pattern MJAPI uses per request. Default 10.
+// Do NOT default to 1 to paper over a shared provider.
+const PARALLEL_BATCH_SIZE = 10;
 
 export interface PushOptions {
   dir?: string;
@@ -795,7 +791,7 @@ export class PushService {
               const batchResults = await Promise.all(
                 batch.map(async (flattenedRecord) => {
                   try {
-                    const result = await this.processFlattenedRecord(
+                    const result = await this.processFlattenedRecordOnIndependentProvider(
                       flattenedRecord,
                       entityDir,
                       options,
@@ -962,7 +958,11 @@ export class PushService {
     return { created, updated, unchanged, deleted, skipped, deferred, errors };
   }
 
-  private async processFlattenedRecord(
+  /**
+   * Run one record on a forked provider (shared pool, own TX stack) so parallel
+   * Saves cannot interleave EntityTransactionScope on the CLI's singleton provider.
+   */
+  private async processFlattenedRecordOnIndependentProvider(
     flattenedRecord: FlattenedRecord,
     entityDir: string,
     options: PushOptions,
@@ -970,6 +970,33 @@ export class PushService {
     callbacks?: PushCallbacks,
     entityConfig?: EntityConfig,
     allowDefer: boolean = true
+  ): Promise<ProcessRecordResult> {
+    const host = Metadata.Provider as unknown as DatabaseProviderBase;
+    let scoped: DatabaseProviderBase | undefined;
+    try {
+      scoped = await host.CreateIndependentInstance();
+    } catch (e) {
+      callbacks?.onLog?.(
+        `⚠️  CreateIndependentInstance unavailable (${(e as Error).message}); this record uses the shared provider`
+      );
+      return this.processFlattenedRecord(flattenedRecord, entityDir, options, batchContext, callbacks, entityConfig, allowDefer);
+    }
+    try {
+      return await this.processFlattenedRecord(flattenedRecord, entityDir, options, batchContext, callbacks, entityConfig, allowDefer, scoped);
+    } finally {
+      await scoped.ReleaseIndependentInstance();
+    }
+  }
+
+  private async processFlattenedRecord(
+    flattenedRecord: FlattenedRecord,
+    entityDir: string,
+    options: PushOptions,
+    batchContext: BatchContext,
+    callbacks?: PushCallbacks,
+    entityConfig?: EntityConfig,
+    allowDefer: boolean = true,
+    recordProvider?: IMetadataProvider
   ): Promise<ProcessRecordResult> {
     const metadata = new Metadata(); // global-provider-ok: metadata sync operates on the configured provider only
     const { record, entityName, parentContext, id: recordId } = flattenedRecord;
@@ -1031,7 +1058,9 @@ export class PushService {
     }
 
     // Get or create entity instance
-    entity = await metadata.GetEntityObject(entityName, this.contextUser);
+    entity = recordProvider
+      ? await recordProvider.GetEntityObject(entityName, this.contextUser)
+      : await metadata.GetEntityObject(entityName, this.contextUser);
     if (!entity) {
       throw new Error(`Failed to create entity object for ${entityName}`);
     }
@@ -1372,8 +1401,9 @@ export class PushService {
       // Skip embedding generation during sync — vectors can be computed later by the
       // API server. This avoids loading the ~50MB Xenova model in short-lived CLI processes.
       entity.SkipEmbeddings = true;
-      // Pass IgnoreDirtyState option when alwaysPush is enabled
-      const saveOptions = alwaysPush ? { IgnoreDirtyState: true } : undefined;
+      const saveOptions = new EntitySaveOptions();
+      if (alwaysPush) saveOptions.IgnoreDirtyState = true;
+      if (entityConfig?.push?.skipGeoCoding) saveOptions.SkipGeoCoding = true;
       saveResult = await entity.Save(saveOptions);
     } catch (saveError: any) {
       // Helper to log to both console and callbacks

--- a/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
+++ b/packages/PostgreSQLDataProvider/src/PostgreSQLDataProvider.ts
@@ -237,6 +237,28 @@ export class PostgreSQLDataProvider extends GenericDatabaseProvider implements I
         return this._schemaName;
     }
 
+    /**
+     * Share this instance's pool + metadata; own transaction stack.
+     * Used by mj sync push parallelism (MJAPI per-request pattern).
+     */
+    public override async CreateIndependentInstance(): Promise<PostgreSQLDataProvider> {
+        const child = new PostgreSQLDataProvider();
+        const parent = this._configData;
+        if (!parent) {
+            throw new Error('PostgreSQLDataProvider.CreateIndependentInstance: provider is not configured');
+        }
+        const cfg = new PostgreSQLProviderConfigData(
+            parent.ConnectionConfig,
+            this.MJCoreSchemaName,
+            0,
+            parent.IncludeSchemas,
+            parent.ExcludeSchemas,
+            false,
+        );
+        await child.ConfigWithSharedPool(cfg, this.DatabaseConnection);
+        return child;
+    }
+
     protected get Metadata(): IMetadataProvider {
         return this as unknown as IMetadataProvider;
     }

--- a/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
+++ b/packages/SQLServerDataProvider/src/SQLServerDataProvider.ts
@@ -430,6 +430,25 @@ export class SQLServerDataProvider
   }
 
   /**
+   * Share this instance's pool + metadata; own transaction stack.
+   * Used by mj sync push parallelism (MJAPI per-request pattern).
+   */
+  public override async CreateIndependentInstance(): Promise<SQLServerDataProvider> {
+    const child = new SQLServerDataProvider();
+    const parent = this.ConfigData;
+    const cfg = new SQLServerProviderConfigData(
+      this._pool,
+      parent.MJCoreSchemaName,
+      0,
+      parent.IncludeSchemas,
+      parent.ExcludeSchemas,
+      false,
+    );
+    await child.Config(cfg, this);
+    return child;
+  }
+
+  /**
    * Configures the SQL Server data provider with connection settings and initializes the connection pool
    * 
    * @param configData - Configuration data including connection string and options

--- a/packages/geo/geo-core/src/__tests__/google-geocode.integration.test.ts
+++ b/packages/geo/geo-core/src/__tests__/google-geocode.integration.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Live Google Geocoding API. Skips (warn, not fail) when GOOGLE_GEOCODING_API_KEY
+ * is unset. Loads MJ/.env if present without printing secrets.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { GoogleGeocodingProvider } from '../providers/GoogleGeocodingProvider';
+
+function readKeyFromMjEnv(): string | undefined {
+    if (process.env.GOOGLE_GEOCODING_API_KEY?.trim()) {
+        return process.env.GOOGLE_GEOCODING_API_KEY.trim();
+    }
+    const mjEnv = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../.env');
+    if (!fs.existsSync(mjEnv)) return undefined;
+    const text = fs.readFileSync(mjEnv, 'utf8');
+    const m = text.match(/^GOOGLE_GEOCODING_API_KEY\s*=\s*['"]?([^'"\n]+)['"]?/m);
+    return m?.[1]?.trim();
+}
+
+const apiKey = readKeyFromMjEnv();
+if (!apiKey) {
+    console.warn('GOOGLE_GEOCODING_API_KEY not set — skipping live Google geocode integration test');
+}
+
+const describeLive = apiKey ? describe : describe.skip;
+
+describeLive('Google Geocoding API (live)', () => {
+    it('geocodes a well-known address', async () => {
+        process.env.GOOGLE_GEOCODING_API_KEY = apiKey;
+        const provider = new GoogleGeocodingProvider();
+        expect(provider.IsConfigured()).toBe(true);
+        const result = await provider.Geocode({ AddressString: '1600 Amphitheatre Parkway, Mountain View, CA' });
+        expect(result).not.toBeNull();
+        expect(result!.Latitude).toBeGreaterThan(37);
+        expect(result!.Latitude).toBeLessThan(38);
+        expect(result!.Longitude).toBeLessThan(-121);
+        expect(result!.Longitude).toBeGreaterThan(-123);
+    }, 20_000);
+});

--- a/plans/geo-features/geo-features.md
+++ b/plans/geo-features/geo-features.md
@@ -171,10 +171,11 @@ AutoUpdateSupportsGeoCoding   BIT   DEFAULT 1
 - Entity with only `Name`, `Description`, `Status` fields → CodeGen leaves `SupportsGeoCoding = 0`
 
 When `SupportsGeoCoding = 1`:
-- CodeGen generates geo-aware subclass code for this entity (GeoFieldMappings + AfterSave hook)
-- CodeGen adds `__mj_Latitude` and `__mj_Longitude` virtual fields to the base view
-- UI shows map view toggle in EntityViewer
-- Scheduled geocoding job includes this entity
+- **Read side:** map view, distance, and similar. Virtual Geo\* fields (e.g. `PrimaryAddressLatitude`, `__mj_Latitude_{FK}`) count. Entity-viewer / map resolve lat/lng in this order: writable native → `PrimaryAddressLatitude` → `__mj_Latitude_{FK}` → `__mj_Latitude`.
+- **Write side (GeoCodeSyncService):** only if the entity has **1+ writable** (`!IsVirtual && AllowUpdateAPI`) Geo\* fields. Person/Org PrimaryAddress\* are virtual — the service never runs. Native lat/lng already populated → do not call the provider (sample data / pasted coords).
+- CodeGen joins `vwRecordGeoCodes` only for write-source entities **without** native lat/lng. Address stores coords on the row (`Latitude`/`Longitude` tagged `GeoLatitude`/`GeoLongitude`).
+- EmbeddedRecord FKs (e.g. `ShipToAddressID`) bubble as `__mj_Latitude_ShipToAddressID` (display only).
+- **Anti-patterns:** hand-authored `RecordGeoCode` JSON + SHA to skip import geocoding; treating Person/Org primary address as `EmbeddedRecord` (that is AddressLink + layered view); global CLI `--skip-geocode` as the only control (use per-entity `push.skipGeoCoding` in `.mj-sync.json`).
 
 #### Virtual Fields in Base View (CodeGen-Generated)
 


### PR DESCRIPTION
## Summary

`SupportsGeoCoding` means **maps, distance, and other geo read features**. `GeoCodeSyncService` is a separate **write** path: it only runs when the entity has **1+ writable** (`!IsVirtual && AllowUpdateAPI`) Geo* fields. Virtual `PrimaryAddressLatitude` / `__mj_Latitude` / `__mj_Latitude_{FK}` never invoke the provider.

- Native lat/lng already set (sample data, pasted coords) → do not call the geocoding API.
- CodeGen joins `vwRecordGeoCodes` only for write-source entities without native lat/lng.
- EmbeddedRecord FKs bubble as `__mj_Latitude_{ForeignKeyField}` (e.g. `__mj_Latitude_ShipToAddressID`).
- Map field order: writable native → `PrimaryAddressLatitude` → `__mj_Latitude_{FK}` → `__mj_Latitude`.
- `mj-sync` `.mj-sync.json` `push.skipGeoCoding` is **per entity**.
- Parallel default stays **10**. Each record uses `CreateIndependentInstance()` (shared pool, own TX) — same pattern as MJAPI per-request providers. SQL Server and PostgreSQL both implement it. `ReleaseIndependentInstance()` does not close the pool.
- Durable AfterCreate without a queue submitter **defers until `TransactionDepth === 0`** (fire-and-forget). It must not nest in the caller’s `EntityTransactionScope`.

### Stack

- MJ: https://github.com/MemberJunction/MJ/pull/4278
- Common: https://github.com/MemberJunction/bizapps-common/pull/131
- Cheese: https://github.com/MemberJunction/more-cheese/pull/33

### Anti-patterns we are **not** doing (and why)

| Anti-pattern | Why it is wrong |
|---|---|
| Hand-authored `RecordGeoCode` JSON + SHA in sample data | Hash is an internal dirty check, not an import contract. Person should not own a geo row; Address stores lat/lng. |
| Global CLI `--skip-geocode` as the only control | Display vs source differs per entity. Use `push.skipGeoCoding` on People/Org; Addresses with coords already skip the API. |
| Treating Person/Org primary address as `EmbeddedRecord` | That API is owner-held FK (`Order.ShipToAddressID`). Person uses AddressLink + layered view → `PrimaryAddressLatitude`. |
| Default `--parallel-batch-size 1` | Penalizes every push. The bug was one shared provider; fork the provider instead. |

## Test plan

- [x] MJCore `geoFields.test.ts` (11)
- [x] GenericDatabaseProvider `skip-side-effects.test.ts` (writable / virtual / coords-set / SkipGeoCoding)
- [x] MetadataSync `skip-geocoding-config.test.ts`
- [x] Actions Durable AfterCreate → `DEFERRED_LOCAL`
- [x] Live Google geocode IT (`GOOGLE_GEOCODING_API_KEY` in MJ `.env`; warns and skips if missing)
- [x] `tsc --noEmit` on CodeGen, SQL Server, PG, MetadataSync, Actions, map-view, entity-viewer

## Docs

- `plans/geo-features/geo-features.md`
- `packages/MetadataSync/README.md`
- `guides/TRANSACTIONS_AND_BATCHING_GUIDE.md`