### PR TITLE
ci: prove the App token's write access by using it, not by reading .permissions

### DIFF
--- a/.github/workflows/verify-release-app-token.yml
+++ b/.github/workflows/verify-release-app-token.yml
@@ -1,0 +1,152 @@
+# One-shot diagnostic for the release automation's GitHub App credential.
+#
+# WHY THIS EXISTS
+# ---------------
+# On 2026-09-03 the `next-protect` ruleset (id 905656) swapped its bypass actor from
+# `RepositoryRole 5` (repository admin) to the `break-glass` team. `MJ-GH-bot` — the
+# account behind `MJ_GH_BOT_GITHUB_TOKEN`, which publish.yml uses to push to `next` — is
+# a repository admin but an OUTSIDE COLLABORATOR, so it lost its bypass and cannot be
+# added to a team (that needs org membership, and the org is at 42/42 seats).
+#
+# v6.1.0-edge.6 published fine and then died on step 22 `Merge main into next`:
+#
+#     remote: error: GH013: Repository rule violations found for refs/heads/next.
+#     - Changes must be made through a pull request.
+#     - Required status check "Check migrations" is expected.
+#
+# Recovered by hand in #4382. It will recur on EVERY release until a bypass exists, and
+# it affects four push sites, not just that one — publish.yml lines 728, 775, 1407 and
+# 1599/1643 all end in `git push origin HEAD:next`.
+#
+# A GitHub App can be a ruleset bypass actor (`actor_type: Integration`) and consumes no
+# org seat, which makes it the only no-cost fix that does not re-widen direct push to
+# `next` for every repo admin. `blue-cypress-ci-bot` (app_id 4705146, installation
+# 156297321) is already installed org-wide with exactly `contents: write` +
+# `pull_requests: write` — strictly narrower than the admin PAT it would replace.
+#
+# WHAT IS NOT YET PROVEN is that the org secret `APP_PRIVATE_KEY` is actually THAT app's
+# key. The secret was created 2026-08-24T23:29, eight hours after the installation, and
+# no workflow in this repo references it — suggestive, not conclusive, and the secret
+# cannot be read outside Actions. This workflow proves it or disproves it before anyone
+# edits a ruleset or rewires the release path.
+#
+# RUN IT TWICE:
+#   1. NOW — confirms the key decodes, names the app, and can write to this repo.
+#      `can_bypass` is expected to report `never` at this point.
+#   2. AFTER the bypass actor is added to ruleset 905656 — `can_bypass` must flip to
+#      `always`. That is the signal the next release will get past step 22.
+#
+# Read-only against the repo: it mints a token and asks questions. It pushes nothing,
+# opens nothing, and edits no ruleset. Delete it once the release path is on App tokens,
+# or keep it as a pre-release smoke test.
+name: Verify the release App token
+
+on:
+  workflow_dispatch:
+
+# The job's own GITHUB_TOKEN needs nothing — every call below uses the minted App token.
+permissions: {}
+
+jobs:
+  verify:
+    name: Verify blue-cypress-ci-bot credentials
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    env:
+      # The identity we expect to be handed. Asserted, not assumed: if `APP_PRIVATE_KEY`
+      # belongs to some OTHER installed app, the token mint would still succeed and every
+      # check below would still pass — against the wrong app. The whole point of this run
+      # is settling which app the key belongs to, so the answer gets compared, not printed.
+      EXPECTED_APP_SLUG: blue-cypress-ci-bot
+      EXPECTED_APP_ID: '4705146'
+      EXPECTED_INSTALLATION_ID: '156297321'
+      RULESET_ID: '905656'
+    steps:
+      # `app-id` accepts a client ID as well as a numeric app id, which is what the org
+      # variable holds. Pulling it from `vars` rather than hardcoding keeps this honest:
+      # it tests the SAME pair of values a rewired publish.yml would use.
+      - name: Mint an installation token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # No `owner:` — default scoping mints a token for THIS repository only. Setting
+          # owner would widen it to every repo the installation can reach, which the
+          # release path never needs.
+
+      - name: The key belongs to the app we think it does
+        env:
+          GOT_SLUG: ${{ steps.token.outputs.app-slug }}
+          GOT_INSTALLATION: ${{ steps.token.outputs.installation-id }}
+        run: |
+          set -euo pipefail
+          echo "app-slug        = $GOT_SLUG"
+          echo "installation-id = $GOT_INSTALLATION"
+          rc=0
+          if [ "$GOT_SLUG" != "$EXPECTED_APP_SLUG" ]; then
+            echo "::error::APP_PRIVATE_KEY belongs to '$GOT_SLUG', not '$EXPECTED_APP_SLUG'."
+            echo "::error::Do NOT add app_id $EXPECTED_APP_ID as a ruleset bypass actor — it is the wrong app."
+            rc=1
+          fi
+          if [ "$GOT_INSTALLATION" != "$EXPECTED_INSTALLATION_ID" ]; then
+            echo "::error::installation is $GOT_INSTALLATION, expected $EXPECTED_INSTALLATION_ID."
+            rc=1
+          fi
+          if [ $rc -eq 0 ]; then
+            echo "::notice::Identity confirmed: $GOT_SLUG (installation $GOT_INSTALLATION)"
+          fi
+          exit $rc
+
+      # `contents: write` on the INSTALLATION is not the same as write on THIS repo — the
+      # installation could be scoped to a subset that excludes MJ. This asks about the repo.
+      - name: The token can actually write to this repo
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          PERMS=$(gh api "repos/${{ github.repository }}" --jq '.permissions | tojson')
+          echo "repo permissions = $PERMS"
+          if [ "$(echo "$PERMS" | jq -r .push)" != "true" ]; then
+            echo "::error::The App token cannot push to ${{ github.repository }}."
+            exit 1
+          fi
+          echo "::notice::push=true on ${{ github.repository }}"
+
+      # The load-bearing question, and the reason to run this a second time. For an
+      # installation token `current_user_can_bypass` reports the APP's standing against
+      # the ruleset. `never` before the bypass actor is added, `always` after. Never
+      # fails the job: on run 1 `never` is the expected, correct answer.
+      - name: Report the App's bypass standing on next-protect
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          CAN=$(gh api "repos/${{ github.repository }}/rulesets/$RULESET_ID" \
+                  --jq '.current_user_can_bypass // "null"' 2>/dev/null || echo 'unreadable')
+          echo "current_user_can_bypass = $CAN"
+          {
+            echo "### next-protect bypass standing"
+            echo
+            echo '| field | value |'
+            echo '|---|---|'
+            echo "| app | \`${{ steps.token.outputs.app-slug }}\` (app_id \`$EXPECTED_APP_ID\`) |"
+            echo "| ruleset | \`$RULESET_ID\` (next-protect) |"
+            echo "| can_bypass | \`$CAN\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          case "$CAN" in
+            always)
+              echo "::notice::Bypass is live. publish.yml can push to next as this App."
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "Bypass is live — the release path is clear." >> "$GITHUB_STEP_SUMMARY" ;;
+            unreadable|null)
+              # `metadata: read` does not cover the rulesets endpoint; a 404 here is about
+              # the App's ability to READ the rule, not its ability to bypass it.
+              echo "::warning::Bypass standing not determinable with the App token — inconclusive, check as an admin."
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "Not determinable by this token — inconclusive, not a failure." >> "$GITHUB_STEP_SUMMARY" ;;
+            *)
+              echo "::warning::No bypass yet (can_bypass=$CAN). Expected on the first run, before the ruleset edit."
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "No bypass yet — add app_id \`$EXPECTED_APP_ID\` as an \`Integration\` bypass actor, then re-run." >> "$GITHUB_STEP_SUMMARY" ;;
+          esac

--- a/.github/workflows/verify-release-app-token.yml
+++ b/.github/workflows/verify-release-app-token.yml
@@ -36,9 +36,12 @@
 #   2. AFTER the bypass actor is added to ruleset 905656 — `can_bypass` must flip to
 #      `always`. That is the signal the next release will get past step 22.
 #
-# Read-only against the repo: it mints a token and asks questions. It pushes nothing,
-# opens nothing, and edits no ruleset. Delete it once the release path is on App tokens,
-# or keep it as a pre-release smoke test.
+# Near-read-only: it mints a token, asks questions, and makes exactly ONE mutation — a
+# throwaway ref created at next's existing tip and deleted again in cleanup, which is the
+# only unambiguous way to prove `contents: write` (see the write step for why the repo
+# `permissions` block cannot be used for this). It never touches `next`, `main` or any
+# lts/** branch, opens no PR, and edits no ruleset. Delete it once the release path is on
+# App tokens, or keep it as a pre-release smoke test.
 name: Verify the release App token
 
 on:
@@ -98,20 +101,40 @@ jobs:
           fi
           exit $rc
 
-      # `contents: write` on the INSTALLATION is not the same as write on THIS repo — the
-      # installation could be scoped to a subset that excludes MJ. This asks about the repo.
+      # DO NOT test write access with `gh api repos/OWNER/REPO --jq .permissions`.
+      #
+      # That block is computed for an authenticated USER. An installation token has no user
+      # behind it, so GitHub returns every field false — `admin`, `maintain`, `pull`, `push`,
+      # `triage` — even when the installation holds `contents: write`. The first version of
+      # this workflow asserted `.push == true` and failed a perfectly good credential.
+      #
+      # The giveaway is `pull: false` on a request that RETURNED 200: a token with no access
+      # to the repo gets a 404, not a permissions block. The successful read already proves
+      # access; the block just isn't populated for app tokens.
+      #
+      # So prove write the only way that is not ambiguous — perform one. Creating a ref is a
+      # `contents: write` operation and is exactly the capability publish.yml needs. The
+      # throwaway branch is deleted in the cleanup step below, and no workflow in this repo
+      # triggers on it: every `push:` trigger here is branch-filtered to next/main/lts/**
+      # or feature/mj-install-v2, so this starts no CI.
       - name: The token can actually write to this repo
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           set -euo pipefail
-          PERMS=$(gh api "repos/${{ github.repository }}" --jq '.permissions | tojson')
-          echo "repo permissions = $PERMS"
-          if [ "$(echo "$PERMS" | jq -r .push)" != "true" ]; then
-            echo "::error::The App token cannot push to ${{ github.repository }}."
+          BRANCH="apptoken-writecheck-${{ github.run_id }}"
+          # Branch off next's current tip: creating a ref AT an existing commit adds no
+          # objects and changes no branch anyone uses.
+          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/next" --jq '.object.sha')
+          echo "creating refs/heads/$BRANCH at $SHA"
+          # Record the name BEFORE the attempt, so cleanup still runs if creation half-succeeds.
+          echo "CLEANUP_BRANCH=$BRANCH" >> "$GITHUB_ENV"
+          if ! gh api -X POST "repos/${{ github.repository }}/git/refs" \
+                 -f ref="refs/heads/$BRANCH" -f sha="$SHA" --silent; then
+            echo "::error::The App token cannot create a ref in ${{ github.repository }} — no contents:write."
             exit 1
           fi
-          echo "::notice::push=true on ${{ github.repository }}"
+          echo "::notice::contents:write confirmed (created refs/heads/$BRANCH)"
 
       # The load-bearing question, and the reason to run this a second time. For an
       # installation token `current_user_can_bypass` reports the APP's standing against
@@ -150,3 +173,21 @@ jobs:
               echo "" >> "$GITHUB_STEP_SUMMARY"
               echo "No bypass yet — add app_id \`$EXPECTED_APP_ID\` as an \`Integration\` bypass actor, then re-run." >> "$GITHUB_STEP_SUMMARY" ;;
           esac
+
+      # always(): the write check exports CLEANUP_BRANCH before it creates the ref, so a
+      # partial failure still gets tidied. No-op when the variable was never set.
+      - name: Remove the throwaway branch
+        if: always()
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          set -uo pipefail
+          if [ -z "${CLEANUP_BRANCH:-}" ]; then
+            echo "nothing to clean up"
+            exit 0
+          fi
+          if gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$CLEANUP_BRANCH" --silent 2>/dev/null; then
+            echo "::notice::deleted refs/heads/$CLEANUP_BRANCH"
+          else
+            echo "::warning::could not delete refs/heads/$CLEANUP_BRANCH — remove it by hand."
+          fi


### PR DESCRIPTION
Follow-up to #4388. The first dispatch answered the question that PR existed to answer, then failed on a check of mine that was simply wrong.

## What run 1 established

**The identity is confirmed.** `APP_PRIVATE_KEY` belongs to `blue-cypress-ci-bot`, installation `156297321`:

```
app-slug        = blue-cypress-ci-bot
installation-id = 156297321
Notice: Identity confirmed: blue-cypress-ci-bot (installation 156297321)
```

That was the one unproven link behind using a GitHub App as the ruleset bypass actor, and it holds. The App route is viable.

## The failure was a bad test, not a bad credential

```
repo permissions = {"admin":false,"maintain":false,"pull":false,"push":false,"triage":false}
Error: The App token cannot push to MemberJunction/MJ.
```

The `permissions` block on a repository object is computed for an authenticated **user**. An installation token has no user behind it, so GitHub returns every field false no matter what the installation actually holds. Asserting `.push == true` against an App token can only ever fail.

The internal contradiction gives it away: `pull: false` on a request that **returned 200**. A token with no access to the repo gets a 404, not a permissions block — so the successful read had already proved access at the moment the check declared there was none.

Independently, the installation object read as an org admin reports exactly:

```json
{ "contents": "write", "pull_requests": "write", "metadata": "read" }
```

with `repository_selection: all`. So the App almost certainly can write here. "Almost certainly" is what this workflow exists to eliminate, hence the replacement rather than simply deleting the check.

## What replaces it

Prove write by performing one. Creating a ref is a `contents: write` operation and is the exact capability publish.yml needs:

- The ref is created **at `next`'s current tip** — no new objects, no branch anyone uses, `next` itself untouched.
- Throwaway name `apptoken-writecheck-<run_id>`, deleted in an `always()` cleanup step.
- Cleanup records the branch name **before** the creation attempt, so a half-succeeded create is still tidied.
- **No CI is triggered.** Every `push:` trigger in this repo is branch-filtered — `next`, `main`, `lts/**`, or `feature/mj-install-v2` — and none match. I checked all 13 rather than assuming.

The header's "pushes nothing" claim is corrected too; the workflow now makes exactly one mutation and says so plainly.

## Still unknown

The bypass-standing step never ran, because the bogus check exited first. So `current_user_can_bypass` on ruleset `905656` is still unmeasured — expected `never` until the bypass actor is added, but unconfirmed.

After this merges, re-run **Verify the release App token**. Expected: identity confirmed again, `contents:write confirmed`, and `can_bypass = never`. That clears the way for adding `{actor_id: 4705146, actor_type: "Integration", bypass_mode: "always"}` to `905656` and re-running for the `always` that says the next release will clear step 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
