### PR TITLE
fix(metadata-sync,ci): clear next's compliance violations, and stop the gate that should have caught them from being cached away

### DIFF
--- a/.changeset/metadatasync-compliance-and-scanner-cache.md
+++ b/.changeset/metadatasync-compliance-and-scanner-cache.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/metadata-sync": patch
+---
+
+fix(metadata-sync): compare entity IDs with `UUIDsEqual` in the IS-A subtype checks, and allowlist the one remaining global-provider read. `RecordProcessor.buildSubtypeExtension` and four sites in `ValidationService` compared `EntityInfo.ParentID` / `ParentEntityInfo.ID` against `EntityInfo.ID` with `===`, which is case-sensitive: SQL Server returns UUIDs uppercase and PostgreSQL lowercase, so a subtype resolved on one database could fail to resolve on the other and be reported as an unregistered or non-subtype entity. The `Metadata.Provider` read in `RecordProcessor` now carries the same `global-provider-ok` note the rest of the package uses — MetadataSync is a single-provider CLI process.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,6 +188,28 @@ jobs:
         if: ${{ !cancelled() }}
         run: node .github/scripts/check-mj-cli-resolution.mjs packages
 
+      # Repo-wide compliance scanners. They live in packages/MJGlobal/src/__tests__ for historical
+      # reasons but scan `packages/**` off disk and assert about every package, so they belong here
+      # rather than in MJGlobal's per-package `test` task: turbo caches that task on MJGlobal's own
+      # `src/**`, which means a violation introduced in ANY other package left the cached pass valid
+      # and the scan never re-ran. #4317's MetadataSync violations rode `next` from 2026-09-09 that
+      # way, surfacing only when #4343 happened to edit MJGlobal and bust its cache. Run here they
+      # are uncached and unconditional, so a violation fails the PR that introduces it.
+      # They import only vitest/fs/path — no build, no MJGlobal source.
+      #
+      # Uses the SHARED vitest config on purpose: MJGlobal's own config excludes these two files
+      # (that is the other half of this fix), so pointing at it here would match nothing. And
+      # `--passWithNoTests=false` overrides the shared default, so if these paths are ever renamed
+      # this step fails loudly instead of quietly passing with zero tests and disabling the gate.
+      - name: Repo-wide compliance scans (UUID + multi-provider)
+        if: ${{ !cancelled() }}
+        run: >-
+          pnpm --filter @memberjunction/global exec vitest run
+          --config ../../vitest.shared.ts
+          --passWithNoTests=false
+          src/__tests__/UUIDCompliance.test.ts
+          src/__tests__/MultiProviderCompliance.test.ts
+
       - name: Generic DOM coverage ratchet
         if: ${{ !cancelled() }}
         run: node scripts/dom-test-report.mjs packages/Angular/Generic --max-none=134

--- a/packages/MJGlobal/vitest.config.ts
+++ b/packages/MJGlobal/vitest.config.ts
@@ -6,6 +6,23 @@ export default mergeConfig(
   defineProject({
     test: {
       environment: 'node',
+      // The two repo-wide compliance scanners that live in this folder are NOT unit tests of
+      // MJGlobal — they read `packages/**` off disk (`SCAN_ROOT = .../packages`) and assert about
+      // every package in the monorepo. Run as part of this package's `test` task they were
+      // effectively disabled: turbo caches `test` on `inputs: src/**` of THIS package, so a
+      // violation introduced anywhere else left the cached pass valid and the scan replayed
+      // ("cache hit, replaying logs") instead of running. They then fired only when MJGlobal's own
+      // source happened to change, dropping an unrelated author into someone else's debt — which
+      // is how #4317's violations sat on `next` from 2026-09-09 until #4343 touched this package.
+      //
+      // They now run in the `Source guards` CI job: uncached, on every PR, next to the other gates
+      // that read source text rather than build output. Excluded here so the cached per-package
+      // task tests only what its cache key actually covers.
+      exclude: [
+        ...(sharedConfig.test?.exclude ?? []),
+        'src/__tests__/UUIDCompliance.test.ts',
+        'src/__tests__/MultiProviderCompliance.test.ts',
+      ],
     },
   })
 );

--- a/packages/MetadataSync/src/lib/RecordProcessor.ts
+++ b/packages/MetadataSync/src/lib/RecordProcessor.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, CompositeKey, EntityInfo, Metadata, RunView, UserInfo } from '@memberjunction/core';
-import { ordinalCompare } from '@memberjunction/global';
+import { ordinalCompare, UUIDsEqual } from '@memberjunction/global';
 import { SyncEngine, RecordData } from '../lib/sync-engine';
 import { EntityConfig } from '../config';
 import { JsonWriteHelper } from './json-write-helper';
@@ -706,9 +706,10 @@ export class RecordProcessor {
     }
 
     // Determine if child type is ambiguous (more than one subtype exists in metadata)
-    const childSubtypes = Metadata.Provider?.Entities
-      ? Metadata.Provider.Entities.filter(
-          (e) => e.ParentID === record.EntityInfo.ID || e.ParentEntityInfo?.ID === record.EntityInfo.ID
+    const provider = Metadata.Provider; // global-provider-ok: MetadataSync is a single-provider CLI process
+    const childSubtypes = provider?.Entities
+      ? provider.Entities.filter(
+          (e) => UUIDsEqual(e.ParentID, record.EntityInfo.ID) || UUIDsEqual(e.ParentEntityInfo?.ID, record.EntityInfo.ID)
         )
       : [];
     const needsEntityName = childSubtypes.length > 1 || record.EntityInfo.AllowMultipleSubtypes;

--- a/packages/MetadataSync/src/services/ValidationService.ts
+++ b/packages/MetadataSync/src/services/ValidationService.ts
@@ -1,4 +1,5 @@
 import { EntityFieldInfo, EntityInfo, EntityRelationshipInfo, Metadata, RunView } from '@memberjunction/core';
+import { UUIDsEqual } from '@memberjunction/global';
 import * as fs from 'fs';
 import * as path from 'path';
 import { minimatch } from 'minimatch';
@@ -376,7 +377,7 @@ export class ValidationService {
         // Section 4.5 diagnostics:
         // Check if related entity looks like an IsA child (shared PK / ParentID is this entity)
         if (
-          relatedEntityInfo.ParentID === entityInfo.ID ||
+          UUIDsEqual(relatedEntityInfo.ParentID, entityInfo.ID) ||
           (relatedEntityInfo.ParentEntityInfo && relatedEntityInfo.ParentEntityInfo.Name.trim().toLowerCase() === entityInfo.Name.trim().toLowerCase())
         ) {
           this.addWarning({
@@ -1700,7 +1701,7 @@ export class ValidationService {
       } else {
         // Look up registered subtypes
         const childSubtypes = this.metadata.Entities.filter(
-          (e) => e.ParentID === parentEntityInfo.ID || e.ParentEntityInfo?.ID === parentEntityInfo.ID
+          (e) => UUIDsEqual(e.ParentID, parentEntityInfo.ID) || UUIDsEqual(e.ParentEntityInfo?.ID, parentEntityInfo.ID)
         );
         if (childSubtypes.length === 1) {
           childEntityName = childSubtypes[0].Name;
@@ -1742,8 +1743,8 @@ export class ValidationService {
       }
 
       const isSubtype =
-        childEntityInfo.ParentID === parentEntityInfo.ID ||
-        childEntityInfo.ParentEntityInfo?.ID === parentEntityInfo.ID;
+        UUIDsEqual(childEntityInfo.ParentID, parentEntityInfo.ID) ||
+        UUIDsEqual(childEntityInfo.ParentEntityInfo?.ID, parentEntityInfo.ID);
       if (!isSubtype) {
         this.addError({
           type: 'entity',
@@ -1782,8 +1783,8 @@ export class ValidationService {
       }
 
       const isSubtype =
-        childEntityInfo.ParentID === parentEntityInfo.ID ||
-        childEntityInfo.ParentEntityInfo?.ID === parentEntityInfo.ID;
+        UUIDsEqual(childEntityInfo.ParentID, parentEntityInfo.ID) ||
+        UUIDsEqual(childEntityInfo.ParentEntityInfo?.ID, parentEntityInfo.ID);
       if (!isSubtype) {
         this.addError({
           type: 'entity',


### PR DESCRIPTION
## Summary

`next` has been carrying 9 compliance violations since 2026-09-09. They are cleared here — but the violations are the smaller half of this PR. The gate that was supposed to catch them had been cached away, which is why nobody saw them for a day and a half.

Found while re-reviewing #4343, which is red through no fault of its own.

## Why the gate went quiet

`UUIDCompliance` and `MultiProviderCompliance` live in `packages/MJGlobal/src/__tests__`, but they are not unit tests of MJGlobal. They set `SCAN_ROOT` to `packages/`, read the whole monorepo off disk, and assert about every package in it. Their only imports are `vitest`, `fs`, and `path`.

They ran as part of MJGlobal's per-package `test` task. Turbo caches that task on:

```jsonc
"test": { "inputs": ["src/**/*.ts", "src/**/__tests__/**", "vitest.config.*", ...] }
```

Package-local. The cache key is blind to every file the scan actually reads. A violation introduced anywhere else leaves the cached pass valid, and CI replays it rather than re-running the scan — on `next`'s own run the log reads, literally:

```
##[group]@memberjunction/global:test
cache hit, replaying logs a0c866c68423a1a8
```

The PR filter closes the other half of the trap. PR runs use `--filter=...[origin/next]`, so a PR that does not touch MJGlobal skips the task entirely. Between the two, the only way to make these scanners run was to edit MJGlobal.

That is exactly what happened. #4317 (merged Sep 9) introduced the violations in MetadataSync and touched no MJGlobal file, so its own run never scanned. Every run since replayed the stale pass. #4343 is the first PR to modify MJGlobal's source since then; it busted the hash, the scanners ran for real, and an author who touched none of this inherited someone else's debt.

## The fix, both halves

- **The scanners move to the `Source guards` job** — uncached, unconditional, on every PR, beside the other gates that read source text rather than build output. That job's own comment already states the property these needed: *"this job never waits on, and can never be silenced by, the build."* They need no build.
- **They are excluded from MJGlobal's vitest config**, so the cached per-package task tests only what its cache key actually covers.

Two details in the CI step that are deliberate:

- It points at the **shared** vitest config, not MJGlobal's — MJGlobal's now excludes these two files, so aiming at it would match nothing.
- It passes `--passWithNoTests=false`. `vitest.shared.ts` sets `passWithNoTests: true`, so a future rename would otherwise make this step exit 0 with zero tests and silently disable the gate again. I confirmed that failure mode exists before guarding it:

```
$ vitest run --config ../../vitest.shared.ts src/__tests__/TYPO_DoesNotExist.test.ts
No test files found, exiting with code 0
```

## The violations themselves

- `RecordProcessor.buildSubtypeExtension` and four sites in `ValidationService` compared `EntityInfo.ParentID` / `ParentEntityInfo.ID` against `EntityInfo.ID` with `===`. SQL Server returns UUIDs uppercase and PostgreSQL lowercase, so a subtype that resolves on one database could fail to resolve on the other and be reported as unregistered or not-a-subtype. Now `UUIDsEqual`, which is what the gate asks for and is also correct on the merits.
- The `Metadata.Provider` read in `RecordProcessor` now carries the same `global-provider-ok` note the other 11 sites in this package already use — MetadataSync is a single-provider CLI process. Consistent with `RecordProcessor.ts:784`, four lines of which were already annotated that way.

## Verification

| Check | Result |
| --- | --- |
| Both scanners against the fixed tree | 2/2 pass |
| **Both scanners with a violation deliberately reintroduced** | **fails — `Found 1 direct UUID comparison(s)`, so the gate is not vacuous** |
| MJGlobal suite | 871/871 in 31 files, scanners correctly excluded |
| MetadataSync build | clean (`tsc -b`) |
| MetadataSync suite | 364/364 in 22 files |
| `--passWithNoTests=false` on a bogus path | exits 1 |
| `npm run check:changeset` | bump levels correct |
| `.github/workflows/test.yml` | parses; step resolves under the `guards` job |

The negative test is the one that matters: without it this PR could have wired a gate that always passes.

## Unblocks

#4343, which is red only because it is the messenger. Once this lands and #4343 merges `next`, its shard 3 goes green with no change on its side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
