### PR TITLE
fix(codegen): Open App CodeGen_Run SQL goes to app migrations/codegen

### DIFF
--- a/.changeset/codegen-sqloutput-open-app.md
+++ b/.changeset/codegen-sqloutput-open-app.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/codegen-lib": patch
+"@memberjunction/cli": patch
+---
+
+Open App CodeGen writes `CodeGen_Run_*.sql` (EntityField INSERTs) to the app's `migrations/codegen` when cwd has `mj-app.json`. Running from the MJ repo with `includeSchemas` set to an app schema fails instead of dumping metadata SQL into `MJ/migrations/v*`. If SQLOutput is enabled but no log file is open, metadata SQL is not applied. `--sql-output-dir` overrides the folder.

--- a/packages/CodeGenLib/README.md
+++ b/packages/CodeGenLib/README.md
@@ -636,6 +636,26 @@ CodeGen reporting success.
 **MJ core uses this itself.** `MJ: Version Installations` and `MJ: User View Run Details` are layered
 as of v6.1, and the remaining fully-custom core entities are expected to follow.
 
+**One CodeGen pass.** Apply the hand-authored overlay (it selects `g.*` from the inner generated
+view plus extra columns), `mj sync push` any Entity pins (e.g. `SupportsGeoCoding`), then run
+`mj codegen --skipfiles` **once from the Open App cwd**. Pass 1 discovers overlay columns from
+`BaseView` (`vwSQLColumnsAndEntityFields`) and logs EntityField INSERTs; Pass 2 writes only the
+**inner** view (`GeneratedBaseViewName`) and never DROPs the overlay. A second CodeGen run is not
+required for overlay columns and is how duplicate `__mj_Latitude` / missing SPs happen.
+
+### Open App metadata SQL (`CodeGen_Run_*.sql`)
+
+EntityField INSERTs are **not** in `SQL Scripts/generated/` (that tree is views/SPs). They go to
+`SQLOutput` as `CodeGen_Run_<utc>.sql`.
+
+- Run `mj codegen` from the **Open App cwd** (`mj-app.json`). SQLOutput defaults to
+  `./migrations/codegen`. Do not run it from the MJ repo with `includeSchemas` pointing at an
+  app — that used to dump EntityField SQL into `MJ/migrations/v5`.
+- `--sql-output-dir` overrides the folder. Pointing it at `MJ/migrations/v*` from an app fails.
+- If `SQLOutput.enabled` and no log file is open, CodeGen **refuses to apply** metadata SQL.
+  Fold the `CodeGen_Run` file into the app V migration; never transcribe EntityField rows from
+  the live DB. ExtendedType pins stay in `metadata/entities` (`mj sync push`).
+
 ### The two paths, side by side
 
 The thing to hold onto: **`BaseView` is always the public surface**, and the only question is who

--- a/packages/CodeGenLib/src/Database/sql_codegen.ts
+++ b/packages/CodeGenLib/src/Database/sql_codegen.ts
@@ -803,6 +803,8 @@ export class SQLCodeGenBase {
         // BaseView while CodeGen keeps writing the inner view underneath it. Gating on
         // BaseViewGenerated alone would skip the inner view and leave the custom layer selecting
         // from an object that does not exist.
+        // One pass: overlay already applied → Pass 1 sees extra BaseView columns and logs
+        // EntityField INSERTs; Pass 2 DROPs/creates only GeneratedViewName, never the overlay.
         const generatesView = (entity.BaseViewGenerated || entity.HasLayeredBaseView) && !entity.VirtualEntity;
 
         const tvfSQL = generatesView ? this.generateRecursiveFKTVFs(entity) : '';

--- a/packages/CodeGenLib/src/Misc/sql_logging.ts
+++ b/packages/CodeGenLib/src/Misc/sql_logging.ts
@@ -1,8 +1,79 @@
 import { CodeGenConnection } from '../Database/codeGenDatabaseProvider';
-import { configInfo, mj_core_schema, SQLOutputConfig, dbPlatform } from "../Config/config";
+import { configInfo, mj_core_schema, SQLOutputConfig, dbPlatform, currentWorkingDirectory } from "../Config/config";
 import { logError, logStatus } from "./status_logging";
 import * as fs from 'fs';
 import path from 'path';
+
+const MJ_DEFAULT_SQL_OUTPUT_RE = /(^|\/|\\)migrations[/\\]v\d+[/\\]?$/i;
+
+/**
+ * True when `folderPath` is the CodeGenLib / MJ-host default (`./migrations/v5` etc.),
+ * not an Open App `migrations/codegen` tree.
+ */
+export function isMjDefaultSqlOutputPath(folderPath: string): boolean {
+    const n = folderPath.replace(/\\/g, '/').replace(/\/+$/, '');
+    return MJ_DEFAULT_SQL_OUTPUT_RE.test(n) || n === './migrations/v5' || n === '../../migrations/v5';
+}
+
+export type ResolveSQLOutputFolderArgs = {
+    cwd: string;
+    configuredFolderPath?: string;
+    includeSchemas?: string[];
+    coreSchema: string;
+    /** CLI `--sql-output-dir`. Wins over config when set. */
+    sqlOutputDirFlag?: string;
+    hasMjAppJson: boolean;
+    isMjMonorepo: boolean;
+};
+
+/**
+ * Where CodeGen writes `CodeGen_Run_*.sql` (EntityField INSERTs and other metadata SQL).
+ *
+ * Open App (`mj-app.json` in cwd): always `{cwd}/migrations/codegen` unless
+ * `--sql-output-dir` or an explicit non-MJ `SQLOutput.folderPath` is set.
+ * Never fall back to `MJ/migrations/v*` — that silently dropped Open App
+ * EntityField SQL into the host tree.
+ *
+ * MJ monorepo cwd + `includeSchemas` listing a non-core schema: throw. Run
+ * CodeGen from the app directory.
+ */
+export function resolveSQLOutputFolder(args: ResolveSQLOutputFolderArgs): string {
+    const cwd = path.resolve(args.cwd);
+    const core = (args.coreSchema || '__mj').toLowerCase();
+    const include = (args.includeSchemas ?? []).map(s => s.toLowerCase());
+    const generatingAppSchemas = include.some(s => s !== core);
+
+    if (args.sqlOutputDirFlag) {
+        const resolved = path.resolve(cwd, args.sqlOutputDirFlag);
+        if (args.hasMjAppJson && isMjDefaultSqlOutputPath(resolved)) {
+            throw new Error(
+                `CodeGen --sql-output-dir resolves to an MJ host migrations tree (${resolved}). ` +
+                `Open App metadata SQL must go to the app's migrations/codegen. ` +
+                `Run from the app cwd (mj-app.json) without this flag, or pass the app codegen folder.`
+            );
+        }
+        return resolved;
+    }
+
+    if (args.hasMjAppJson) {
+        const configured = args.configuredFolderPath;
+        if (configured && !isMjDefaultSqlOutputPath(configured)) {
+            return path.resolve(cwd, configured);
+        }
+        return path.join(cwd, 'migrations', 'codegen');
+    }
+
+    if (args.isMjMonorepo && generatingAppSchemas) {
+        throw new Error(
+            `CodeGen SQLOutput would write Open App metadata SQL into the MJ repo (${cwd}). ` +
+            `Run \`mj codegen\` from the Open App directory (a cwd that contains mj-app.json), not from MJ. ` +
+            `includeSchemas=${(args.includeSchemas ?? []).join(',') || '(empty)'}`
+        );
+    }
+
+    const folder = args.configuredFolderPath ?? './migrations/v5/';
+    return path.resolve(cwd, folder);
+}
 
 /**
  * Utility class for logging SQL to a run file that can be fresh for each run or appended to depending on the settings in the configuration
@@ -10,6 +81,8 @@ import path from 'path';
 export class SQLLogging {
     private static _SQLLoggingFilePath: string = '';
     private static _OmitRecurringScriptsFromLog: boolean = false;
+    /** CLI `--sql-output-dir`. Set before {@link initSQLLogging}. */
+    public static sqlOutputDirFlag: string | undefined;
 
     public static get SQLLoggingFilePath(): string {
         return SQLLogging._SQLLoggingFilePath;
@@ -69,45 +142,52 @@ export class SQLLogging {
     public static initSQLLogging() {
         SQLLogging._OmitRecurringScriptsFromLog = configInfo.SQLOutput.omitRecurringScriptsFromLog;
         if (!SQLLogging.SQLLoggingFilePath) {
-            // not already set up, so proceed, otherwise we do nothing as we're already good to go
             const config = configInfo.SQLOutput;
             if(!config){
-                logError("MetadataLoggingConfig is required to enable metadata logging");
-                return;
+                throw new Error("SQLOutput config is required to enable metadata logging");
             }
 
             if (!config.enabled)
-                return; // we are not doing anything here....
-
-            if (config.folderPath) {
-                // On PostgreSQL, redirect the migrations root so CodeGen audit SQL lands in
-                // migrations-pg/ alongside the rest of the PG tooling.
-                let folderPath = config.folderPath;
-                if (dbPlatform() === 'postgresql') {
-                    folderPath = SQLLogging.redirectToPGMigrations(folderPath);
-                }
-
-                const dirExists: boolean = fs.existsSync(folderPath);
-                if (!dirExists) {
-                    fs.mkdirSync(folderPath, {recursive: true });
-                }
-
-                const fileName: string = config.fileName || this.createFileName();
-                SQLLogging._SQLLoggingFilePath = path.join(folderPath, fileName);
-
-                if (!config.appendToFile || !fs.existsSync(SQLLogging.SQLLoggingFilePath)) {
-                    //create an empty file
-                    fs.writeFileSync(SQLLogging.SQLLoggingFilePath, '');
-                }
-
-                logStatus(`Metadata logging enabled. File path: ${SQLLogging.SQLLoggingFilePath}`);
-            }
-            else {
-                logError("folderPath is required to enable metadata logging");
                 return;
+
+            const cwd = currentWorkingDirectory || process.cwd();
+            const coreSchema = mj_core_schema();
+            let folderPath = resolveSQLOutputFolder({
+                cwd,
+                configuredFolderPath: config.folderPath,
+                includeSchemas: configInfo.includeSchemas,
+                coreSchema,
+                sqlOutputDirFlag: SQLLogging.sqlOutputDirFlag,
+                hasMjAppJson: fs.existsSync(path.join(cwd, 'mj-app.json')),
+                isMjMonorepo:
+                    fs.existsSync(path.join(cwd, 'packages', 'CodeGenLib')) ||
+                    fs.existsSync(path.join(cwd, 'packages', 'MJCLI')),
+            });
+
+            if (dbPlatform() === 'postgresql') {
+                folderPath = SQLLogging.redirectToPGMigrations(folderPath);
             }
+
+            if (!fs.existsSync(folderPath)) {
+                fs.mkdirSync(folderPath, {recursive: true });
+            }
+
+            const fileName: string = config.fileName || this.createFileName();
+            SQLLogging._SQLLoggingFilePath = path.join(folderPath, fileName);
+
+            if (!config.appendToFile || !fs.existsSync(SQLLogging.SQLLoggingFilePath)) {
+                fs.writeFileSync(SQLLogging.SQLLoggingFilePath, '');
+            }
+
+            logStatus(`Metadata logging enabled. File path: ${SQLLogging.SQLLoggingFilePath}`);
         }
      }
+
+    /** Test hook — SQLLogging is a process-wide singleton. */
+    public static resetForTests(): void {
+        SQLLogging._SQLLoggingFilePath = '';
+        SQLLogging.sqlOutputDirFlag = undefined;
+    }
 
      public static finishSQLLogging() {
         if (SQLLogging.SQLLoggingFilePath) {
@@ -210,6 +290,12 @@ export class SQLLogging {
     * @returns - The result of the query execution.
     */
     public static async LogSQLAndExecute(ds: CodeGenConnection, query: string, description?: string, isRecurringScript: boolean = false, includeBatchSeparator: boolean = false, batchSeparator: string = 'GO'): Promise<any> {
+        if (configInfo.SQLOutput?.enabled && !SQLLogging.SQLLoggingFilePath) {
+            throw new Error(
+                'SQLOutput.enabled but no CodeGen_Run log file is open. Refusing to apply metadata SQL with no artifact. ' +
+                'Run `mj codegen` from the Open App directory (mj-app.json) or pass --sql-output-dir.'
+            );
+        }
         SQLLogging.appendToSQLLogFile(query, description, isRecurringScript, includeBatchSeparator, batchSeparator);
         const result = await ds.query(query);
         return result.recordset;

--- a/packages/CodeGenLib/src/__tests__/sql-output-folder.test.ts
+++ b/packages/CodeGenLib/src/__tests__/sql-output-folder.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import { isMjDefaultSqlOutputPath, resolveSQLOutputFolder } from '../Misc/sql_logging';
+
+describe('isMjDefaultSqlOutputPath', () => {
+    it('detects MJ host v5/v6 trees', () => {
+        expect(isMjDefaultSqlOutputPath('./migrations/v5/')).toBe(true);
+        expect(isMjDefaultSqlOutputPath('./migrations/v5')).toBe(true);
+        expect(isMjDefaultSqlOutputPath('../../migrations/v5/')).toBe(true);
+        expect(isMjDefaultSqlOutputPath('/repo/MJ/migrations/v6/')).toBe(true);
+    });
+
+    it('does not treat app codegen folders as MJ defaults', () => {
+        expect(isMjDefaultSqlOutputPath('./migrations/codegen')).toBe(false);
+        expect(isMjDefaultSqlOutputPath('/app/migrations/codegen/')).toBe(false);
+    });
+});
+
+describe('resolveSQLOutputFolder', () => {
+    const appCwd = '/work/bizapps-common';
+    const mjCwd = '/work/MJ';
+
+    it('Open App cwd uses migrations/codegen and ignores MJ v5 default', () => {
+        expect(resolveSQLOutputFolder({
+            cwd: appCwd,
+            configuredFolderPath: './migrations/v5/',
+            includeSchemas: ['__mj_BizAppsCommon'],
+            coreSchema: '__mj',
+            hasMjAppJson: true,
+            isMjMonorepo: false,
+        })).toBe(path.join(appCwd, 'migrations', 'codegen'));
+    });
+
+    it('Open App honors an explicit non-MJ folderPath', () => {
+        expect(resolveSQLOutputFolder({
+            cwd: appCwd,
+            configuredFolderPath: './audit-sql',
+            hasMjAppJson: true,
+            isMjMonorepo: false,
+            coreSchema: '__mj',
+        })).toBe(path.resolve(appCwd, './audit-sql'));
+    });
+
+    it('throws when MJ monorepo cwd generates an Open App schema', () => {
+        expect(() => resolveSQLOutputFolder({
+            cwd: mjCwd,
+            configuredFolderPath: './migrations/v5/',
+            includeSchemas: ['__mj_BizAppsCommon'],
+            coreSchema: '__mj',
+            hasMjAppJson: false,
+            isMjMonorepo: true,
+        })).toThrow(/Open App metadata SQL into the MJ repo/);
+    });
+
+    it('MJ monorepo cwd with only core includeSchemas keeps host folder', () => {
+        expect(resolveSQLOutputFolder({
+            cwd: mjCwd,
+            configuredFolderPath: './migrations/v6/',
+            includeSchemas: ['__mj'],
+            coreSchema: '__mj',
+            hasMjAppJson: false,
+            isMjMonorepo: true,
+        })).toBe(path.resolve(mjCwd, './migrations/v6/'));
+    });
+
+    it('--sql-output-dir wins on an Open App', () => {
+        expect(resolveSQLOutputFolder({
+            cwd: appCwd,
+            hasMjAppJson: true,
+            isMjMonorepo: false,
+            coreSchema: '__mj',
+            sqlOutputDirFlag: './migrations/codegen',
+        })).toBe(path.resolve(appCwd, './migrations/codegen'));
+    });
+});

--- a/packages/CodeGenLib/src/plugins/index.ts
+++ b/packages/CodeGenLib/src/plugins/index.ts
@@ -49,6 +49,10 @@ advanced generation for ALL entities (bypasses changed-entity scoping).`;
     'force-advanced-gen': Flags.boolean({
       description: 'Bypass entity scoping in Pass 2 and force advanced generation to re-run for all entities.',
     }),
+    'sql-output-dir': Flags.string({
+      description:
+        'Directory for CodeGen_Run_*.sql (EntityField INSERTs and other metadata SQL). Open Apps default to ./migrations/codegen. Do not point this at MJ/migrations/v*.',
+    }),
   };
 
   static Usage: PluginUsage = {
@@ -61,6 +65,7 @@ advanced generation for ALL entities (bypasses changed-entity scoping).`;
       { name: '--skipdb', type: 'boolean', description: 'Regenerate code from existing metadata only (no DB operations)' },
       { name: '--skipfiles', type: 'boolean', description: 'Run DB-side operations only (no code files)' },
       { name: '--force-advanced-gen', type: 'boolean', description: 'Re-run advanced generation for all entities' },
+      { name: '--sql-output-dir', type: 'string', description: 'Directory for CodeGen_Run metadata SQL (Open Apps: ./migrations/codegen)' },
       { name: '--format', type: 'text|json|md', description: 'Output format (json for machine-readable result)' },
     ],
     examples: ['mj codegen', 'mj codegen --skipdb', 'mj codegen --format=json'],
@@ -84,6 +89,9 @@ advanced generation for ALL entities (bypasses changed-entity scoping).`;
     }
 
     initializeConfig(process.cwd());
+
+    const { SQLLogging } = await import('../Misc/sql_logging.js');
+    SQLLogging.sqlOutputDirFlag = flags['sql-output-dir'];
 
     // --force-advanced-gen bypasses Pass 2 scoping by toggling the existing
     // forceRegeneration.enabled config flag (honored by both sql_codegen.ts and


### PR DESCRIPTION
## Summary

Open App CodeGen was applying EntityField INSERTs to the authoring DB while logging `CodeGen_Run_*.sql` into **`MJ/migrations/v5`** (CodeGenLib default `SQLOutput.folderPath`) because `mj codegen` ran from the MJ repo. The app never got an artifact; we transcribed EntityField rows by hand (drift).

- **Open App cwd** (`mj-app.json`): SQLOutput defaults to `./migrations/codegen`. MJ `./migrations/v5` default is ignored.
- **MJ repo cwd + `includeSchemas` listing a non-core schema**: **fails** — run CodeGen from the app directory.
- **`SQLOutput.enabled` but no log file open**: refuse to apply metadata SQL.
- **`--sql-output-dir`**: override; cannot point an app run at `MJ/migrations/v*`.
- Layered BaseViews (People/Org overlay wrapping `vw*Generated`): **one CodeGen pass**. Overlay is hand-authored; CodeGen writes only the inner view. Apply overlay + `mj sync push` pins, then codegen once.

Common follow-up folds the official `CodeGen_Run_2026-09-07_14-06-05.sql` Org lat/lng INSERTs (not a hand transcription).

## Test plan

- [x] `sql-output-folder.test.ts` + existing PG routing tests (23 passed)
- [x] `tsc --noEmit` on `@memberjunction/codegen-lib`