### PR TITLE
fix(migrations): drop literal EntityField Sequence from Conversation_Scoped_Skill_Activation

### DIFF
--- a/.changeset/entityfield-literal-sequence-conversation-skills.md
+++ b/.changeset/entityfield-literal-sequence-conversation-skills.md
@@ -1,0 +1,21 @@
+---
+"@memberjunction/core-entities": minor
+---
+
+Migration `V202609031400__v6.1.x__Conversation_Scoped_Skill_Activation` no longer inserts `EntityField` rows with a literal `Sequence`.
+
+Twelve `EntityField` INSERTs carried literal sequence numbers (1–11 on `MJ: Conversation Skills`, 14 on `MJ: AI Skills`). Each was preceded by the `+100000` sequence park, which is why a from-scratch `mj migrate` still succeeds today — but the park is the mechanism `#4292` removed, and its own changeset records why: it "could be made idempotent within one run but not across two migrations replayed on a fresh database." Its `NOT EXISTS (Sequence >= 100000)` guard makes a *second* migration's park a silent no-op, and the next literal insert then collides on `UQ_EntityField_EntityID_Sequence` — surfacing as an unrelated foreign-key error against `EntityFieldValue`, and only ever on a fresh install.
+
+The literals are replaced with the apply-time expression CodeGen now emits, one per INSERT:
+
+```sql
+(SELECT COALESCE(MAX([Sequence]), 0) + 1
+   FROM [${flyway:defaultSchema}].[EntityField]
+  WHERE [EntityID] = '<entity-id>')
+```
+
+The parks are left in place, matching `V202609081111__v6.1.x__Entity_SubtypeSelector`, which already pairs a park with an apply-time expression. Park-plus-expression is safe where park-plus-literal was not: `MAX + 1` avoids a collision whatever the park did.
+
+This migration merged to `next` on 2026-09-03; the CI gate that detects the pattern landed on 2026-09-08, and it diffs against the PR's base — so on PRs into `next` the file is already present and invisible to it. It surfaces for the first time on a release PR into `main`, which is where it was caught.
+
+No behaviour change on a fresh install: verified that the resulting sequences are identical, because the repeatable renumber normalises them either way.

--- a/migrations/v6/V202609031400__v6.1.x__Conversation_Scoped_Skill_Activation.sql
+++ b/migrations/v6/V202609031400__v6.1.x__Conversation_Scoped_Skill_Activation.sql
@@ -308,7 +308,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '5be7bba0-3d9c-46d2-aa89-12b159defbe6',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            1,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'ID',
             'ID',
             NULL,
@@ -371,7 +371,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '56693a11-25d6-48f4-90d7-ecb1a850d4d7',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            2,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'ConversationID',
             'Conversation ID',
             'The conversation the skill is active in.',
@@ -434,7 +434,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '88f0e3c9-f8bd-4a69-b51c-9bdd61e695d0',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            3,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'SkillID',
             'Skill ID',
             'The skill (AISkill.ActivationScope = Conversation) held active.',
@@ -497,7 +497,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '1fc1d01a-1f6f-4492-a2b2-be5e4384a5f3',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            4,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'Status',
             'Status',
             'Active: re-requested on every root run in the conversation. Ended: history — the mode was left; a later activation re-uses the row and sets it Active again.',
@@ -560,7 +560,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '70fc39bb-0302-47c4-bab2-b931466e1e6a',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            5,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'ActivatedByRunID',
             'Activated By Run ID',
             'The agent run in which the skill was (most recently) activated — provenance for the Active row.',
@@ -623,7 +623,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             'f84c2254-12d2-438c-8434-aa37db8357b1',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            6,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'EndedAt',
             'Ended At',
             'When the mode was left. NULL while Active.',
@@ -686,7 +686,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             'bdc50332-0960-4d12-96a7-7088bbccabca',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            7,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             '__mj_CreatedAt',
             'Created At',
             NULL,
@@ -749,7 +749,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '17d857de-a44c-4351-b551-077362545765',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            8,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             '__mj_UpdatedAt',
             'Updated At',
             NULL,
@@ -821,7 +821,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '7184d031-59ee-42c1-8b55-d70abe05eb11',
             '1D52DE84-DD3F-4E46-8D2B-574B70080BB4', -- Entity: MJ: AI Skills
-            14,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = '1D52DE84-DD3F-4E46-8D2B-574B70080BB4'),
             'ActivationScope',
             'Activation Scope',
             'How long an activation lasts. Run (default): the skill is active for the run that activated it and no longer — a one-shot capability. Conversation: once activated in a run that belongs to a conversation, the skill stays active for that conversation (an MJ: Conversation Skills row, Status Active) and is re-requested at the start of every later root run there until ended — a persona, or a mode whose menu is pressed on the next turn. Subject to every availability gate on each run; ActivationMode still decides who may trigger the FIRST activation.',
@@ -2666,7 +2666,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '63782154-4994-44a9-826b-59ddd9b0e1c8',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            9,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'Conversation',
             'Conversation',
             NULL,
@@ -2729,7 +2729,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '8f4ef253-724b-49ea-a771-32d40cfce6a8',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            10,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'Skill',
             'Skill',
             NULL,
@@ -2792,7 +2792,7 @@ UPDATE [${flyway:defaultSchema}].[EntityField]
          (
             '5b64deaa-b6d6-40f7-820d-3cee8ea92514',
             'D2021771-50D7-4E0F-A2A8-27AC37E01B34', -- Entity: MJ: Conversation Skills
-            11,
+            (SELECT COALESCE(MAX([Sequence]), 0) + 1 FROM [${flyway:defaultSchema}].[EntityField] WHERE [EntityID] = 'D2021771-50D7-4E0F-A2A8-27AC37E01B34'),
             'ActivatedByRun',
             'Activated By Run',
             NULL,


### PR DESCRIPTION
**Found while preparing the `v6.1.0-edge.6` release. This would have blocked the release PR into `main`.**

## What's wrong

`V202609031400__v6.1.x__Conversation_Scoped_Skill_Activation` inserts 12 `EntityField` rows with a **literal `Sequence`** — 1–11 on `MJ: Conversation Skills`, 14 on `MJ: AI Skills`.

Each INSERT is preceded by the `+100000` sequence park, which is why a from-scratch `mj migrate` still succeeds today. But the park is the mechanism **#4292 removed**, and its own changeset says why:

> The park could be made idempotent within one run **but not across two migrations replayed on a fresh database**; CodeGen now emits an apply-time `MAX(Sequence)` expression instead.

Its `NOT EXISTS (Sequence >= 100000)` guard makes a *second* migration's park a silent no-op, and the next literal insert then collides on `UQ_EntityField_EntityID_Sequence`. Without `SET XACT_ABORT ON` that surfaces later as an unrelated FK error against `EntityFieldValue` — and only ever on a fresh install, never on a working dev database.

## Why it surfaced only now

The migration merged to `next` on **2026-09-03**. The gate that detects the pattern landed **2026-09-08** (#4292). `changes.yml` diffs against `pull_request.base.ref`, so on a PR into `next` this file is already on the base and invisible to it. It is only ever scanned against `main` — on a release PR. I hit it running that comparison locally while cutting edge.6.

## The fix

The literals become the apply-time expression CodeGen now emits, one per INSERT:

```sql
(SELECT COALESCE(MAX([Sequence]), 0) + 1
   FROM [${flyway:defaultSchema}].[EntityField]
  WHERE [EntityID] = '<entity-id>')
```

**The parks are deliberately left in place**, matching `V202609081111__v6.1.x__Entity_SubtypeSelector`, which already pairs a park with an apply-time expression. Park-plus-expression is safe where park-plus-literal was not: `MAX + 1` cannot collide whatever the park did or skipped. Leaving them also keeps the diff to the 12 value lines.

## Verified — no behaviour change

Two databases built from scratch with `mj migrate` (78 migrations each), one on the original file and one on this commit:

| | original | this commit |
|---|---|---|
| `MJ: Conversation Skills` | 11 fields, seqs `1..11` | 11 fields, seqs `1..11` |
| `MJ: AI Skills`.`ActivationScope` | 14 | 14 |
| parked rows (`>= 100000`) | 0 | 0 |

Identical — the repeatable renumber normalises the sequences either way. This removes a latent fresh-install collision without altering any outcome.

`check-migration-entityfield-sequence.mjs` now **passes** (was: 12 findings).

## Note on the PostgreSQL counterpart — deliberately not touched

`migrations-pg/v6/V202609031400__…pg.sql` mirrors the same literals. I left it alone:

- The gate scans `migrations/` only, so nothing is blocked by it.
- Both dialects produce **identical** sequences today — the risk is latent in both, and pre-existing in both.
- That file is `--split --bake-codegen` output and says so at the top; regenerating it needs a live PG database seeded to the state immediately before this migration, and per `migrations/CLAUDE.md` PG is converter territory, not hand-authored.

Happy to regenerate it as release-time toolchain work if you'd rather have the two dialects converge now — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdSozdvJ1MbZqC1sUTUChv
