### PR TITLE
chore(lockfile): add MJServer's @memberjunction/sql-parser workspace link

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12347,6 +12347,9 @@ importers:
       '@memberjunction/sql-dialect':
         specifier: 6.1.0-edge.5
         version: link:../SQLDialect
+      '@memberjunction/sql-parser':
+        specifier: 6.1.0-edge.5
+        version: link:../SQLParser
       '@memberjunction/sqlserver-dataprovider':
         specifier: 6.1.0-edge.5
         version: link:../SQLServerDataProvider


### PR DESCRIPTION
## Problem

806e7f2dc3 (#4293) added `@memberjunction/sql-parser` to `packages/MJServer/package.json` without updating `pnpm-lock.yaml`. Every CI job that installs with `--frozen-lockfile` now fails on next's tip, and so does any PR that merges next:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with packages/MJServer/package.json
```

Observed on #4292 after merging next: Build, Source guards, Run unit tests, Integration, adopted standards, PG migration validation and the dependency check all fail at the install step.

## Change

The lockfile gains exactly the three lines pnpm needs in the `packages/MJServer` importer:

```yaml
'@memberjunction/sql-parser':
  specifier: 6.1.0-edge.5
  version: link:../SQLParser
```

It is a workspace link; no new packages are resolved. A full regeneration was deliberately not committed: on this machine it also rewrote unrelated peer-resolution keys (`googleapis`, `webpack-dev-server`), which are not this fix's to change.

No changeset: no package source changes; #4293 carried the changeset for the dependency itself.

## Verification

- `pnpm install --frozen-lockfile --offline --lockfile-only` fails on next's tip and passes with this change.
- `pnpm install --frozen-lockfile --offline` completes and `packages/MJServer/node_modules/@memberjunction/sql-parser` links to `../../../SQLParser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
