### PR TITLE
fix(ci): stop the spec anti-pattern lint matching inside string literals

### DIFF
--- a/.github/scripts/__tests__/check-spec-antipatterns.test.mjs
+++ b/.github/scripts/__tests__/check-spec-antipatterns.test.mjs
@@ -1,17 +1,57 @@
 import { describe, it, expect } from 'vitest';
-import { lintText, stripComments, hasAdjacentKnownLimitation, ALLOWLIST } from '../../../scripts/check-spec-antipatterns.mjs';
+import { lintText, stripCommentsAndStrings, hasAdjacentKnownLimitation, ALLOWLIST } from '../../../scripts/check-spec-antipatterns.mjs';
 
 const whys = (text, kind) => lintText(text, kind).map((f) => f.why);
 
-describe('stripComments', () => {
+describe('stripCommentsAndStrings', () => {
     it('strips line comments so prose about an anti-pattern does not trip a rule', () => {
         expect(whys(`// mentioning expect(true) or as any here is fine\nexpect(x).toBe(1);\n`, 'node')).toEqual([]);
     });
 
     it('strips block-comment interiors line-wise', () => {
-        const stripped = stripComments(['/* expect(true)', 'still comment as any', '*/ expect(x).toBe(1);']);
+        const stripped = stripCommentsAndStrings(['/* expect(true)', 'still comment as any', '*/ expect(x).toBe(1);']);
         expect(stripped.join('\n')).not.toContain('expect(true)');
         expect(stripped.join('\n')).toContain('expect(x).toBe(1);');
+    });
+});
+
+describe('stripCommentsAndStrings — string literals are prose too', () => {
+    it('does not flag `as any` inside a test title (the #4355 false positive)', () => {
+        // Verbatim from packages/Angular/Generic/base-forms — "as soon AS ANY count" tripped the rule.
+        expect(whys(`it('is false as soon as any count is positive', () => {});`, 'node')).toEqual([]);
+    });
+
+    it('does not flag an anti-pattern named in a double-quoted string', () => {
+        expect(whys(`const why = "as any is banned repo-wide";`, 'node')).toEqual([]);
+    });
+
+    it('does not flag one named in a template literal', () => {
+        expect(whys('const why = `we ban as any here`;', 'node')).toEqual([]);
+    });
+
+    it('STILL flags real code inside a template expression', () => {
+        expect(whys('const s = `${value as any}`;', 'node')).toContain('`as any` — banned repo-wide (CLAUDE.md)');
+    });
+
+    it('still flags real code on a line that also carries a harmless string', () => {
+        expect(whys(`const x = describe('as any', () => {}) as any;`, 'node')).toContain(
+            '`as any` — banned repo-wide (CLAUDE.md)'
+        );
+    });
+
+    it('an escaped quote does not end the literal early', () => {
+        expect(whys(`const s = 'it\\'s as any, really';`, 'node')).toEqual([]);
+    });
+
+    it('carries an unterminated template literal to the next line', () => {
+        const stripped = stripCommentsAndStrings(['const s = `line one', 'still literal as any', '`; const y = z as any;']);
+        expect(stripped[1]).not.toContain('as any');
+        expect(stripped[2]).toContain('as any');
+    });
+
+    it('preserves line count and order so reported line numbers stay accurate', () => {
+        const src = `const a = 1;\nit('as any', () => {});\nconst b = c as any;\n`;
+        expect(lintText(src, 'node').map((f) => f.line)).toEqual([3]);
     });
 });
 

--- a/.github/scripts/__tests__/check-spec-antipatterns.test.mjs
+++ b/.github/scripts/__tests__/check-spec-antipatterns.test.mjs
@@ -49,6 +49,26 @@ describe('stripCommentsAndStrings — string literals are prose too', () => {
         expect(stripped[2]).toContain('as any');
     });
 
+    it('does not let an unterminated quote hide a real violation after it', () => {
+        // An apostrophe inside a regex is not a string opening — a single-quoted literal cannot
+        // span a line, so treating it as one would blank the rest and swallow the `as any`.
+        expect(whys(String.raw`const re = /don't/; const x = y as any;`, 'node')).toContain(
+            '`as any` — banned repo-wide (CLAUDE.md)'
+        );
+    });
+
+    it('an escaped backslash still closes the literal, so what follows is scanned', () => {
+        expect(whys(String.raw`const s = 'a\\'; const x = y as any;`, 'node')).toContain(
+            '`as any` — banned repo-wide (CLAUDE.md)'
+        );
+    });
+
+    it('a comment marker inside a string does not start a comment', () => {
+        expect(whys(`const s = '// as any'; const x = y as any;`, 'node')).toContain(
+            '`as any` — banned repo-wide (CLAUDE.md)'
+        );
+    });
+
     it('preserves line count and order so reported line numbers stay accurate', () => {
         const src = `const a = 1;\nit('as any', () => {});\nconst b = c as any;\n`;
         expect(lintText(src, 'node').map((f) => f.line)).toEqual([3]);

--- a/scripts/check-spec-antipatterns.mjs
+++ b/scripts/check-spec-antipatterns.mjs
@@ -109,8 +109,21 @@ export function walk(dir, acc = []) {
 }
 
 /** Strip `// …` line comments and (crudely, line-wise) `/* … *​/` block-comment interiors. */
-export function stripComments(lines) {
+/**
+ * Blanks comment bodies AND string-literal contents so a rule only ever matches real code.
+ *
+ * Comments were stripped from the start, for the reason the tests state: prose describing an
+ * anti-pattern must not trip the rule that bans it. String literals need the same treatment and
+ * did not get it, so a test TITLE was enough to fail the gate — `it('is false as soon as any
+ * count is positive')` matched the `as any` rule inside its own description. Same class of false
+ * positive for `: any` and `as never` in any sentence that happens to contain them.
+ *
+ * `${ ... }` inside a template literal is kept: that is code, and `` `${x as any}` `` is a real
+ * violation. Line count and order are preserved, so reported line numbers stay accurate.
+ */
+export function stripCommentsAndStrings(lines) {
   let inBlock = false;
+  let inTemplate = false;
   return lines.map((line) => {
     let out = '';
     let i = 0;
@@ -120,17 +133,84 @@ export function stripComments(lines) {
         if (end === -1) return out; // rest of line is comment
         inBlock = false;
         i = end + 2;
+      } else if (inTemplate) {
+        const scan = scanTemplate(line, i);
+        out += scan.out;
+        i = scan.next;
+        inTemplate = scan.stillOpen;
       } else if (line.startsWith('//', i)) {
         return out;
       } else if (line.startsWith('/*', i)) {
         inBlock = true;
         i += 2;
+      } else if (line[i] === "'" || line[i] === '"') {
+        i = skipQuoted(line, i + 1, line[i]);
+      } else if (line[i] === '`') {
+        const scan = scanTemplate(line, i + 1);
+        out += scan.out;
+        i = scan.next;
+        inTemplate = scan.stillOpen;
       } else {
         out += line[i++];
       }
     }
     return out;
   });
+}
+
+/**
+ * Index just past the closing `quote`, or end of line when the literal never closes.
+ * A backslash escapes the next character, so `'it\'s as any'` is one string, not two.
+ */
+function skipQuoted(line, start, quote) {
+  let i = start;
+  while (i < line.length) {
+    if (line[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (line[i] === quote) return i + 1;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Walks a template literal from `start`, dropping its literal text but KEEPING the contents of
+ * every `${ ... }` — real code lives in there, so `` `${x as any}` `` must still be flagged.
+ * `stillOpen` is true when the backtick did not close on this line, so the caller carries the
+ * state to the next one.
+ */
+function scanTemplate(line, start) {
+  let i = start;
+  let out = '';
+  while (i < line.length) {
+    if (line[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (line[i] === '`') return { out, next: i + 1, stillOpen: false };
+    if (line[i] === '$' && line[i + 1] === '{') {
+      i += 2;
+      let depth = 1;
+      while (i < line.length) {
+        const c = line[i];
+        if (c === '{') depth++;
+        else if (c === '}') {
+          depth--;
+          if (depth === 0) {
+            i++;
+            break;
+          }
+        }
+        out += c;
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return { out, next: i, stillOpen: true };
 }
 
 /** Is a `KNOWN LIMITATION` marker on the raw line itself or within the window above it? */
@@ -148,7 +228,7 @@ export function hasAdjacentKnownLimitation(rawLines, idx) {
 export function lintText(text, kind) {
   const rules = kind === 'dom' ? DOM_RULES : NODE_RULES;
   const raw = text.split('\n');
-  const code = stripComments(raw);
+  const code = stripCommentsAndStrings(raw);
   const findings = [];
   code.forEach((line, idx) => {
     for (const rule of rules) {

--- a/scripts/check-spec-antipatterns.mjs
+++ b/scripts/check-spec-antipatterns.mjs
@@ -120,6 +120,12 @@ export function walk(dir, acc = []) {
  *
  * `${ ... }` inside a template literal is kept: that is code, and `` `${x as any}` `` is a real
  * violation. Line count and order are preserved, so reported line numbers stay accurate.
+ *
+ * KNOWN LIMITATION: a template literal legitimately spans lines, so an unpaired backtick carries
+ * the "inside a literal" state to the end of the file and can mask findings after it. Single and
+ * double quotes get the opposite treatment — see skipQuoted — because those cannot span a line, so
+ * an unterminated one is an apostrophe rather than an opening. Erring toward a false NEGATIVE only
+ * where the language forces it.
  */
 export function stripCommentsAndStrings(lines) {
   let inBlock = false;
@@ -144,7 +150,15 @@ export function stripCommentsAndStrings(lines) {
         inBlock = true;
         i += 2;
       } else if (line[i] === "'" || line[i] === '"') {
-        i = skipQuoted(line, i + 1, line[i]);
+        const close = skipQuoted(line, i + 1, line[i]);
+        if (close === -1) {
+          // Never closed on this line, so it was not a string literal — an apostrophe in a
+          // regex (/don't/) or in an identifier reads this way. Emit it and keep scanning, or
+          // one stray quote would blank the rest of the line and hide a real violation.
+          out += line[i++];
+        } else {
+          i = close;
+        }
       } else if (line[i] === '`') {
         const scan = scanTemplate(line, i + 1);
         out += scan.out;
@@ -159,8 +173,13 @@ export function stripCommentsAndStrings(lines) {
 }
 
 /**
- * Index just past the closing `quote`, or end of line when the literal never closes.
- * A backslash escapes the next character, so `'it\'s as any'` is one string, not two.
+ * Index just past the closing `quote`, or -1 when it never closes on this line.
+ *
+ * A backslash escapes the next character, so `'it\'s as any'` is one string, not two. The -1 case
+ * matters as much as the success case: a single-quoted or double-quoted literal cannot span a line
+ * in practice, so an unterminated quote is an apostrophe in something else — a regex, a word — and
+ * treating it as a string opening would blank the remainder of the line and hide any real
+ * violation after it. The caller emits the character instead and carries on.
  */
 function skipQuoted(line, start, quote) {
   let i = start;
@@ -172,7 +191,7 @@ function skipQuoted(line, start, quote) {
     if (line[i] === quote) return i + 1;
     i++;
   }
-  return i;
+  return -1;
 }
 
 /**


### PR DESCRIPTION
The spec anti-pattern lint fails PRs for prose. `#4355` carries no `as any` and cannot merge.

## The gap

`scripts/check-spec-antipatterns.mjs` strips comment bodies before applying its rules, for the reason its own tests state — prose describing an anti-pattern must not trip the rule banning it:

```js
it('strips line comments so prose about an anti-pattern does not trip a rule', ...)
```

String literals never got the same treatment. So a test **title** is enough to fail the gate:

```ts
it('is false as soon as any count is positive', () => {
```

`/\bas\s+any\b/` matches "as soon **as any** count" inside the description. That is the whole of the `Source guards` failure on #4355 — the file contains no actual `as any`, and `Run unit tests` fails only because it aggregates lane results. All six shards, `Build` and the ESM guard pass there.

The same exposure exists for `: any` and `as never` in any sentence containing them.

## The fix

`stripComments` becomes `stripCommentsAndStrings`, blanking single-quoted, double-quoted and template-literal contents alongside comment bodies.

Three things it deliberately keeps:

- **`${ ... }` inside a template literal.** That is code, and `` `${x as any}` `` is a real violation.
- **Backslash escapes.** `'it\'s as any'` is one string, not two, so an apostrophe cannot end a literal early and expose the rest of the line.
- **Line count and order**, so reported line numbers stay accurate.

An unterminated template carries its state to the next line, the way the existing block-comment handling already does.

## Evidence

Eight regression tests, including the verbatim #4355 line, the template expression that must **still** flag, the escaped-quote case, and a multi-line template.

Verified directly rather than by inference:

| check | result |
|---|---|
| fixed gate against #4355's actual test file | clean |
| fixed gate still flags `const x = y as any;` | flags |
| `node scripts/check-spec-antipatterns.mjs packages` on `next` | clean, graced count unchanged at 259 |

So this unblocks #4355 with no change to that PR, and the graced allowlist neither grows nor shifts.

## No changeset

The branch touches `scripts/` and `.github/scripts/` only and ships no package code, so there is nothing to version. The nearest precedent (#4325) attached a nominal `@memberjunction/core: patch` to a CI fix; say the word if you would rather match that and have this appear in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
