### PR TITLE
fix(codegen): load persisted validators on every path, not just --skipdb

### DIFF
--- a/.changeset/codegen-load-persisted-validators-always.md
+++ b/.changeset/codegen-load-persisted-validators-always.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+CodeGen no longer deletes committed `Validate()` overrides when it runs without AI.
+
+`ManageMetadataBase.generatedValidators` — the list `GenerateValidateFunction` reads to emit each entity's `Validate()` override — was populated in only one of `runCodeGen`'s two branches. On the skip-database path `loadGeneratedCode` read the persisted `GeneratedCode` records; on the database-generation path the sole source was `runValidationGeneration`, which requires AI. File generation runs on both paths, so a full `mj codegen --no-ai` emitted the entity subclasses as though no validators existed and removed every committed override — not "declined to add new ones", deleted the existing ones.
+
+That is how v6.1.0-edge.5's 56 overrides disappeared in `197fdf8376`, a full regeneration whose commit message and changeset mention validation nowhere. The `codegen-drift` CI gate then held the loss in place, because it runs `codegen --no-ai` and requires the committed artifacts to match that output.
+
+Persisted validators are now loaded on every path, before file generation. Safe on the AI path too: `GenerateValidateFunction` already deduplicates by `functionName` over a deterministic sort, so a validator both freshly generated and read back from `GeneratedCode` yields one emission rather than two.

--- a/packages/CodeGenLib/src/runCodeGen.ts
+++ b/packages/CodeGenLib/src/runCodeGen.ts
@@ -468,17 +468,35 @@ export class RunCodeGenBase {
         }
       } else {
         warnSpinner('Skipping database generation (skip_database_generation = true)');
+      }
 
-        const manageMD = MJGlobal.Instance.ClassFactory.CreateInstance<ManageMetadataBase>(ManageMetadataBase)!;
-        startSpinner('Checking/Loading AI Generated Code from Metadata...');
-        const metadataSuccess = await reporter.phase('loadGeneratedCode', () => manageMD.loadGeneratedCode(conn, currentUser));
-        if (!metadataSuccess) {
-          failSpinner('ERROR checking/loading AI Generated Code from Metadata');
-          pipelineSuccess = false;
-          return false;
-        } else {
-          succeedSpinner('AI Generated Code loaded from Metadata');
-        }
+      // Persisted validators must reach file generation on EVERY path, not just the skip-DB one.
+      //
+      // File generation below runs for both branches, but `ManageMetadataBase.generatedValidators`
+      // — which `GenerateValidateFunction` reads to emit each entity's `Validate()` override — was
+      // only populated here, inside the `else`. On the database-generation path the sole source was
+      // `runValidationGeneration`, which needs AI. So a FULL `mj codegen --no-ai` emitted the entity
+      // subclasses as though no validators existed and silently DELETED every committed
+      // `Validate()` override — not "declined to add new ones", removed the existing ones.
+      //
+      // That is not hypothetical: it is how v6.1.0-edge.5's 56 overrides disappeared in 197fdf8376
+      // ("100% CodeGen idempotency, field change tracking, and churn elimination"), a full
+      // regeneration whose commit message and changeset mention validation nowhere. The
+      // `codegen-drift` CI gate then locked the loss in, because it runs `codegen --no-ai` and
+      // requires the committed file to match that lossy output.
+      //
+      // Loading unconditionally is safe on the AI path too: `GenerateValidateFunction` already
+      // deduplicates by `functionName` over a deterministic sort, so a validator both freshly
+      // generated and read back from `GeneratedCode` yields one emission, not two.
+      const manageMD = MJGlobal.Instance.ClassFactory.CreateInstance<ManageMetadataBase>(ManageMetadataBase)!;
+      startSpinner('Checking/Loading AI Generated Code from Metadata...');
+      const metadataSuccess = await reporter.phase('loadGeneratedCode', () => manageMD.loadGeneratedCode(conn, currentUser));
+      if (!metadataSuccess) {
+        failSpinner('ERROR checking/loading AI Generated Code from Metadata');
+        pipelineSuccess = false;
+        return false;
+      } else {
+        succeedSpinner('AI Generated Code loaded from Metadata');
       }
 
       const skipFiles = skipFileGeneration || getSettingValue('skip_file_generation', false);


### PR DESCRIPTION
## Why this is needed now

`next` currently has the 56 restored `Validate()` overrides (from #4362) but **not** this fix — so the **CodeGen drift gate fails on `next`** until this lands. That gate is the one check that failed on #4362.

## The bug

A full `mj codegen --no-ai` **silently deleted every committed `Validate()` override** from the generated entity subclasses. Not "declined to add new ones" — removed the ones already there.

`runCodeGen` has two branches, and **file generation runs for both**, but the validator list was populated in only one:

```
skip-database path  →  loadGeneratedCode(...)   reads persisted GeneratedCode records
database-gen path   →  runValidationGeneration  requires AI
```

So on the database-generation path with `--no-ai`, `ManageMetadataBase.generatedValidators` stayed empty and `GenerateValidateFunction` emitted every entity as though it had no validators.

This is the mechanism behind the `v6.1.0-edge.5` → `next` regression: `197fdf8376` ("100% CodeGen idempotency, field change tracking, and churn elimination") was a full regeneration that dropped all 57 overrides, with validation mentioned **nowhere** in its commit message or changeset.

**The gate then locked the loss in.** `codegen-drift` runs `codegen --no-ai --skip-commands` and requires committed artifacts to match that output — so *restoring* the validators failed CI while *deleting* them passed. The safety net was holding the bug in place.

## The fix

Hoist the load out of the `else` so persisted validators reach file generation on **every** path. This removes the special case rather than adding one: file generation is what consumes the list, so the list is now populated unconditionally before it.

Safe on the AI path too — `GenerateValidateFunction` already deduplicates by `functionName` over a deterministic sort, so a validator both freshly generated and read back from `GeneratedCode` yields one emission, not two.

## Proven locally, using the drift gate's own commands

```
node packages/MJCLI/bin/run.js codegen --no-ai --skip-commands
   ✔ "AI Generated Code loaded from Metadata"   ← now runs on the database-gen path
   git diff on __mj.ts → EMPTY                   ← was: 56 overrides deleted
   56 validators retained; no other file changed

node scripts/codegen-idempotency-check.mjs --stage warm-twice --no-ai --skip-first-run
   ✅ PASSED: 0 diffs, 0 surviving SQL logs, 0 changed fields

@memberjunction/codegen-lib unit tests
   1409 passed, 0 failed (66 skipped)
```

The idempotency result is the one that matters for safety: loading unconditionally could have made CodeGen non-idempotent, and warm-twice says it didn't.

## Reviewer note

This touches `runCodeGen.ts` — a core package with wide blast radius. The change is small (one step moved out of an `if/else`) and guarded by existing dedup, but it deserves eyes on the branch structure specifically rather than being read as a routine fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdSozdvJ1MbZqC1sUTUChv
