### PR TITLE
docs: release notes for v6.1.0-edge.6

### DIFF
--- a/releases/v6.1.0-edge.6.md
+++ b/releases/v6.1.0-edge.6.md
@@ -1,0 +1,46 @@
+# CodeGen reproducibility, IsA subtype composition, and privilege-escalation guards
+
+The seventh Edge build of the 6.1 line — 95 changesets across 306 packages, and unusually inward-looking. The dominant theme is **CodeGen telling the truth about a database built only from what the repo ships**: a run of fixes that each began as "this works on my dev database and fails on a fresh install," which is the class of defect that reaches customers first and developers last. Alongside it, **IS-A subtype composition becomes declarative** — an entity can now describe how to resolve its own subtype in metadata rather than in registered runtime code — and a sustained pass over **privilege escalation, SQL-fragment injection surfaces, and undrained fetch bodies**.
+
+Edge builds are prereleases. They publish under the `edge` dist-tag and never move `latest`.
+
+## New Features
+
+- **`Entity.SubtypeSelector` — declarative IS-A subtype resolution.** An entity can carry a dotted foreign-key dereference path ending at the column that names its target subtype entity (`ProductID.ProductTypeID.OrderLineExtensionEntity`). `BaseEntity.ResolveSubtypeEntityName()` reads it when no runtime `EntitySubtypeResolver` is registered, and offline tooling — Loom, CodeGen — can determine conditional IS-A children without executing application code. Prospective subtype resolution and sync composition axes land alongside it.
+- **Conversation-scoped skill activation.** `AISkill.ActivationScope` distinguishes a one-shot capability (`Run`) from a persona or mode that persists (`Conversation`). A skill activated in a run belonging to a conversation stays active for that conversation via an `MJ: Conversation Skills` row and is re-requested at the start of every later root run until ended — still subject to every availability gate on each run.
+- **`Authorization.Check` as a remotable operation**, with composite-filter evaluation, so authorization decisions are callable across the wire rather than only in-process.
+- **Image, Color and JSON `EntityField.ExtendedType`s**, with `PhotoURL` / `LogoURL` rendering as linked thumbnails in the entity viewer.
+- **Host-controllable whiteboard `ToolRoster`** that gates the toolbar, keyboard shortcuts and context menu together, plus host `ReadOnly` support.
+- **Form section indicators** — an unsaved-edits dot and an invalid-field count on the form rail and panel headers, re-resolving automatically when field visibility changes.
+- **Writable geo** — a real write path, isolated parallel providers, and `skipGeoCoding` for callers that already have coordinates.
+- **Open App server packages load in every MJ process**, with per-process scoping, so a dynamic package behaves the same in MJAPI, the CLI and CodeGen.
+- **Artifacts without a viewer plugin** now get a file card and a working download instead of an empty frame.
+- **`BaseEntity.FieldIsDirty`** for per-field edited checks.
+- **The installer defaults to pnpm**, with an explicit `npm` override.
+
+## Improvements
+
+- **CodeGen is idempotent against database state.** Two runs over an unchanged database produce zero diffs; a single new column touches only that entity's artifacts. Field-categorisation decisions persist to `metadata/entities/decisions/`, so a clean-room build matches a warm one.
+- **Fresh-database drift eliminated.** A cluster of fixes for output that differed between a long-lived dev database and one built only from migrations — pending `EntityField` discovery scoped to `includeSchemas`, `IdentityClaim` metadata tail and relationship dedupe, and UTC default normalisation.
+- **Recurring reconcilers no longer leak into versioned migrations.** `omitRecurringScriptsFromLog` now defaults to `true`. CodeGen's SQL log was capturing `spDeleteUnneededEntityFields`, which then replayed from an intermediate schema state on a fresh install and deleted `EntityField` rows the migrations had correctly created — surfacing much later as `Msg 213` on every `Save()`. A CI gate now refuses a migration carrying that prune.
+- **PostgreSQL counterparts for the full v6 backlog**, bringing `migrations/v6` ↔ `migrations-pg/v6` to complete parity.
+- **`ExtraFilter` accepts `IN (SELECT … FROM entity BaseView)`**, so a subquery against a base view is expressible without dropping to custom SQL.
+- **One provider per JSON graph in sync**, so nested children share the parent transaction.
+- **Deterministic save-call SQL variable suffixes** on SQL Server, and nested savepoints moved onto `GenericDatabaseProvider` where both dialects can use them.
+- **The AI-model research routine prompt is checked in**, including the cost-status rule that has twice broken a sync push.
+
+## Bug Fixes
+
+- **Privilege-escalation and role-elevation guards** on `MJ: Users`, `MJ: Roles` and `MJ: User Roles` — a non-Owner administrator can no longer create or delete users, or modify privileged columns on a user row.
+- **Security hardening across request surfaces**: CORS defaults, an OAuth error open redirect, consent scope grants, `CustomWhereClause` gating, client SQL fragments screened for subqueries, the Conditional action, the artifact iframe, and Gmail header handling.
+- **Six recurring undrained-fetch-body leaks closed**, and `RemoteBrowserActionResolver`'s session maps bounded.
+- **Generated `Validate()` overrides are no longer silently deleted.** `mj codegen --no-ai` emitted every entity subclass as though it had no validators, removing 56 committed overrides rather than declining to add new ones — because the load of persisted `GeneratedCode` was reachable on only one code path, and then gated behind the AI feature flag even there. Reading approved generated code is a database read; it is no longer treated as an AI call.
+- **`EntityField` INSERTs no longer carry a literal `Sequence`.** A literal collides on `UQ_EntityField_EntityID_Sequence` on any database built only from migrations, and reports itself as an unrelated foreign-key error.
+- **`InstanceConnectionString` collapsed every connection to one identity** in the SQL Server provider.
+- **RLS exemption honours the permission row's `Can*` flags** rather than exempting wholesale.
+- **The polymorphic `EntityID`/`RecordID` soft-link path works**, instead of assuming every record pointer holds a single bare key value.
+- **Five form controls stopped latching their disabled state**, and the related-grid reserves horizontal-scrollbar height.
+- **Cognito OAuth endpoints resolve from the hosted-UI domain** in the MCP server.
+- **Agent-generated media is stored in configured file storage** rather than inline.
+- **Conversation diagnostic logging is opt-in** instead of unconditional.
+- **Open App CodeGen_Run SQL is written to the app's own `migrations/codegen`**, not the core repo's.


### PR DESCRIPTION
The canonical release record for **v6.1.0-edge.6**, completing DEPLOYMENT.md Step 11.

Written after `publish.yml` succeeded rather than during prep, because the filename carries the version that `changeset version` does not compute until publish time.

## Why this file exists when two other layers already do

Per-package `CHANGELOG.md` and the GitHub Release are both machine-compiled from PR titles, so their quality is exactly PR-title quality. `releases/README.md` names this markdown file — not the GitHub Release — as the canonical record, and `docs-site/scripts/ingest.mjs` renders the directory at **/releases/**. The file *is* the publication.

## Range covered

`v6.1.0-edge.5..v6.1.0-edge.6` — **320 commits, 51 merged PRs, 95 changesets, 9 migrations.**

H1: *CodeGen reproducibility, IsA subtype composition, and privilege-escalation guards* — the three things that actually characterise this build. It is an unusually inward-looking release: most of the CodeGen work began as "this works on my dev database and fails on a fresh install," which is the class of defect that reaches customers first and developers last.

## Release verification

Confirmed against the registry rather than the workflow's exit code:

```
npm  edge   6.1.0-edge.6
npm  latest 5.51.2        <- unmoved
tag         v6.1.0-edge.6
GitHub Rel  prerelease=true, draft=false
main / next 6.1.0-edge.6  (next 0 commits behind main)
release-lines newest: 6.1.0-edge.6  dbImpact: schema
```

Ten packages sampled across the fixed-version group — `core`, `global`, `cli`, `core-entities`, `sqlserver-dataprovider`, `server`, `ai-agents`, `ng-explorer-core`, `codegen-lib`, `metadata-sync` — are all at `6.1.0-edge.6`. **No split publish.** (`integration-test-suite` is absent from npm by design: `private: true`.)

## Expected during the Edge era

This file will not appear on the public site yet. `docs.yml` checks out `lts/5` on every trigger except a manual dispatch with an explicit `ref`, so the push touching `releases/**` fires a deploy that goes green while rebuilding the **LTS** site. The 6.x notes render retroactively when versioned docs land or the pin moves. Written anyway, per Step 11.

No changeset — matches `88a03e45e3` (edge.5) and `24efc87dc5` (edge.4), which each touched only their notes file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdSozdvJ1MbZqC1sUTUChv
