### PR TITLE
fix(server): allow ExtraFilter IN (SELECT … FROM entity BaseView)

### DIFF
--- a/.changeset/graphql-extrafilter-baseview-ast.md
+++ b/.changeset/graphql-extrafilter-baseview-ast.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/server": patch
+"@memberjunction/sql-parser": patch
+---
+
+Replace the GraphQL ExtraFilter SELECT/EXISTS keyword ban with an AST screen that allows `IN (SELECT … FROM <entity BaseView>)` and still rejects base tables (`__mj.User`). Uses `@memberjunction/sql-parser` (same wrap as EDS `assertReadOnlyClause`). SQLParser now walks `expr.value` so `IN (SELECT …)` subqueries are visible to ExtractTableRefs.

--- a/packages/MJServer/package.json
+++ b/packages/MJServer/package.json
@@ -109,6 +109,7 @@
     "@memberjunction/search-engine": "6.1.0-edge.5",
     "@memberjunction/server-extensions-core": "6.1.0-edge.5",
     "@memberjunction/sql-dialect": "6.1.0-edge.5",
+    "@memberjunction/sql-parser": "6.1.0-edge.5",
     "@memberjunction/sqlserver-dataprovider": "6.1.0-edge.5",
     "@memberjunction/storage": "6.1.0-edge.5",
     "@memberjunction/tag-engine": "6.1.0-edge.5",

--- a/packages/MJServer/src/__tests__/ResolverBase.filterEscaping.test.ts
+++ b/packages/MJServer/src/__tests__/ResolverBase.filterEscaping.test.ts
@@ -2,7 +2,7 @@
 // Reflect.metadata polyfill at import time.
 import 'reflect-metadata';
 import { describe, it, expect } from 'vitest';
-import type { DatabaseProviderBase, RunViewParams, RunViewResult, UserInfo } from '@memberjunction/core';
+import type { DatabaseProviderBase, IMetadataProvider, RunViewParams, RunViewResult, UserInfo } from '@memberjunction/core';
 import { ResolverBase } from '../generic/ResolverBase.js';
 import type { UserPayload } from '../types.js';
 import type { RunDynamicViewInput, RunViewByNameInput } from '../generic/RunViewResolver.js';
@@ -39,7 +39,9 @@ function fakeProvider(captured: Captured, rows: Record<string, unknown>[] = []):
             {
                 ID: 'E1',
                 Name: ENTITY_NAME,
+                SchemaName: '__mj',
                 BaseView: 'vwUsers',
+                BaseTable: 'User',
                 Fields: [
                     { Name: 'Email', NeedsQuotes: true },
                     { Name: 'Name', NeedsQuotes: true },
@@ -49,8 +51,22 @@ function fakeProvider(captured: Captured, rows: Record<string, unknown>[] = []):
             },
             {
                 Name: 'MJ: User Views',
+                SchemaName: '__mj',
+                BaseView: 'vwUserViews',
                 Fields: [{ Name: 'Name', NeedsQuotes: true }],
             },
+            {
+                Name: 'MJ_BizApps_Tasks: Task Assignments',
+                SchemaName: '__mj_BizAppsTasks',
+                BaseView: 'vwTaskAssignments',
+                BaseTable: 'TaskAssignment',
+                Fields: [{ Name: 'TaskID', NeedsQuotes: true }],
+            },
+            { Name: 'MJ_BizApps_Tasks: Tasks', SchemaName: '__mj_BizAppsTasks', BaseView: 'vwTasks', BaseTable: 'Task', Fields: [] },
+            { Name: 'Committees: Meetings', SchemaName: '__mj_BizAppsCommittees', BaseView: 'vwMeetings', BaseTable: 'Meeting', Fields: [] },
+            { Name: 'Committees: Motions', SchemaName: '__mj_BizAppsCommittees', BaseView: 'vwMotions', BaseTable: 'Motion', Fields: [] },
+            { Name: 'Committees: Memberships', SchemaName: '__mj_BizAppsCommittees', BaseView: 'vwMemberships', BaseTable: 'Membership', Fields: [] },
+            { Name: 'Committees: Terms', SchemaName: '__mj_BizAppsCommittees', BaseView: 'vwTerms', BaseTable: 'Term', Fields: [] },
         ],
         RunView: async (params: RunViewParams): Promise<RunViewResult> => {
             captured.params = params;
@@ -68,8 +84,8 @@ class Probe extends ResolverBase {
         return this.findBy(provider, entity, params, fakeUser());
     }
 
-    public AssertNoClientSubquery(clause: string | undefined | null, label: string) {
-        return this.assertNoClientSubquery(clause, label);
+    public ScreenClause(clause: string | undefined | null, label: string, provider: DatabaseProviderBase) {
+        return this.assertClientClauseUsesEntityBaseViews(clause, label, provider as unknown as IMetadataProvider);
     }
 
     public RunDynamic(input: RunDynamicViewInput, provider: DatabaseProviderBase) {
@@ -137,63 +153,89 @@ describe('ResolverBase.findBy — ExtraFilter escaping', () => {
     });
 });
 
-describe('ResolverBase — GraphQL-boundary subquery screen (assertNoClientSubquery)', () => {
-    // ValidateUserProvidedSQLClause deliberately permits SELECT (server-internal engines pass
-    // richer filters straight into RunView), so a client could previously turn ExtraFilter into
-    // a blind boolean oracle over tables it cannot read. These tests pin the stricter screen
-    // applied only to clauses arriving through the GraphQL resolvers.
+describe('ResolverBase — GraphQL-boundary ExtraFilter AST screen', () => {
+    // Keyword SELECT/EXISTS ban (#4253) broke first-party IN (SELECT … FROM base view).
+    // The replacement parses the fragment and allows only entity BaseViews.
 
-    it('rejects an EXISTS subquery probing a foreign table', () => {
+    const provider = () => fakeProvider({ params: null });
+
+    it('rejects an EXISTS subquery against a base table', () => {
         expect(() =>
-            new Probe().AssertNoClientSubquery(`EXISTS (SELECT 1 FROM __mj.[User] WHERE Type='Owner')`, 'ExtraFilter')
-        ).toThrow(/subqueries are not permitted/);
+            new Probe().ScreenClause(`EXISTS (SELECT 1 FROM __mj.[User] WHERE Type='Owner')`, 'ExtraFilter', provider())
+        ).toThrow(/entity base view/);
     });
 
-    it('rejects a scalar SELECT subquery in ORDER BY', () => {
+    it('rejects a scalar SELECT subquery against a non-view', () => {
         expect(() =>
-            new Probe().AssertNoClientSubquery('(SELECT COUNT(*) FROM __mj.APIKey)', 'OrderBy')
-        ).toThrow(/subqueries are not permitted/);
+            new Probe().ScreenClause('(SELECT COUNT(*) FROM __mj.APIKey)', 'OrderBy', provider())
+        ).toThrow(/entity base view/);
     });
 
-    it('rejects EXISTS regardless of case', () => {
+    it('allows IN (SELECT …) against an entity BaseView', () => {
         expect(() =>
-            new Probe().AssertNoClientSubquery(`eXiStS (SeLeCt 1 FROM __mj.[User])`, 'ExtraFilter')
-        ).toThrow(/subqueries are not permitted/);
+            new Probe().ScreenClause(
+                `ID IN (SELECT TaskID FROM [__mj_BizAppsTasks].[vwTaskAssignments] WHERE AssigneeRecordID = 'x')`,
+                'ExtraFilter',
+                provider(),
+            )
+        ).not.toThrow();
+    });
+
+    it('allows the restored Committees ExtraFilter shapes (Command Center, workspace, tracker)', () => {
+        const p = new Probe();
+        const md = provider();
+        const clauses = [
+            `TaskID IN (SELECT ID FROM [__mj_BizAppsTasks].[vwTasks] WHERE Status IN ('Open', 'InProgress'))`,
+            `ID IN (SELECT TaskID FROM [__mj_BizAppsTasks].[vwTaskAssignments] WHERE AssigneeRecordID = 'x')`,
+            `MeetingID IN (SELECT ID FROM [__mj_BizAppsCommittees].[vwMeetings] WHERE CommitteeID='x')`,
+            `MotionID IN (SELECT ID FROM [__mj_BizAppsCommittees].[vwMotions] WHERE MeetingID = 'x')`,
+            `ID IN (SELECT m.PersonID FROM [__mj_BizAppsCommittees].[vwMemberships] m JOIN [__mj_BizAppsCommittees].[vwTerms] t ON m.TermID = t.ID WHERE t.CommitteeID = 'x' AND m.Status = 'Active')`,
+        ];
+        for (const c of clauses) {
+            expect(() => p.ScreenClause(c, 'ExtraFilter', md)).not.toThrow();
+        }
     });
 
     it('allows an ordinary comparison filter', () => {
         expect(() =>
-            new Probe().AssertNoClientSubquery(`Email = 'a@b.com' AND IsActive = 1`, 'ExtraFilter')
+            new Probe().ScreenClause(`Email = 'a@b.com' AND IsActive = 1`, 'ExtraFilter', provider())
         ).not.toThrow();
     });
 
     it('does not false-positive on SELECT/EXISTS inside string literals', () => {
-        // Literals are stripped before the keyword test, so a value that merely CONTAINS the
-        // words is fine.
         expect(() =>
-            new Probe().AssertNoClientSubquery(`Name LIKE '%select%' OR Name = 'exists'`, 'ExtraFilter')
+            new Probe().ScreenClause(`Name LIKE '%select%' OR Name = 'exists'`, 'ExtraFilter', provider())
         ).not.toThrow();
     });
 
     it('allows empty/undefined clauses', () => {
-        expect(() => new Probe().AssertNoClientSubquery('', 'ExtraFilter')).not.toThrow();
-        expect(() => new Probe().AssertNoClientSubquery(undefined, 'OrderBy')).not.toThrow();
+        expect(() => new Probe().ScreenClause('', 'ExtraFilter', provider())).not.toThrow();
+        expect(() => new Probe().ScreenClause(undefined, 'OrderBy', provider())).not.toThrow();
     });
 
-    it('RunDynamicViewGeneric never reaches RunView when ExtraFilter carries a subquery', async () => {
+    it('RunDynamicViewGeneric never reaches RunView when ExtraFilter hits a base table', async () => {
         const captured: Captured = { params: null };
         const input = {
             EntityName: ENTITY_NAME,
             ExtraFilter: `EXISTS (SELECT 1 FROM __mj.[User] WHERE Type='Owner')`,
         } as RunDynamicViewInput;
 
-        // The screen throws inside RunViewGenericInternal. RunDynamicViewGeneric returns that
-        // promise without awaiting it, so its try/catch does not swallow the rejection — the
-        // caller sees the error directly.
         await expect(new Probe().RunDynamic(input, fakeProvider(captured))).rejects.toThrow(
-            /subqueries are not permitted/
+            /entity base view/
         );
-        expect(captured.params).toBeNull(); // never reached RunView
+        expect(captured.params).toBeNull();
+    });
+
+    it('RunDynamicViewGeneric passes a BaseView subquery through to RunView', async () => {
+        const captured: Captured = { params: null };
+        const input = {
+            EntityName: ENTITY_NAME,
+            ExtraFilter: `ID IN (SELECT ID FROM [__mj].[vwUsers] WHERE Email = 'a@b.com')`,
+        } as RunDynamicViewInput;
+
+        await new Probe().RunDynamic(input, fakeProvider(captured));
+
+        expect(captured.params?.ExtraFilter).toBe(`ID IN (SELECT ID FROM [__mj].[vwUsers] WHERE Email = 'a@b.com')`);
     });
 
     it('RunDynamicViewGeneric passes a benign ExtraFilter through to RunView', async () => {

--- a/packages/MJServer/src/generic/ResolverBase.ts
+++ b/packages/MJServer/src/generic/ResolverBase.ts
@@ -31,7 +31,9 @@ import { httpTransport, CloudEvent, emitterFor } from 'cloudevents';
 import { RunViewGenericParams, UserPayload } from '../types.js';
 import { RunDynamicViewInput, RunViewByIDInput, RunViewByNameInput } from './RunViewResolver.js';
 import { DeleteOptionsInput } from './DeleteOptionsInput.js';
-import { MJEvent, MJEventType, MJGlobal, ENCRYPTED_SENTINEL, EscapeSQLString, IsValueEncrypted, IsOnlyTimezoneShift, StripSQLStringLiterals } from '@memberjunction/global';
+import { MJEvent, MJEventType, MJGlobal, ENCRYPTED_SENTINEL, EscapeSQLString, IsValueEncrypted, IsOnlyTimezoneShift } from '@memberjunction/global';
+import { SQLParser } from '@memberjunction/sql-parser';
+import { PostgreSQLDialect, SQLServerDialect, type SQLParserDialect } from '@memberjunction/sql-dialect';
 import { EncryptionEngine } from '@memberjunction/encryption';
 import { PUSH_STATUS_UPDATES_TOPIC, publishStatusUpdate } from './PushStatusResolver.js';
 import { CACHE_INVALIDATION_TOPIC } from './CacheInvalidationResolver.js';
@@ -801,41 +803,124 @@ export class ResolverBase {
   /**
    * SECURITY — GraphQL-boundary screen for one client-supplied SQL clause fragment.
    *
-   * The shared `ValidateUserProvidedSQLClause` screen (databaseProviderBase) blocks stacked
-   * statements, DML, comments, UNION and WAITFOR, but deliberately permits SELECT because
-   * server-internal engines legitimately pass richer filters straight into RunView. A
-   * CLIENT, however, has no legitimate reason to embed a subquery in ExtraFilter / OrderBy /
-   * UserSearchString / OverrideExcludeFilter — and permitting one turns those fields into a
-   * blind boolean oracle over tables the caller cannot read (e.g.
-   * `EXISTS (SELECT 1 FROM __mj.User WHERE ...)`). So clauses arriving through the GraphQL
-   * resolvers are additionally rejected when they contain SELECT or EXISTS outside of
-   * string literals.
+   * `ValidateUserProvidedSQLClause` still blocks stacked statements, DML, comments, UNION
+   * and WAITFOR, and still permits SELECT (server-internal engines pass richer filters).
+   * A keyword ban on SELECT/EXISTS at this boundary (#4253) broke first-party clients that
+   * use `IN (SELECT … FROM <entity base view>)` — that is a legitimate ExtraFilter.
+   *
+   * This screen uses `@memberjunction/sql-parser` (same wrap as EDS `assertReadOnlyClause`):
+   * wrap the fragment as a single SELECT, fail closed if it does not parse as a read, then
+   * allow a FROM only when it is an entity **BaseView**. Base tables (`Meeting`, `__mj.User`)
+   * and catalogs are rejected. Server-internal RunView callers never hit this.
+   *
+   * RLS is applied by RunView as an outer WHERE around the entity being queried, not compiled
+   * into the view. Subqueries against another entity's BaseView therefore do not inherit that
+   * entity's RLS; they are still restricted to the view (not the table).
    */
-  protected assertNoClientSubquery(clause: string | undefined | null, label: string): void {
-    if (!clause) return;
-    // Strip string literals first so a legitimate value like Name LIKE '%select%' passes.
-    const stripped = StripSQLStringLiterals(clause);
-    if (/\bselect\b/i.test(stripped) || /\bexists\b/i.test(stripped)) {
-      throw new Error(`Invalid ${label}: subqueries are not permitted in client-supplied filters`);
+  protected assertClientClauseUsesEntityBaseViews(
+    clause: string | undefined | null,
+    label: string,
+    provider?: IMetadataProvider,
+  ): void {
+    if (!clause?.trim()) return;
+
+    const dialect = this.dialectForProvider(provider);
+    if (SQLParser.HasStackedStatements(clause, dialect)) {
+      throw new Error(`Invalid ${label}: multiple statements are not permitted in client-supplied filters`);
+    }
+
+    const wrapped =
+      label === 'OrderBy'
+        ? `SELECT 1 FROM __mj_clause_screen ORDER BY ${clause}`
+        : `SELECT 1 FROM __mj_clause_screen WHERE (${clause})`;
+    const parser = new SQLParser(wrapped, dialect);
+    if (!parser.IsValid || parser.HasWriteStatement || parser.StatementKind !== 'select') {
+      throw new Error(
+        `Invalid ${label}: not a safe read-only filter fragment — refusing under uncertainty`,
+      );
+    }
+    if (this.astContainsWriteNode(parser.AST)) {
+      throw new Error(`Invalid ${label}: write/DDL nested in a subquery is not permitted`);
+    }
+
+    const allowed = this.entityBaseViewAllowList(provider);
+    const tables = SQLParser.ExtractTableRefs(wrapped, dialect);
+    for (const t of tables) {
+      const table = this.stripSqlIdent(t.TableName);
+      const schema = this.stripSqlIdent(t.SchemaName);
+      if (table.toLowerCase() === '__mj_clause_screen') continue;
+      const qualified = `${schema}.${table}`.toLowerCase();
+      const bare = table.toLowerCase();
+      if (allowed.qualified.has(qualified) || allowed.bare.has(bare)) continue;
+      throw new Error(
+        `Invalid ${label}: subquery must use an entity base view, not '${schema}.${table}'`,
+      );
     }
   }
 
   /**
-   * Applies {@link assertNoClientSubquery} to the full set of client-supplied clause fields a
-   * view request can carry. Every GraphQL entry point that accepts these fields
-   * (RunViewByName, RunViewByID, RunDynamicView, and the batched RunViews) funnels through
-   * RunViewGenericInternal / RunViewsGenericInternal, which both call this.
+   * Applies {@link assertClientClauseUsesEntityBaseViews} to every client-supplied clause
+   * a view request can carry. GraphQL entry points (RunViewByName, RunViewByID,
+   * RunDynamicView, RunViews) funnel through RunViewGenericInternal / RunViewsGenericInternal.
    */
-  protected screenClientViewClauses(clauses: {
-    extraFilter?: string | null;
-    orderBy?: string | null;
-    userSearchString?: string | null;
-    overrideExcludeFilter?: string | null;
-  }): void {
-    this.assertNoClientSubquery(clauses.extraFilter, 'ExtraFilter');
-    this.assertNoClientSubquery(clauses.orderBy, 'OrderBy');
-    this.assertNoClientSubquery(clauses.userSearchString, 'UserSearchString');
-    this.assertNoClientSubquery(clauses.overrideExcludeFilter, 'OverrideExcludeFilter');
+  protected screenClientViewClauses(
+    clauses: {
+      extraFilter?: string | null;
+      orderBy?: string | null;
+      userSearchString?: string | null;
+      overrideExcludeFilter?: string | null;
+    },
+    provider?: IMetadataProvider,
+  ): void {
+    this.assertClientClauseUsesEntityBaseViews(clauses.extraFilter, 'ExtraFilter', provider);
+    this.assertClientClauseUsesEntityBaseViews(clauses.orderBy, 'OrderBy', provider);
+    this.assertClientClauseUsesEntityBaseViews(clauses.userSearchString, 'UserSearchString', provider);
+    this.assertClientClauseUsesEntityBaseViews(clauses.overrideExcludeFilter, 'OverrideExcludeFilter', provider);
+  }
+
+  /** Same write-node walk as EDS `sqlReadOnlyScreen.astContainsWriteNode`. */
+  private astContainsWriteNode(node: unknown): boolean {
+    if (!node || typeof node !== 'object') return false;
+    if (Array.isArray(node)) return node.some((n) => this.astContainsWriteNode(n));
+    const obj = node as Record<string, unknown>;
+    const type = obj.type;
+    if (typeof type === 'string' && ResolverBase.WRITE_NODE_TYPES.has(type.toLowerCase())) {
+      return true;
+    }
+    return Object.values(obj).some((v) => this.astContainsWriteNode(v));
+  }
+
+  private static readonly WRITE_NODE_TYPES = new Set<string>([
+    'insert', 'update', 'delete', 'merge', 'replace', 'drop', 'create', 'alter', 'truncate',
+    'rename', 'call', 'exec', 'execute', 'grant', 'revoke', 'use', 'load', 'copy', 'do',
+  ]);
+
+  private dialectForProvider(provider?: IMetadataProvider): SQLParserDialect {
+    const name = provider?.constructor?.name ?? '';
+    if (/postgres/i.test(name)) return new PostgreSQLDialect();
+    return new SQLServerDialect();
+  }
+
+  private stripSqlIdent(name: string | null | undefined): string {
+    if (!name) return '';
+    return name.replace(/^\[|\]$/g, '').replace(/^"|"$/g, '').replace(/^`|`$/g, '');
+  }
+
+  private entityBaseViewAllowList(provider?: IMetadataProvider): {
+    qualified: Set<string>;
+    bare: Set<string>;
+  } {
+    const qualified = new Set<string>();
+    const bare = new Set<string>();
+    const entities = provider?.Entities ?? [];
+    for (const e of entities) {
+      const view = this.stripSqlIdent(e.BaseView);
+      if (!view) continue;
+      const schema = this.stripSqlIdent(e.SchemaName);
+      bare.add(view.toLowerCase());
+      if (schema) qualified.add(`${schema}.${view}`.toLowerCase());
+    }
+    return { qualified, bare };
   }
 
   /**
@@ -869,9 +954,12 @@ export class ResolverBase {
     try {
       if (!viewInfo || !userPayload) return null;
 
-      // SECURITY: reject client-supplied clause fragments containing subqueries before they
-      // reach the provider (see screenClientViewClauses).
-      this.screenClientViewClauses({ extraFilter, orderBy, userSearchString, overrideExcludeFilter });
+      // SECURITY: GraphQL ExtraFilter may contain IN (SELECT … FROM <base view>).
+      // Screen at this boundary: parse, reject writes, allow only entity BaseViews.
+      this.screenClientViewClauses(
+        { extraFilter, orderBy, userSearchString, overrideExcludeFilter },
+        provider as unknown as IMetadataProvider,
+      );
 
       // Check API key scope authorization for view operations
       await this.CheckAPIKeyScopeAuthorization('view:run', viewInfo.Entity, userPayload);
@@ -1034,13 +1122,16 @@ export class ResolverBase {
 
       // Transform parameters
       for (const param of params) {
-        // SECURITY: same GraphQL-boundary subquery screen as RunViewGenericInternal.
-        this.screenClientViewClauses({
-          extraFilter: param.extraFilter,
-          orderBy: param.orderBy,
-          userSearchString: param.userSearchString,
-          overrideExcludeFilter: param.overrideExcludeFilter,
-        });
+        // SECURITY: same GraphQL-boundary BaseView screen as RunViewGenericInternal.
+        this.screenClientViewClauses(
+          {
+            extraFilter: param.extraFilter,
+            orderBy: param.orderBy,
+            userSearchString: param.userSearchString,
+            overrideExcludeFilter: param.overrideExcludeFilter,
+          },
+          md,
+        );
 
         if (param.viewInfo) {
           // Validate entity only once per entity type

--- a/packages/SQLParser/src/__tests__/sql-parser.test.ts
+++ b/packages/SQLParser/src/__tests__/sql-parser.test.ts
@@ -37,6 +37,19 @@ describe('SQLParser', () => {
             expect(tables[0].SchemaName).toBe('__mj');
         });
 
+        it('extracts the FROM of an IN (SELECT …) subquery (ExtraFilter shape)', () => {
+            const sql = `SELECT 1 FROM __mj_clause_screen WHERE (ID IN (SELECT TaskID FROM [__mj_BizAppsTasks].[vwTaskAssignments] WHERE AssigneeRecordID = 'x'))`;
+            const names = extractTableRefs(sql).map(t => t.TableName).sort();
+            expect(names).toContain('__mj_clause_screen');
+            expect(names).toContain('vwTaskAssignments');
+        });
+
+        it('extracts the FROM of an EXISTS subquery', () => {
+            const sql = `SELECT 1 FROM __mj_clause_screen WHERE (EXISTS (SELECT 1 FROM __mj.[User] WHERE Type='Owner'))`;
+            const tables = extractTableRefs(sql);
+            expect(tables.some(t => t.TableName === 'User' && t.SchemaName === '__mj')).toBe(true);
+        });
+
         it('should return empty for empty SQL', () => {
             expect(extractTableRefs('')).toEqual([]);
         });

--- a/packages/SQLParser/src/sql-parser.ts
+++ b/packages/SQLParser/src/sql-parser.ts
@@ -2392,6 +2392,16 @@ export class SQLParser {
             }
         }
         if (expr.expr) SQLParser.walkExpression(expr.expr as Record<string, unknown>, columnRefs, tableAliasMap);
+        // IN (SELECT …) is an expr_list on `value`, not `args`. Without this walk,
+        // ExtractTableRefs misses the subquery FROM (EXISTS uses `args` and was found).
+        if (expr.value != null) {
+            const values = Array.isArray(expr.value) ? expr.value : [expr.value];
+            for (const v of values) {
+                if (v && typeof v === 'object') {
+                    SQLParser.walkExpression(v as Record<string, unknown>, columnRefs, tableAliasMap);
+                }
+            }
+        }
     }
 
     // ═══════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- [#4253](https://github.com/MemberJunction/MJ/pull/4253) banned `SELECT`/`EXISTS` in GraphQL ExtraFilter by keyword. That broke Committees Command Center and any Open App using `IN (SELECT … FROM <view>)`.
- Keyword `SELECT` is not stacked DML. The leak is a subquery against a **base table** or catalog (`EXISTS (SELECT 1 FROM __mj.User …)`).
- This PR keeps the GraphQL-boundary screen but uses `@memberjunction/sql-parser` (same wrap as EDS `assertReadOnlyClause`): parse as a single read, reject nested writes, allow FROM only when it is an entity **BaseView**.
- `SQLParser.walkExpression` now walks `expr.value` so `IN (SELECT …)` tables are extracted (EXISTS already was).
- Does **not** revert the rest of #4253 (CustomWhereClause Owner-only, Conditional `new Function`, iframe, Gmail).
- RLS is still applied by RunView as an outer WHERE, not compiled into the view. Subqueries against another entity’s BaseView do not inherit that entity’s RLS; they are still restricted to the view, not the table.

## Test plan
- [ ] `pnpm exec vitest run src/__tests__/ResolverBase.filterEscaping.test.ts` in MJServer (18 tests, includes restored Committees ExtraFilter shapes)
- [ ] `pnpm exec vitest run src/__tests__/sql-parser.test.ts` in SQLParser
- [ ] Committee Management Command Center loads after this + Committees PR (SELECT IN against `vwTasks` / `vwMeetings` / …)
- [ ] `EXISTS (SELECT 1 FROM __mj.[User] …)` ExtraFilter still fails at GraphQL