### PR TITLE
docs(cerebras, ms-graph): correct two comments that describe code that is not there

### DIFF
--- a/.changeset/cerebras-narrowing-comment-correction.md
+++ b/.changeset/cerebras-narrowing-comment-correction.md
@@ -1,0 +1,12 @@
+---
+"@memberjunction/ai-cerebras": patch
+"@memberjunction/communication-ms-graph": patch
+---
+
+Correct two comments that state things the code does not do.
+
+`cerebras.ts` claimed `ChatCompletion` is not a union at the pinned SDK version and framed the narrowing as fixing a latent break that arrives with a future lockfile refresh. It is a union at 1.64.1 — the version the lockfile pins — and always has been; the original code coped by casting at each of the three reads, and the change replaced those with one narrowing at the declaration. The comment now says that, and explains why the reads collapse to `unknown` on the bare union (`ErrorChunkResponse` declares only `error` and `status_code`, and every member carries an index signature). The retained `usage` cast is removed with them: it was kept on the stated grounds that `usage` is nullable on the narrowed member, which is not true at 1.64.1 where it is required.
+
+`MSGraphProvider.ts` said Reply reads `ContextData.Email` "as eleven sibling operations already read it". Nine do.
+
+No behaviour change: the removed cast was a no-op on the pinned SDK, and the rest is comment text.

--- a/packages/AI/Providers/Cerebras/src/models/cerebras.ts
+++ b/packages/AI/Providers/Cerebras/src/models/cerebras.ts
@@ -237,20 +237,23 @@ export class CerebrasLLM extends BaseLLM {
         /**
          * NARROWED TO THE NON-STREAMING MEMBER OF THE UNION, DELIBERATELY.
          *
-         * Newer versions of the SDK export `ChatCompletion` as a UNION:
+         * The SDK exports `ChatCompletion` as a UNION, and has done since at least 1.64.1 — the
+         * version the lockfile pins:
          *   ChatCompletion.ChatCompletionResponse | ChatCompletion.ChatChunkResponse | ChatCompletion.ErrorChunkResponse
-         * Only the first carries `choices`, `usage` and `model`, so holding the bare union makes all
-         * three reads below fail to compile (TS2339). This method is `nonStreamingChatCompletion` and
-         * never sets `stream`, so the non-streaming member is correct by construction rather than by
-         * assumption; the other two arrive only on a stream, and a transport failure throws into the
-         * catch below rather than returning an error chunk here. The cast is erased at runtime.
          *
-         * WHICH VERSIONS THIS BITES: the lockfile resolves `@cerebras/cerebras_cloud_sdk` to 1.64.1,
-         * where `ChatCompletion` is not a union, so this file compiles without the narrowing and CI
-         * has always been green. The declared range is `^1.64.1`, which admits 1.91.0 — where it IS a
-         * union. So this is a LATENT break rather than a current one: it surfaces for anyone who
-         * installs fresh outside the lockfile, and it becomes CI's problem the moment the lockfile is
-         * refreshed, where it would arrive attached to an unrelated dependency bump.
+         * `ErrorChunkResponse` declares only `error` and `status_code`, so `choices`, `usage` and
+         * `model` are not common to all three members. On the bare union each of those three reads
+         * therefore comes back as `unknown` rather than its real type, and assigning `unknown` is what
+         * fails — the property access itself stays legal, because every member also carries an
+         * `[k: string]: unknown` index signature.
+         *
+         * WHAT CHANGED HERE is only WHERE that is handled. The original code coped by casting at each
+         * of the three reads; this narrows once, at the declaration, and the reads then need nothing.
+         * Same behaviour, one assertion instead of three, and the cast is erased at runtime either way.
+         *
+         * The narrowing is safe BY CONSTRUCTION rather than by assumption: this method is
+         * `nonStreamingChatCompletion` and never sets `stream`, streaming has its own method, and a
+         * transport failure throws into the catch below rather than returning an error chunk here.
          */
         let chatResponse: ChatCompletion.ChatCompletionResponse;
         try {
@@ -263,7 +266,8 @@ export class CerebrasLLM extends BaseLLM {
         }
         const endTime = new Date();
 
-        // Cast to any to extract the choices
+        // `choice` stays `any` here: the per-choice shape is read loosely below (`message.reasoning`
+        // is not on every model's response), and tightening it is a separate change.
         const choices: ChatResultChoice[] = chatResponse.choices.map((choice: any) => {
             const rawMessage = choice.message.content;
             // in some cases, Cerebras models do thinking and return that as the first part 
@@ -285,11 +289,7 @@ export class CerebrasLLM extends BaseLLM {
         });
          
          
-        // Cast retained deliberately: `usage` is declared `Usage | null | undefined` on the union
-        // member, and the reads below assume it is present. This package compiles without
-        // strictNullChecks, so dropping the cast would look clean and merely hide that assumption
-        // until the day strict is turned on. `choices` needs no such cast — it is a required field.
-        const usage = chatResponse.usage as ChatCompletion.ChatCompletionResponse.Usage
+        const usage = chatResponse.usage
         // OpenAI-compatible cache reporting (if Cerebras enables prompt caching for the model): the
         // cache-read count is nested at prompt_tokens_details.cached_tokens and is INCLUDED in
         // prompt_tokens. Normalize to the uniform ModelUsage contract: promptTokens must be

--- a/packages/Communication/providers/MSGraph/src/MSGraphProvider.ts
+++ b/packages/Communication/providers/MSGraph/src/MSGraphProvider.ts
@@ -459,7 +459,7 @@ export class MSGraphProvider extends BaseCommunicationProvider {
                 comment: params.Message.ProcessedBody || params.Message.ProcessedHTMLBody
             };
 
-            // `ContextData.Email` FIRST, as eleven sibling operations already read it. Without it this
+            // `ContextData.Email` FIRST, as nine sibling operations already read it. Without it this
             // site could only resolve `creds.accountEmail` — which the `Azure Service Principal`
             // credential type declares no property for, and which `disableEnvironmentFallback` removes
             // the environment source for. Reply was therefore unreachable on exactly the stored


### PR DESCRIPTION
Two comments raised in review on #4333 and #4334, merged before they were corrected. Comments only — plus one no-op cast that existed solely because of the wrong comment.

## Cerebras

The block comment said `ChatCompletion` is **not** a union at the version the lockfile pins, and framed the narrowing as pre-empting a break that arrives with a future lockfile refresh.

Checked against the published package rather than a local install: it **is** a union at 1.64.1, and has been all along.

| | 1.64.1 (lockfile → CI) | 1.91.0 |
|---|---|---|
| `ChatCompletion` | union | union |
| `ChatCompletionResponse.usage` | `usage: Usage` — required | `usage?: Usage \| null` |
| index signature | `[k: string]: unknown` | removed |

So the change never fixed a latent break. What it did was replace three per-read casts with one narrowing at the declaration — a smaller and more accurate claim, and the comment now makes it.

The old comment also had the *mechanism* wrong: it is not that only the first member carries the fields. Every member has an `[k: string]: unknown` index signature, so the property access is legal and the reads come back as `unknown`; `ErrorChunkResponse` declaring only `error` and `status_code` is what makes those three not common to the union.

**The retained `usage` cast goes with it.** It was kept on the stated grounds that `usage` is nullable on the narrowed member — true at 1.91.0, which is what I had installed locally, and false at 1.64.1, which is what CI resolves, where it is required. Redundant on the pinned SDK, so it follows the `choices` cast out rather than keeping a paragraph in the file explaining a no-op. Typechecks clean on either version, since this package compiles without `strictNullChecks`.

The stale `// Cast to any to extract the choices` line is reworded — it described a cast that is gone and now sat above a different one.

## MS Graph

`ContextData.Email` is read by **nine** sibling operations, not eleven.

## Verification

No behaviour change. Cerebras typechecks clean, 72 MS Graph tests green, `check:changeset` green (patch; no migration, no metadata).

The `(choice: any)` sweep in the same file stays out of scope, as it did on #4333.
