### PR TITLE
fix(codegen): reading persisted validators is a DB read, not an AI call

### DIFF
--- a/.changeset/codegen-validator-load-not-gated-on-ai.md
+++ b/.changeset/codegen-validator-load-not-gated-on-ai.md
@@ -1,0 +1,24 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+CodeGen: reading persisted validators is a database read, not an AI call — stop gating it on the AI feature flag.
+
+`mj codegen --no-ai` emitted every entity subclass as though it had no `Validate()` override, silently
+DELETING the ones already committed. `loadGeneratedCode` reached
+`manageEntityFieldValuesAndValidatorFunctions`, but both call sites that queue a validator sat behind
+`ag.featureEnabled('ParseCheckConstraints')` — and `--no-ai` sets `enableAdvancedGeneration = false`, so
+that predicate is false. The method still returned `true` and the spinner still reported success, having
+loaded nothing.
+
+The read never needed AI: it is called with `generateNewCode = false`, and
+`generateValidatorFunctionFromCheckConstraint` only reaches an LLM when that flag is true. The load pass
+is now unconditional; generation stays gated exactly as before.
+
+This is the second half of the `v6.1.0-edge.5` regression. The first half (loading only on the `--skipdb`
+branch) was fixed separately; with the load reachable but inert under `--no-ai`, a full run still dropped
+all 56 overrides — and the `codegen-drift` gate, which runs `--no-ai`, required that lossy output, so
+restoring the validators failed CI while deleting them passed.
+
+Also: the success line now reports how many validators were loaded, so a zero-load run is visible in CI
+output rather than indistinguishable from a healthy one.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -716,6 +716,16 @@ jobs:
           if [ -s /tmp/drift.txt ]; then
             echo "::error::CodeGen output DIFFERS from committed artifacts (drift). Files:"
             cat /tmp/drift.txt
+            # A filename alone does not say WHAT moved, and these artifacts are megabytes — so the
+            # only way to act on this failure used to be reproducing the whole job locally. Emit the
+            # shape of the change (per-file +/-) and a bounded excerpt instead. Bounded because a
+            # full regeneration of __mj.ts is ~100k lines and would bury the log.
+            git diff --stat -- packages/ metadata/ migrations/ > /tmp/drift-stat.txt || true
+            git diff -- packages/ metadata/ migrations/ | head -c 100000 > /tmp/drift-diff.txt || true
+            echo "--- change shape ---"
+            cat /tmp/drift-stat.txt
+            echo "--- first 100KB of diff ---"
+            cat /tmp/drift-diff.txt
             exit 1
           fi
           echo "No drift — committed generated artifacts match a clean-DB CodeGen run."
@@ -735,6 +745,16 @@ jobs:
               echo '```'
               cat /tmp/drift.txt
               echo '```'
+            fi
+            if [ -s /tmp/drift-stat.txt ]; then
+              echo ''
+              echo '<details><summary>What changed</summary>'
+              echo ''
+              echo '```'
+              cat /tmp/drift-stat.txt
+              echo '```'
+              echo ''
+              echo '</details>'
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -840,6 +860,16 @@ jobs:
           if [ -s /tmp/drift.txt ]; then
             echo "::error::CodeGen output DIFFERS from committed artifacts (drift). Files:"
             cat /tmp/drift.txt
+            # A filename alone does not say WHAT moved, and these artifacts are megabytes — so the
+            # only way to act on this failure used to be reproducing the whole job locally. Emit the
+            # shape of the change (per-file +/-) and a bounded excerpt instead. Bounded because a
+            # full regeneration of __mj.ts is ~100k lines and would bury the log.
+            git diff --stat -- packages/ metadata/ migrations/ > /tmp/drift-stat.txt || true
+            git diff -- packages/ metadata/ migrations/ | head -c 100000 > /tmp/drift-diff.txt || true
+            echo "--- change shape ---"
+            cat /tmp/drift-stat.txt
+            echo "--- first 100KB of diff ---"
+            cat /tmp/drift-diff.txt
             exit 1
           fi
           echo "No drift — committed generated artifacts match a clean-DB CodeGen run."
@@ -859,5 +889,15 @@ jobs:
               echo '```'
               cat /tmp/drift.txt
               echo '```'
+            fi
+            if [ -s /tmp/drift-stat.txt ]; then
+              echo ''
+              echo '<details><summary>What changed</summary>'
+              echo ''
+              echo '```'
+              cat /tmp/drift-stat.txt
+              echo '```'
+              echo ''
+              echo '</details>'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -5471,6 +5471,15 @@ export class ManageMetadataBase {
          const generationPromises = [];
          const ag = new AdvancedGeneration();
 
+         // `skipDBUpdate` means load-only: `runValidationGeneration` is called below with
+         // `generateNewCode = false`, and `generateValidatorFunctionFromCheckConstraint` only reaches an
+         // LLM when that flag is true. Reading a validator back out of an Approved `GeneratedCode` record
+         // is therefore a plain database read — gating it on the AI feature flag is what made
+         // `mj codegen --no-ai` DELETE every committed `Validate()` override rather than preserve it, and
+         // the `codegen-drift` gate (which runs `--no-ai`) then demanded that lossy output. Generation
+         // stays gated; only the read is unconditional.
+         const emitValidators = skipDBUpdate || ag.featureEnabled('ParseCheckConstraints');
+
          const columnLevelResults = result.filter((r: any) => r.EntityFieldID); // get the column level constraints
          const tableLevelResults = result.filter((r: any) => !r.EntityFieldID); // get the table level constraints
          for (const r of columnLevelResults) {
@@ -5507,8 +5516,8 @@ export class ManageMetadataBase {
                else {
                   // if we get here that means we don't have a simple condition in the check constraint that the RegEx could parse. If Advanced Generation is enabled, we will
                   // attempt to use an LLM to do things fancier now
-                  if (ag.featureEnabled('ParseCheckConstraints')) {
-                     // the user has the feature turned on, let's generate a description of the constraint and then build a Validate function for the constraint 
+                  if (emitValidators) {
+                     // either we are loading persisted validators, or the feature is on and we may generate new ones
                      // run this in parallel
                      generationPromises.push(this.runValidationGeneration(r, allEntityFields, !skipDBUpdate, currentUser));
                   }
@@ -5518,8 +5527,8 @@ export class ManageMetadataBase {
 
          // now for the table level constraints run the process for advanced generation
          for (const r of tableLevelResults) {
-            if (ag.featureEnabled('ParseCheckConstraints')) {
-               // the user has the feature turned on, let's generate a description of the constraint and then build a Validate function for the constraint 
+            if (emitValidators) {
+               // either we are loading persisted validators, or the feature is on and we may generate new ones
                // run this in parallel
                generationPromises.push(this.runValidationGeneration(r, allEntityFields, !skipDBUpdate, currentUser));
             }

--- a/packages/CodeGenLib/src/runCodeGen.ts
+++ b/packages/CodeGenLib/src/runCodeGen.ts
@@ -496,7 +496,13 @@ export class RunCodeGenBase {
         pipelineSuccess = false;
         return false;
       } else {
-        succeedSpinner('AI Generated Code loaded from Metadata');
+        // Report the COUNT, not just success. Loading zero validators is a legitimate state for a
+        // database that has none, and an invisible catastrophe for one that has plenty: file
+        // generation emits each entity as though it had no `Validate()` override, silently deleting
+        // whatever was committed. Both times that regression shipped, the log said exactly this
+        // line and nothing else. A number here makes the next one visible in CI output.
+        const loadedValidators = ManageMetadataBase.generatedValidators.length;
+        succeedSpinner(`AI Generated Code loaded from Metadata (${loadedValidators} validator${loadedValidators === 1 ? '' : 's'})`);
       }
 
       const skipFiles = skipFileGeneration || getSettingValue('skip_file_generation', false);


### PR DESCRIPTION
Closes the `codegen-drift` failure on `next` @ `57975fdaee`.

## What was still broken

`#4370` fixed one gate in front of the validator load. There were two.

| | |
|---|---|
| Gate 1 — fixed in #4370 | `loadGeneratedCode` was reachable only on the `--skipdb` branch |
| **Gate 2 — this PR** | both call sites that queue a validator sit behind `ag.featureEnabled('ParseCheckConstraints')`, and `--no-ai` sets `enableAdvancedGeneration = false` |

So after #4370 the load *ran*, returned `true`, printed `✔ AI Generated Code loaded from Metadata` — and loaded **zero**. The drift gate runs `--no-ai`, so CI kept emitting `__mj.ts` with none of the 56 `Validate()` overrides, and the gate required that lossy output: restoring the validators failed CI while deleting them passed.

Independent confirmation of the direction: the gate ran genuinely green on `next` up to `6ac6bcc5ca`, when the file had **0** validators, and went red the moment the 56 were committed.

## Why the read never needed AI

The load calls `runValidationGeneration(..., generateNewCode = !skipDBUpdate = false, ...)`, and `generateValidatorFunctionFromCheckConstraint` only reaches an LLM when that flag is true. An AI feature flag was gating a plain database read of Approved `GeneratedCode` records.

```ts
const emitValidators = skipDBUpdate || ag.featureEnabled('ParseCheckConstraints');
```

The load-only pass is unconditional; **generation stays gated exactly as before**. This removes the special case rather than adding one.

## Why the previous proof was wrong

#4370's local verification was vacuous, and it is worth recording so it doesn't recur. Per-schema emit (#3804) rebuilds only **dirty** schemas, and on an already-migrated database nothing is dirty — so `__mj.ts` was never written. The empty `git diff` meant nothing was generated, not that the output matched. The file's mtime stayed at `12:44` through a `16:43` codegen run.

**An empty `git diff` after CodeGen is not evidence unless the artifact's mtime moved.**

## Verification

Throwaway database built by the drift gate's own steps — `migrate` → `sync push --dir=metadata --ci` → `codegen --no-ai --skip-commands`. 78 migrations, 383 entities, `unchanged: 14089` — identical to the CI job.

| scenario | validators loaded | `Validate()` overrides | size | drift |
|---|---|---|---|---|
| forced emit, before fix | 0 | 0 | 4,522,259 | **`M __mj.ts`** |
| forced emit, after fix | 116 | 56 | 4,661,490 | none |
| **artifact deleted + full run** | 116 | 56 | 4,661,490 | none |

The last row is the strict case: deleting the artifact makes the emit unskippable, and it regenerated **byte-identical** to what is committed.

- `codegen-idempotency-check --stage warm-twice` → PASSED (0 diffs, 0 surviving SQL logs, 0 changed fields)
- `codegen-idempotency-check --stage single-column` → PASSED
- `@memberjunction/codegen-lib` unit tests → **1409 passed**, 0 failed (66 skipped)

## Second commit — CI diagnostics only

Both drift gates reported a filename and nothing else, so acting on the failure meant reproducing the whole job locally to see a diff CI already had. They now print `git diff --stat` plus a bounded 100 KB excerpt.

**This does not touch pass/fail.** Every added line sits inside the block that has already decided to fail, after the error and before the unchanged `exit 1`; the comparison and its condition are untouched, and on a green run none of it executes. Reverting that commit would still leave this branch green.

## Changeset

`patch` — this branch touches no migration and no metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdSozdvJ1MbZqC1sUTUChv
