### PR TITLE
fix(core): RLS exemption honours the permission row's Can* flags

### DIFF
--- a/.changeset/rls-exemption-honours-can-flags.md
+++ b/.changeset/rls-exemption-honours-can-flags.md
@@ -1,0 +1,9 @@
+---
+"@memberjunction/core": patch
+---
+
+`EntityInfo.UserExemptFromRowLevelSecurity` now requires the permission row to GRANT the operation before it can exempt the user from row-level security for it.
+
+A permission row carries an RLS filter only for the operations it grants, so a row with `CanCreate=false` also has `CreateRLSFilterID=null`. The exemption check read that null as "unrestricted" and returned exempt. Every authenticated user holds the `UI` role, whose rows are read-only on most entities, so any user whose tenant role bound Create/Update/Delete to a row filter was silently exempt from that filter on the client (RunView/GraphQL) path: an org admin could write a record into another organization.
+
+The check is now `ep.CanCreate && !ep.CreateRLSFilterID` (and likewise for Read/Update/Delete). A filter-less row that grants the operation still exempts, exactly as before; a row that does not grant it no longer says anything about exemption. Regression tests added to `entityInfo.rlsExemption.test.ts`.

--- a/packages/MJCore/src/__tests__/entityInfo.rlsExemption.test.ts
+++ b/packages/MJCore/src/__tests__/entityInfo.rlsExemption.test.ts
@@ -333,6 +333,84 @@ describe('EntityInfo RLS Exemption (centralized in GetUserRowLevelSecurityWhereC
         });
     });
 
+    describe('Exemption requires the row to GRANT the operation (Can* flags)', () => {
+        // A permission row confers an RLS exemption only for an operation it grants. A row that
+        // does not grant an operation carries no filter for it either, and that absence means
+        // "not applicable", not "unrestricted". Before this guard, a read-only row (CanCreate=false,
+        // hence CreateRLSFilterID=null) made every holder of that role exempt from CREATE RLS —
+        // and a read-only role is exactly the shape of the 'UI' role every authenticated user holds.
+        it('a read-only row does NOT exempt the user from Create/Update/Delete RLS', () => {
+            const entity = buildEntityInfo([
+                buildPermission({
+                    RoleID: UI_ROLE_ID,
+                    CanRead: true, CanCreate: false, CanUpdate: false, CanDelete: false,
+                    ReadRLSFilterID: READ_RLS_FILTER_ID,
+                }),
+            ]);
+            const user = buildUser(USER_ID, [UI_ROLE_ID]);
+
+            expect(entity.UserExemptFromRowLevelSecurity(user, EntityPermissionType.Create)).toBe(false);
+            expect(entity.UserExemptFromRowLevelSecurity(user, EntityPermissionType.Update)).toBe(false);
+            expect(entity.UserExemptFromRowLevelSecurity(user, EntityPermissionType.Delete)).toBe(false);
+        });
+
+        it('a read-only row does NOT exempt the user from Read RLS when CanRead is false either', () => {
+            const entity = buildEntityInfo([
+                buildPermission({
+                    RoleID: UI_ROLE_ID,
+                    CanRead: false, CanCreate: false, CanUpdate: false, CanDelete: false,
+                }),
+            ]);
+            const user = buildUser(USER_ID, [UI_ROLE_ID]);
+
+            expect(entity.UserExemptFromRowLevelSecurity(user, EntityPermissionType.Read)).toBe(false);
+        });
+
+        it('a filter-less row that GRANTS the operation still exempts (unchanged behaviour)', () => {
+            const entity = buildEntityInfo([
+                buildPermission({ RoleID: INTEGRATION_ROLE_ID, CanCreate: true, CreateRLSFilterID: null }),
+            ]);
+            const user = buildUser(USER_ID, [INTEGRATION_ROLE_ID]);
+
+            expect(entity.UserExemptFromRowLevelSecurity(user, EntityPermissionType.Create)).toBe(true);
+        });
+
+        it('the real shape: UI (read-only, filtered) + Org Admin (filtered create) is NOT create-exempt', () => {
+            // The multi-tenant case this guards: an org admin holds the UI role (read-only) and a
+            // tenant role whose Create is bound to their own organization. The read-only UI row must
+            // not lift the tenant bound.
+            const entity = buildEntityInfo([
+                buildPermission({
+                    RoleID: UI_ROLE_ID,
+                    CanRead: true, CanCreate: false, CanUpdate: false, CanDelete: false,
+                    ReadRLSFilterID: READ_RLS_FILTER_ID,
+                }),
+                buildPermission({
+                    RoleID: DEV_ROLE_ID,
+                    CanRead: true, CanCreate: true, CanUpdate: true, CanDelete: false,
+                    ReadRLSFilterID: READ_RLS_FILTER_ID,
+                    CreateRLSFilterID: CREATE_RLS_FILTER_ID,
+                    UpdateRLSFilterID: CREATE_RLS_FILTER_ID,
+                }),
+            ]);
+            const user = buildUser(USER_ID, [UI_ROLE_ID, DEV_ROLE_ID]);
+
+            expect(entity.UserExemptFromRowLevelSecurity(user, EntityPermissionType.Create)).toBe(false);
+            const clause = entity.GetUserRowLevelSecurityWhereClause(user, EntityPermissionType.Create, 'AND');
+            expect(clause).toContain('DepartmentID');
+        });
+
+        it('the same read-only row leaves READ exemption semantics untouched', () => {
+            // Read is granted and unfiltered on this row: exemption for Read still applies.
+            const entity = buildEntityInfo([
+                buildPermission({ RoleID: UI_ROLE_ID, CanRead: true, CanCreate: false, ReadRLSFilterID: null }),
+            ]);
+            const user = buildUser(USER_ID, [UI_ROLE_ID]);
+
+            expect(entity.UserExemptFromRowLevelSecurity(user, EntityPermissionType.Read)).toBe(true);
+        });
+    });
+
     describe('Permission type isolation', () => {
         it('Read RLS does not affect Create checks', () => {
             const entity = buildEntityInfo([

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -2981,7 +2981,15 @@ export class EntityInfo extends BaseInfo {
     }
 
     /**
-     * Determines if a given user, for a given permission type, is exempt from RowLevelSecurity or not
+     * Determines if a given user, for a given permission type, is exempt from RowLevelSecurity or not.
+     *
+     * A permission row confers an exemption only for an operation it GRANTS (the matching `Can*`
+     * flag is true) and leaves unfiltered. A row that does not grant the operation has no filter
+     * for it either, and that absence means "not applicable", not "unrestricted" — so it must not
+     * lift a filter that another of the user's roles binds. Without the `Can*` check, a role that
+     * grants only reads (CanCreate=false, hence CreateRLSFilterID=null) made every holder of that
+     * role exempt from CREATE row-level security, which is the shape of the 'UI' role every
+     * authenticated user holds on nearly every entity.
      * @param user 
      * @param type 
      * @returns 
@@ -2993,19 +3001,19 @@ export class EntityInfo extends BaseInfo {
             if (roleMatch) { // user has this role 
                 switch (type) {
                     case EntityPermissionType.Create:
-                        if (!ep.CreateRLSFilterID)
+                        if (ep.CanCreate && !ep.CreateRLSFilterID)
                             return true;
                         break;
                     case EntityPermissionType.Read:
-                        if (!ep.ReadRLSFilterID)
+                        if (ep.CanRead && !ep.ReadRLSFilterID)
                             return true;
                         break;
                     case EntityPermissionType.Update:
-                        if (!ep.UpdateRLSFilterID)
+                        if (ep.CanUpdate && !ep.UpdateRLSFilterID)
                             return true;
                         break;
                     case EntityPermissionType.Delete:
-                        if (!ep.DeleteRLSFilterID)
+                        if (ep.CanDelete && !ep.DeleteRLSFilterID)
                             return true;
                         break;
                 }


### PR DESCRIPTION

Branch: `fix/rls-exemption-honours-can-flags` (off `origin/next` @ c1fea88930) · commit `7f3c60c435`

## The gap

`EntityInfo.UserExemptFromRowLevelSecurity` decides whether a user is exempt from row-level security
for an operation by scanning the user's permission rows and returning exempt on the first row with no
filter for that operation:

```ts
case EntityPermissionType.Create:
    if (!ep.CreateRLSFilterID) return true;
```

A permission row carries a filter only for operations it grants. A row with `CanCreate=false` also
has `CreateRLSFilterID=null`, and the check reads that null as "unrestricted". So a **read-only**
role exempts its holders from Create/Update/Delete RLS.

Every authenticated user holds the `UI` role, whose rows are read-only on most entities. Any user
whose *other* role binds Create/Update/Delete to a row filter (the multi-tenant shape: an org admin
whose writes are bound to their own organization) is therefore exempt from that filter on the
client path — `RunView` / the generated GraphQL mutations — and can write a record into another
tenant. The server-side `PreRunView` middleware does not see this because the exemption is decided
inside `GetUserRowLevelSecurityWhereClause` / `GetEffectiveRowFilterWhereClause` before any filter
is composed.

Betty (BlueCypress) has carried this as a local dist patch since 2026-08-21
(`patches/@memberjunction+core+6.1.0-edge.1.patch`); this PR is the upstream fix so that patch can
be deleted.

## The fix

Four one-line condition changes in `UserExemptFromRowLevelSecurity`:

```ts
if (ep.CanCreate && !ep.CreateRLSFilterID) return true;   // and Read / Update / Delete alike
```

A filter-less row that **grants** the operation still exempts, exactly as before. A row that does
not grant the operation no longer says anything about exemption. `GetUserRowLevelSecurityInfo`
(which collects the filters that apply) is untouched: it already keys on the filter ID being
present. JSDoc on the method explains the rule.

## Evidence

- **5 new tests** in `entityInfo.rlsExemption.test.ts` under
  *"Exemption requires the row to GRANT the operation (Can* flags)"*: read-only row does not exempt
  Create/Update/Delete; `CanRead=false` row does not exempt Read; filter-less granting row still
  exempts; the real multi-role shape (UI read-only + tenant role with a Create filter) is not
  create-exempt and the Create clause still renders; a read-only row with an unfiltered Read still
  exempts Read.
- **Red before, green after:** 3 of the 5 fail on `next` as-is (the two "still exempts" cases pass
  either way, by design). All 34 tests in the file pass with the fix. The pre-existing 29 tests are
  unchanged — they all build rows with every `Can*` flag true, so they were never sensitive to this.
- Verified on a fresh `pnpm install --frozen-lockfile` of `next`: `packages/MJCore` builds, all 2316
  core tests pass (160 files), `check:esm` and `check:changeset` are green.

## Changeset

`.changeset/rls-exemption-honours-can-flags.md` — `@memberjunction/core: patch`.

## Not in this PR — but not inert either

`GetUserRowLevelSecurityInfo` still collects a filter from a row whose `Can*` flag is false when that
row happens to keep its filter ID. I first called that inert on the grounds that the permission gate
refuses the operation; that is wrong. `GetUserPermisions` ORs the flags across roles
(`entityInfo.ts:2957`), so a granting role carries the user past the gate and the non-granting
role's leftover filter is then OR'd into the clause, which widens. Nothing in MJ clears a filter
when its flag is cleared. On the BlueCypress production copy there are 9 such rows, all with
"own rows by UserID" filters, so the exposure there is bounded to the user's own rows. The
symmetric fix (honour the same `Can*` flag before collecting a filter) is a follow-up, kept
separate as suggested in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQSaYbUh2YWwPs1FeiMArZ


