### PR TITLE
ci(publish): push next as the release App, and fall back to a PR when the back-merge cannot land

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -737,6 +737,14 @@ jobs:
         with:
           app-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Least privilege, named explicitly rather than inheriting whatever the App
+          # happens to hold. Two effects: the blast radius of this token is legible at the
+          # call site, and if the App's grants are ever trimmed the mint fails HERE with a
+          # clear error instead of the push failing later with a permissions error that
+          # looks like the protection problem this whole change was about.
+          # contents -> the push to `next`; pull-requests -> the back-merge fallback PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       # A SECOND remote, deliberately, rather than re-pointing `origin`.
       #
@@ -1477,6 +1485,14 @@ jobs:
         with:
           app-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Least privilege, named explicitly rather than inheriting whatever the App
+          # happens to hold. Two effects: the blast radius of this token is legible at the
+          # call site, and if the App's grants are ever trimmed the mint fails HERE with a
+          # clear error instead of the push failing later with a permissions error that
+          # looks like the protection problem this whole change was about.
+          # contents -> the push to `next`; pull-requests -> the back-merge fallback PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Add the App-authenticated remote for next
         env:
@@ -1725,6 +1741,14 @@ jobs:
         with:
           app-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Least privilege, named explicitly rather than inheriting whatever the App
+          # happens to hold. Two effects: the blast radius of this token is legible at the
+          # call site, and if the App's grants are ever trimmed the mint fails HERE with a
+          # clear error instead of the push failing later with a permissions error that
+          # looks like the protection problem this whole change was about.
+          # contents -> the push to `next`; pull-requests -> the back-merge fallback PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Add the App-authenticated remote for next
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -725,12 +725,79 @@ jobs:
           fi
           gh release create "$VERSION" --title "$VERSION" --generate-notes --latest=false $EXTRA_FLAGS --repo "${{ github.repository }}"
 
+      # Minted HERE rather than at the top of the job, and this is load-bearing: an App
+      # installation token lives one hour, while this job's budget is 120 minutes and the
+      # build alone takes ~25. A token minted at checkout would routinely be expired by the
+      # time the back-merge runs — which is the LAST thing the job does. Mint it late, use
+      # it immediately. Covers this step and the two below; nothing between them is slow.
+      - name: Mint the App token for pushes to next
+        if: ${{ env.BRANCH == 'main' }}
+        id: next_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      # A SECOND remote, deliberately, rather than re-pointing `origin`.
+      #
+      # `next` is protected by ruleset `next-protect`, whose bypass list accepts only roles,
+      # teams and GitHub Apps — never an individual user. The release PAT's account
+      # (MJ-GH-bot) is an outside collaborator, so it cannot hold a bypass at all; as of
+      # 2026-09-03 it does not, and every push to `next` from this workflow was rejected
+      # with GH013 until `blue-cypress-ci-bot` was added as a bypass actor (MJ#4382).
+      #
+      # Only the write to `next` moves. `origin` keeps the PAT, so the push to `main` and
+      # the tag (both already done by this point), every `gh release` call, and all reads
+      # behave exactly as before. The App holds only `contents: write` +
+      # `pull_requests: write` — it could NOT do the `gh issue` and `gh workflow run` work
+      # elsewhere in this file, which is why this is a second remote and not a swap.
+      - name: Add the App-authenticated remote for next
+        if: ${{ env.BRANCH == 'main' }}
+        env:
+          APP_TOKEN: ${{ steps.next_token.outputs.token }}
+        run: |
+          git remote remove next-push 2>/dev/null || true
+          git remote add next-push "https://x-access-token:$APP_TOKEN@github.com/${GITHUB_REPOSITORY}"
+          echo "::notice::next-push remote configured as ${{ steps.next_token.outputs.app-slug }}"
+
+      # continue-on-error, paired with the explicit failure step at the end of the job.
+      # The back-merge is no longer allowed to kill the steps after it: recording the
+      # release in release-lines.json is independent work that should still happen, and the
+      # fallback below needs to run precisely when this fails. The job still ends RED —
+      # see "Fail the run if the back-merge did not land".
       - name: Merge main into next and update package-lock
         if: ${{ env.BRANCH == 'main' }}
+        id: backmerge
+        continue-on-error: true
+        env:
+          MJ_NEXT_PUSH_REMOTE: next-push
         run: |
           git checkout next
           git log -n1
-          pnpm run mergemain:update-lock
+          pnpm run mergemain:update-lock 2>&1 | tee "$RUNNER_TEMP/backmerge.log"
+          exit "${PIPESTATUS[0]}"
+
+      # The recovery that #4382 had to do by hand. Two different failures land here — a
+      # genuine merge conflict (ci/back-merge.mjs refuses to guess at anything but the
+      # lockfile) and a rejected push (the bypass is configuration outside this repo and
+      # can be revoked, exactly as it was on 2026-09-03). A PR answers both.
+      #
+      # It does NOT make the release done: the back-merge is outstanding until someone
+      # merges that PR, which is why the job still fails below.
+      - name: Fallback - open a back-merge PR
+        if: ${{ env.BRANCH == 'main' && steps.backmerge.outcome == 'failure' }}
+        id: backmerge_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.next_token.outputs.token }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          set -euo pipefail
+          REASON=$(tail -c 2000 "$RUNNER_TEMP/backmerge.log" 2>/dev/null || echo 'back-merge step produced no log')
+          node ci/backmerge-fallback.mjs \
+            --version "$VERSION" \
+            --remote next-push \
+            --reason "$REASON"
 
       # release-lines.json bookkeeping. Process doc §4.1 says publish workflows append the
       # mechanical fields (`newest`, and the per-release `releases` ledger) via direct push.
@@ -741,14 +808,19 @@ jobs:
       # It writes to `next`, never to `main`. A push to main is this workflow's own Edge
       # trigger, so a bookkeeping commit there would start a publish that consumes whatever
       # changesets are banked on main. `next` carries no publish trigger, and main inherits
-      # the entry at the next release through the merge step above. The step above has already
-      # pushed HEAD:next, so HEAD is the branch tip here.
+      # the entry at the next release through the merge step above.
       #
-      # LAST step in the job, deliberately, and fatal rather than continue-on-error. The
-      # packages are on npm by the time this runs, so a failure means "released, not yet
-      # recorded" — recoverable by hand — while a red run is the only signal that the ledger
-      # is behind. [skip ci] keeps a predictable two-field JSON edit from re-running every
-      # gate; `--mode push` proves the edit touched nothing else before it is committed.
+      # This step used to rely on the back-merge above having pushed HEAD:next, so that HEAD
+      # was the branch tip here. That coupling is why ONE rejected push at v6.1.0-edge.6
+      # produced TWO unfinished steps. It now resolves `next` itself, which makes it
+      # independent: the ledger is recorded whether or not the back-merge landed, and the
+      # two failures are reported separately instead of one masking the other.
+      #
+      # Still fatal rather than continue-on-error. The packages are on npm by the time this
+      # runs, so a failure means "released, not yet recorded" — recoverable by hand — while
+      # a red run is the only signal that the ledger is behind. [skip ci] keeps a predictable
+      # two-field JSON edit from re-running every gate; `--mode push` proves the edit touched
+      # nothing else before it is committed.
       - name: Record the release in release-lines.json
         if: ${{ env.BRANCH == 'main' }}
         env:
@@ -768,11 +840,39 @@ jobs:
           fi
           echo "::notice::classifying dbImpact over ${PREV}..${VERSION}"
           git fetch origin next
+          # Move onto next's actual tip rather than assuming HEAD is already there. `-f` for
+          # the same reason the LTS path documents below: the build rewrites tracked
+          # generated files, so the tree is dirty here and a plain checkout would abort with
+          # "local changes would be overwritten". What gets discarded is build output.
+          # `git describe` above already ran against a local tag object, so it is unaffected.
+          git checkout -f -B record-release-lines origin/next
           node ci/append-release-line.mjs --version "${VERSION#v}" --since "$PREV" --until "$VERSION"
           node ci/validate-release-lines.mjs --base origin/next --mode push
           git add release-lines.json
           git commit -m "chore: record ${VERSION#v} in release-lines.json [skip ci]"
-          git push origin HEAD:next
+          git push next-push HEAD:next
+
+      # The back-merge runs continue-on-error so the ledger step above still gets its turn
+      # and the fallback PR can be opened. The run must still end RED: until that PR is
+      # merged the repo is "published, not merged", and a green run would say otherwise.
+      # Same doctrine the ledger step has always had, just reported at the end instead of
+      # by stopping the job halfway.
+      - name: Fail the run if the back-merge did not land
+        if: ${{ env.BRANCH == 'main' && steps.backmerge.outcome == 'failure' }}
+        env:
+          PR_URL: ${{ steps.backmerge_pr.outputs.pr_url }}
+        run: |
+          echo "::error::The release published, but the main -> next back-merge did not land."
+          if [ -n "${PR_URL:-}" ]; then
+            echo "::error::Resolve and merge ${PR_URL} to finish the release."
+            echo "### Back-merge outstanding" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The release is on npm. Merge $PR_URL to complete it." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::The fallback could not open a PR either — finish the back-merge by hand:"
+            echo "::error::  git checkout next && git merge origin/main"
+          fi
+          exit 1
 
   # ---------------------------------------------------------------------------
   # LTS line release (guides/RELEASE_ENGINEERING_RUNBOOK.md operation 3;
@@ -1365,6 +1465,27 @@ jobs:
             -f version="${VERSION#v}" -f line_branch="$LINE"
           echo "::notice::release-notes generation dispatched for ${VERSION#v} on $LINE; review and merge the PR it opens."
 
+      # `next` is protected and only the release App may push to it — see the edge path's
+      # remote step for the full reasoning. Minted here, immediately before the only step in
+      # this job that writes to `next`, because an installation token lives one hour and this
+      # job's budget is far longer. The line branch's own pushes above keep using `origin`
+      # on the PAT: `lts-lines` still bypasses on the repository-admin role, so they were
+      # never affected by the 2026-09-03 change.
+      - name: Mint the App token for pushes to next
+        id: next_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Add the App-authenticated remote for next
+        env:
+          APP_TOKEN: ${{ steps.next_token.outputs.token }}
+        run: |
+          git remote remove next-push 2>/dev/null || true
+          git remote add next-push "https://x-access-token:$APP_TOKEN@github.com/${GITHUB_REPOSITORY}"
+          echo "::notice::next-push remote configured as ${{ steps.next_token.outputs.app-slug }}"
+
       # Same bookkeeping as the edge path above — see that step for why it writes to `next`,
       # why it is last, and why it is fatal. One difference: this job is checked out on the
       # LINE branch, whose own release-lines.json is inert (`"lines": {}`) because the source
@@ -1404,7 +1525,7 @@ jobs:
           node ci/validate-release-lines.mjs --base origin/next --mode push
           git add release-lines.json
           git commit -m "chore: record ${VERSION#v} in release-lines.json [skip ci]"
-          git push origin HEAD:next
+          git push next-push HEAD:next
 
 
   # ---------------------------------------------------------------------------
@@ -1594,10 +1715,35 @@ jobs:
       - name: Re-enter Edge pre-mode and open the ${{ steps.cut.outputs.NEXTLINE }} stream
         run: node ci/candidate-cut.mjs reenter --line "$CUT"
 
-      # next kept merging during the build. push-next merges origin/next in and retries
+      # `next` is protected and only the release App may push to it — see the edge path's
+      # remote step for the reasoning. Minted here rather than at job start because an
+      # installation token lives one hour; the two steps that write to `next` (this one and
+      # the ledger at the end) both fall inside that window from this point.
+      - name: Mint the App token for pushes to next
+        id: next_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Add the App-authenticated remote for next
+        env:
+          APP_TOKEN: ${{ steps.next_token.outputs.token }}
+        run: |
+          git remote remove next-push 2>/dev/null || true
+          git remote add next-push "https://x-access-token:$APP_TOKEN@github.com/${GITHUB_REPOSITORY}"
+          echo "::notice::next-push remote configured as ${{ steps.next_token.outputs.app-slug }}"
+
+      # next kept merging during the build. push-next merges next-push/next in and retries
       # (bounded); only pnpm-lock.yaml may auto-resolve. Never force.
+      #
+      # --remote moves BOTH the fetch and the push onto the App-authenticated remote, which
+      # is required: pushNext() merges `<remote>/next` between attempts, so the ref it reads
+      # and the ref it writes must be the same remote. The tag push and branch creation in
+      # the step below deliberately stay on `origin` — those are not covered by next-protect
+      # and the App has no reason to hold them.
       - name: Push next
-        run: node ci/candidate-cut.mjs push-next
+        run: node ci/candidate-cut.mjs push-next --remote next-push
 
       - name: Push the tag and create ${{ steps.cut.outputs.BRANCH }} at it
         env:
@@ -1640,7 +1786,7 @@ jobs:
           node ci/validate-release-lines.mjs --base origin/next --mode push
           git add release-lines.json
           git commit -m "chore: record $VERSION in release-lines.json [skip ci]"
-          git push origin HEAD:next
+          git push next-push HEAD:next
 
       - name: Deploy docs for the new line
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -785,22 +785,46 @@ jobs:
           pnpm run mergemain:update-lock 2>&1 | tee "$RUNNER_TEMP/backmerge.log"
           exit "${PIPESTATUS[0]}"
 
-      # The recovery that #4382 had to do by hand. Two different failures land here — a
-      # genuine merge conflict (ci/back-merge.mjs refuses to guess at anything but the
-      # lockfile) and a rejected push (the bypass is configuration outside this repo and
-      # can be revoked, exactly as it was on 2026-09-03). A PR answers both.
+      # A SECOND mint, not a reuse of steps.next_token.
       #
-      # It does NOT make the release done: the back-merge is outstanding until someone
-      # merges that PR, which is why the job still fails below.
+      # That token was minted before the back-merge, and an installation token lives one
+      # hour. The back-merge is a merge plus `pnpm install --lockfile-only` over ~300
+      # packages; on a bad day it can run long enough for the token to expire. The fallback
+      # would then fail on an expired credential and produce exactly the state it exists to
+      # prevent: released, not merged, and no PR to show for it. A fresh token costs one
+      # step and removes the dependency on how long the step that just failed took to fail.
+      - name: Re-mint the App token for the fallback
+        if: ${{ env.BRANCH == 'main' && steps.backmerge.outcome == 'failure' }}
+        id: fallback_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      # The recovery that #4382 had to do by hand. Three outcomes land here — a genuine
+      # merge conflict (ci/back-merge.mjs refuses to guess at anything but the lockfile), a
+      # rejected push (the bypass is configuration outside this repo and can be revoked,
+      # exactly as it was on 2026-09-03), and "the merge actually landed before the step
+      # reported failure", which the script detects by ancestry and reports as
+      # nothing_to_merge rather than opening an empty PR.
+      #
+      # A PR does NOT make the release done: the back-merge is outstanding until someone
+      # merges it, which is why the job still fails below.
       - name: Fallback - open a back-merge PR
         if: ${{ env.BRANCH == 'main' && steps.backmerge.outcome == 'failure' }}
         id: backmerge_pr
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.next_token.outputs.token }}
+          GH_TOKEN: ${{ steps.fallback_token.outputs.token }}
+          APP_TOKEN: ${{ steps.fallback_token.outputs.token }}
           VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           set -euo pipefail
+          # The next-push remote still carries the OLD token in its URL — repoint it, or the
+          # re-mint above buys nothing for the push.
+          git remote set-url next-push "https://x-access-token:$APP_TOKEN@github.com/${GITHUB_REPOSITORY}"
           REASON=$(tail -c 2000 "$RUNNER_TEMP/backmerge.log" 2>/dev/null || echo 'back-merge step produced no log')
           node ci/backmerge-fallback.mjs \
             --version "$VERSION" \
@@ -865,11 +889,24 @@ jobs:
       # merged the repo is "published, not merged", and a green run would say otherwise.
       # Same doctrine the ledger step has always had, just reported at the end instead of
       # by stopping the job halfway.
+      #
+      # `always()` is load-bearing: a step `if:` carries an implicit success(), so without it
+      # a failure in the ledger step above would SKIP this one — losing the pointer to the
+      # fallback PR at precisely the moment two things have gone wrong.
       - name: Fail the run if the back-merge did not land
-        if: ${{ env.BRANCH == 'main' && steps.backmerge.outcome == 'failure' }}
+        if: ${{ always() && env.BRANCH == 'main' && steps.backmerge.outcome == 'failure' }}
         env:
           PR_URL: ${{ steps.backmerge_pr.outputs.pr_url }}
+          NOTHING_TO_MERGE: ${{ steps.backmerge_pr.outputs.nothing_to_merge }}
         run: |
+          # The back-merge step can fail with main already merged (e.g. the lockfile
+          # regeneration died after the merge commit had landed and pushed). There is then
+          # nothing outstanding and nothing to fail the release over.
+          if [ "${NOTHING_TO_MERGE:-}" = "true" ]; then
+            echo "::warning::The back-merge step failed, but main is already an ancestor of next — nothing to back-merge."
+            echo "::warning::Treating the release as complete. Check the back-merge step's log for why it reported failure."
+            exit 0
+          fi
           echo "::error::The release published, but the main -> next back-merge did not land."
           if [ -n "${PR_URL:-}" ]; then
             echo "::error::Resolve and merge ${PR_URL} to finish the release."

--- a/.github/workflows/verify-release-app-token.yml
+++ b/.github/workflows/verify-release-app-token.yml
@@ -30,18 +30,18 @@
 # cannot be read outside Actions. This workflow proves it or disproves it before anyone
 # edits a ruleset or rewires the release path.
 #
-# RUN IT TWICE:
-#   1. NOW — confirms the key decodes, names the app, and can write to this repo.
-#      `can_bypass` is expected to report `never` at this point.
-#   2. AFTER the bypass actor is added to ruleset 905656 — `can_bypass` must flip to
-#      `always`. That is the signal the next release will get past step 22.
+# WHAT GREEN LOOKS LIKE: the token mints (key valid, grants intact), the identity matches
+# blue-cypress-ci-bot, and `can_bypass` reports `always`. Anything else means the release
+# path is broken and a publish will strand itself between npm and `next` — fix it before
+# you start, not 40 minutes in.
 #
-# Near-read-only: it mints a token, asks questions, and makes exactly ONE mutation — a
-# throwaway ref created at next's existing tip and deleted again in cleanup, which is the
-# only unambiguous way to prove `contents: write` (see the write step for why the repo
-# `permissions` block cannot be used for this). It never touches `next`, `main` or any
-# lts/** branch, opens no PR, and edits no ruleset. Delete it once the release path is on
-# App tokens, or keep it as a pre-release smoke test.
+# READ-ONLY. It mints a scoped token and asks two questions. It writes nothing, pushes
+# nothing, opens nothing, and edits no ruleset — run it whenever you like.
+#
+# Keep it: what it checks is configuration living OUTSIDE this repo (the ruleset bypass,
+# the App's private key, the App's permission grants). Nothing in the codebase and no CI
+# job can prove those are intact, so without this the next release is what finds out —
+# which is exactly how v6.1.0-edge.6 went. See DEPLOYMENT.md Step 0.
 name: Verify the release App token
 
 on:
@@ -77,6 +77,14 @@ jobs:
           # No `owner:` — default scoping mints a token for THIS repository only. Setting
           # owner would widen it to every repo the installation can reach, which the
           # release path never needs.
+          #
+          # Naming the permissions is what makes this workflow read-only without losing
+          # coverage. GitHub refuses to mint a token carrying permissions the installation
+          # does not hold, so a trimmed grant fails HERE — no write required to detect it.
+          # These are exactly the two publish.yml needs: contents for the push to `next`,
+          # pull-requests for the back-merge fallback PR.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: The key belongs to the app we think it does
         env:
@@ -101,41 +109,20 @@ jobs:
           fi
           exit $rc
 
-      # DO NOT test write access with `gh api repos/OWNER/REPO --jq .permissions`.
+      # There is deliberately NO write test here any more.
       #
-      # That block is computed for an authenticated USER. An installation token has no user
-      # behind it, so GitHub returns every field false — `admin`, `maintain`, `pull`, `push`,
-      # `triage` — even when the installation holds `contents: write`. The first version of
-      # this workflow asserted `.push == true` and failed a perfectly good credential.
+      # The first version created and deleted a throwaway ref, because the question at the
+      # time was one-off: does this key work at all? (It also replaced an earlier check that
+      # read `gh api repos/OWNER/REPO --jq .permissions` and asserted `.push == true` — that
+      # block is computed for an authenticated USER, so an installation token reads
+      # all-false no matter what it holds, and the assertion could only ever fail.)
       #
-      # The giveaway is `pull: false` on a request that RETURNED 200: a token with no access
-      # to the repo gets a 404, not a permissions block. The successful read already proves
-      # access; the block just isn't populated for app tokens.
-      #
-      # So prove write the only way that is not ambiguous — perform one. Creating a ref is a
-      # `contents: write` operation and is exactly the capability publish.yml needs. The
-      # throwaway branch is deleted in the cleanup step below, and no workflow in this repo
-      # triggers on it: every `push:` trigger here is branch-filtered to next/main/lts/**
-      # or feature/mj-install-v2, so this starts no CI.
-      - name: The token can actually write to this repo
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          set -euo pipefail
-          BRANCH="apptoken-writecheck-${{ github.run_id }}"
-          # Branch off next's current tip: creating a ref AT an existing commit adds no
-          # objects and changes no branch anyone uses.
-          SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/next" --jq '.object.sha')
-          echo "creating refs/heads/$BRANCH at $SHA"
-          # Record the name BEFORE the attempt, so cleanup still runs if creation half-succeeds.
-          echo "CLEANUP_BRANCH=$BRANCH" >> "$GITHUB_ENV"
-          if ! gh api -X POST "repos/${{ github.repository }}/git/refs" \
-                 -f ref="refs/heads/$BRANCH" -f sha="$SHA" --silent; then
-            echo "::error::The App token cannot create a ref in ${{ github.repository }} — no contents:write."
-            exit 1
-          fi
-          echo "::notice::contents:write confirmed (created refs/heads/$BRANCH)"
-
+      # That question is answered. What this workflow is FOR now is being run casually
+      # before a release, and a diagnostic that mutates the repo is one people hesitate to
+      # run. The scoped `permission-*` inputs on the mint step above cover the same
+      # regression read-only: if the App's grants were trimmed, the mint fails. Without
+      # them a trimmed grant would slip through, because `can_bypass` below would still
+      # report `always` while the actual push failed.
       # The load-bearing question, and the reason to run this a second time. For an
       # installation token `current_user_can_bypass` reports the APP's standing against
       # the ruleset. `never` before the bypass actor is added, `always` after. Never
@@ -173,21 +160,3 @@ jobs:
               echo "" >> "$GITHUB_STEP_SUMMARY"
               echo "No bypass yet — add app_id \`$EXPECTED_APP_ID\` as an \`Integration\` bypass actor, then re-run." >> "$GITHUB_STEP_SUMMARY" ;;
           esac
-
-      # always(): the write check exports CLEANUP_BRANCH before it creates the ref, so a
-      # partial failure still gets tidied. No-op when the variable was never set.
-      - name: Remove the throwaway branch
-        if: always()
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          set -uo pipefail
-          if [ -z "${CLEANUP_BRANCH:-}" ]; then
-            echo "nothing to clean up"
-            exit 0
-          fi
-          if gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$CLEANUP_BRANCH" --silent 2>/dev/null; then
-            echo "::notice::deleted refs/heads/$CLEANUP_BRANCH"
-          else
-            echo "::warning::could not delete refs/heads/$CLEANUP_BRANCH — remove it by hand."
-          fi

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -95,7 +95,13 @@ cp -n docker/workbench/.env.database.example docker/workbench/.env.database
 
 > The template is the single source for those values — do not retype them here or anywhere else. If you override `SA_PASSWORD` / `PG_PASSWORD` in `docker/workbench/.env`, update `.env.database` to match.
 
-**2. Provider API keys are *valid*, not merely present.** The live-model tier has **no credential preflight** — a dead key fails the tier and the failures look exactly like product defects. In one build an expired Gemini key produced 11 red agent tests that were triaged as a `BaseAgent` regression before the real cause surfaced. Verify before you start:
+**2. The release path can still write to `next`.** Run **Actions → "Verify the release App token" → Run workflow**. It is read-only and takes under a minute.
+
+Everything `publish.yml` does after the packages reach npm — the `main` → `next` back-merge and the `release-lines.json` ledger — pushes to a protected branch, and the identity doing it must hold a ruleset bypass. That bypass is GitHub configuration living outside this repo: no CI job can prove it is intact, and a ruleset edit that revokes it looks like nothing at all until a release is already half-done. On 2026-09-03 exactly that happened, and v6.1.0-edge.6 published to npm and then could not merge back ([#4382](https://github.com/MemberJunction/MJ/pull/4382)).
+
+Green means the App token minted (key valid, permissions intact), the identity is `blue-cypress-ci-bot`, and `can_bypass` reports `always`. Anything else: **stop and fix it before starting the release.** A publish that strands itself between npm and `next` opens a fallback PR rather than losing work, but it is still a red release and an hour you do not get back.
+
+**3. Provider API keys are *valid*, not merely present.** The live-model tier has **no credential preflight** — a dead key fails the tier and the failures look exactly like product defects. In one build an expired Gemini key produced 11 red agent tests that were triaged as a `BaseAgent` regression before the real cause surfaced. Verify before you start:
 
 ```bash
 # Google — 200 = good, 400 = dead key
@@ -107,13 +113,13 @@ curl -s -o /dev/null -w 'openai=%{http_code}\n' https://api.openai.com/v1/models
   -H "Authorization: Bearer $(grep '^AI_VENDOR_API_KEY__OpenAILLM=' .env | cut -d= -f2- | tr -d "'\"")"
 ```
 
-**3. `MJ_API_KEY` is in repo-root `.env`, not just your shell.** It is a **self-chosen shared secret** — no registry issues it; `MJServer` reads `process.env.MJ_API_KEY` and string-compares it against the `x-mj-api-key` header. Both MJAPI *and* the test run need the same value, so `.env` is the only channel that reliably reaches both. Generate one if absent:
+**4. `MJ_API_KEY` is in repo-root `.env`, not just your shell.** It is a **self-chosen shared secret** — no registry issues it; `MJServer` reads `process.env.MJ_API_KEY` and string-compares it against the `x-mj-api-key` header. Both MJAPI *and* the test run need the same value, so `.env` is the only channel that reliably reaches both. Generate one if absent:
 
 ```bash
 grep -q '^MJ_API_KEY=' .env || printf 'MJ_API_KEY=%s\n' "$(openssl rand -hex 32)" >> .env
 ```
 
-**4. Docker has headroom.** Step 8's workbench adds four containers plus two turbo builds. Check before you start — an unrelated hot container has starved SQL Server badly enough to masquerade as migration timeouts for over an hour:
+**5. Docker has headroom.** Step 8's workbench adds four containers plus two turbo builds. Check before you start — an unrelated hot container has starved SQL Server badly enough to masquerade as migration timeouts for over an hour:
 
 ```bash
 docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}'
@@ -121,14 +127,14 @@ docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}'
 
 Stop anything unrelated. On a < 8 GiB Docker VM, cap every turbo build with `--concurrency=2`.
 
-**5. If you are releasing from a FRESH CLONE, four things are missing that nothing tells you about.** Each is gitignored, so the repo looks complete and fails later, in a place that does not name the cause.
+**6. If you are releasing from a FRESH CLONE, four things are missing that nothing tells you about.** Each is gitignored, so the repo looks complete and fails later, in a place that does not name the cause.
 
 - **The repo must be BUILT before Step 3.** `mj` is a workspace package; without `packages/MJCLI/dist` the CLI loads but registers no subcommands, so `pnpm mj migrate` fails with a bare `Error: command migrate not found` — which reads like a bad install, not a missing build. Run `pnpm install && pnpm run build` first. This effectively moves Step 7 to the front on a fresh clone; that is fine, and Step 7 re-runs cheaply from cache.
 - **`packages/MJAPI/.env` must exist**, as a symlink to the repo-root `.env` (`ln -s ../../.env .env`). Without it MJAPI dies at boot on `dbDatabase / dbUsername / dbPassword … Required`, which reads as a config-file problem rather than a missing file. Working clones have this symlink; a fresh one does not.
 - **`packages/MJExplorer/src/environments/environment.ts` must exist**, or any full build fails on `Could not resolve "../environments/environment"`. CI writes this file inline before building — copy that block out of `.github/workflows/test.yml` rather than inventing values.
 - **Step 8's converter needs Python + `sqlglot`.** `mj migrate convert` shells out to a Python interpreter and fails with `the interpreter 'python3' has no sqlglot module`. On macOS, PEP 668 blocks a system `pip install`, so make a venv and point the converter at it: `python3 -m venv <dir> && <dir>/bin/pip install 'sqlglot>=27'`, then `export MJ_SQLGLOT_PYTHON=<dir>/bin/python`.
 
-**6. Pointing `mj` at PostgreSQL takes the `DB_*` variables, not the `PG_*` ones — and `.env` beats your shell.** Step 8's verification runs `mj migrate` / `mj sync push` against a PostgreSQL database, and there are three separate traps in getting them there. Each produces an error that names something other than its cause.
+**7. Pointing `mj` at PostgreSQL takes the `DB_*` variables, not the `PG_*` ones — and `.env` beats your shell.** Step 8's verification runs `mj migrate` / `mj sync push` against a PostgreSQL database, and there are three separate traps in getting them there. Each produces an error that names something other than its cause.
 
 - **`mj.config.cjs` reads `DB_HOST` / `DB_PORT` / `DB_DATABASE` / `DB_USERNAME` / `DB_PASSWORD` only.** It never consults `PG_HOST` / `PG_PORT`. (Those exist for CodeGenLib's own config layer — see [`packages/CodeGenLib/CLAUDE.md`](packages/CodeGenLib/CLAUDE.md) — which is a different resolver.) Export only the `PG_*` family and `DB_PORT` stays **1433**, so the PostgreSQL client dials SQL Server, which closes the socket on an unrecognised startup packet. You get `Database connection failed: Connection terminated unexpectedly` — which reads as a flaky database, not a wrong port.
 - **`mj migrate` authenticates with the CODEGEN credentials**, because migrations need DDL rights: `CODEGEN_DB_USERNAME` / `CODEGEN_DB_PASSWORD`. Set `DB_USERNAME=postgres` but leave `CODEGEN_DB_USERNAME=sa` and PostgreSQL rejects `sa`. The CLI truncates the message to `password authentication failed for user` **without naming the user**; `docker logs <pg-container>` names it (`FATAL: password authentication failed for user "sa"`) and is the fastest way to see what actually happened.
@@ -400,7 +406,7 @@ cd packages/MJAPI && MJ_DISABLE_TASK_GRAPH_DISPATCHER=1 pnpm start
 
 > ⚠️ **Run it from `packages/MJAPI`, not `pnpm run start:api` from the repo root.** The root script is `turbo start --filter=mj_api`, and **turbo passes through only the environment variables declared in `turbo.json`** — anything else is stripped before the task sees it. Overriding the database with `DB_DATABASE=… pnpm run start:api` therefore fails with `Error parsing config file … "path": ["dbDatabase"] … "received": "undefined"`, which reads like a config-file problem rather than an env-passthrough one. Running from the package directory bypasses turbo entirely and the variables arrive intact.
 
-- `MJ_API_KEY` must be in **repo-root `.env`** (Step 0.3), not just your shell — MJAPI and the test run are separate processes and both must see the same value. You invent this value; nothing issues it (`MJServer` string-compares `process.env.MJ_API_KEY` against the `x-mj-api-key` header). Confirm it authenticates end-to-end before running the suite, rather than discovering it 19 tests later:
+- `MJ_API_KEY` must be in **repo-root `.env`** (Step 0.4), not just your shell — MJAPI and the test run are separate processes and both must see the same value. You invent this value; nothing issues it (`MJServer` string-compares `process.env.MJ_API_KEY` against the `x-mj-api-key` header). Confirm it authenticates end-to-end before running the suite, rather than discovering it 19 tests later:
   ```bash
   curl -s -o /dev/null -w '%{http_code}\n' -X POST "http://localhost:${GRAPHQL_PORT:-4000}/" \
     -H 'Content-Type: application/json' -H "x-mj-api-key: $(grep '^MJ_API_KEY=' .env | cut -d= -f2-)" \

--- a/ci/back-merge.mjs
+++ b/ci/back-merge.mjs
@@ -17,6 +17,29 @@ import fs from 'node:fs';
 export const LOCKFILE = 'pnpm-lock.yaml';
 
 /**
+ * Git remote to PUSH `next` through.
+ *
+ * `next` is protected by ruleset `next-protect`, whose bypass list accepts only roles,
+ * teams and GitHub Apps — never an individual user. The release PAT's account
+ * (`MJ-GH-bot`) is an outside collaborator, so it cannot be granted a bypass at all, and
+ * as of 2026-09-03 it no longer has one: every push to `next` from publish.yml was
+ * rejected with GH013 until the `blue-cypress-ci-bot` App was added as a bypass actor.
+ *
+ * The workflow therefore adds a second remote authenticated as that App and points this
+ * at it. Reads still go through `origin` on the PAT — only the write to `next` moves, so
+ * pushes to `main` and `lts/**` and every `gh` call are untouched.
+ *
+ * Defaults to `origin` so a developer running `pnpm run mergemain` by hand behaves exactly
+ * as before (and succeeds if they are in `break-glass`).
+ *
+ * @returns {string} remote name
+ */
+export function nextPushRemote() {
+    const remote = (process.env.MJ_NEXT_PUSH_REMOTE ?? '').trim();
+    return remote === '' ? 'origin' : remote;
+}
+
+/**
  * Paths a conflicted back-merge may resolve without a human.
  *
  * The lockfile qualifies because it is *derived* — regenerated from the package.json files

--- a/ci/back-merge.test.mjs
+++ b/ci/back-merge.test.mjs
@@ -11,6 +11,7 @@ import {
   classifyMergeConflicts,
   mergeMainIntoNext,
   refreshLockfile,
+  nextPushRemote,
   LOCKFILE,
 } from './back-merge.mjs';
 
@@ -146,4 +147,43 @@ test('refreshLockfile: an unchanged lockfile produces no commit', async () => {
   const { client, calls } = fakeGit({ status: { modified: [], not_added: [] } });
   assert.equal(await refreshLockfile(client, { required: false, runInstall: () => {} }), false);
   assert.deepEqual(calls, []);
+});
+
+// --- nextPushRemote -------------------------------------------------------------------
+// `next` is protected and the release PAT's account can never hold a ruleset bypass (it is
+// an outside collaborator, and bypass accepts only roles, teams and Apps). The push is
+// therefore redirected to an App-authenticated remote in CI — but a developer running
+// `pnpm run mergemain` by hand must keep the old behaviour.
+
+test('nextPushRemote defaults to origin so a local mergemain is unchanged', () => {
+  const prior = process.env.MJ_NEXT_PUSH_REMOTE;
+  delete process.env.MJ_NEXT_PUSH_REMOTE;
+  try {
+    assert.equal(nextPushRemote(), 'origin');
+  } finally {
+    if (prior !== undefined) process.env.MJ_NEXT_PUSH_REMOTE = prior;
+  }
+});
+
+test('nextPushRemote honours the override CI sets', () => {
+  const prior = process.env.MJ_NEXT_PUSH_REMOTE;
+  process.env.MJ_NEXT_PUSH_REMOTE = 'next-push';
+  try {
+    assert.equal(nextPushRemote(), 'next-push');
+  } finally {
+    if (prior === undefined) delete process.env.MJ_NEXT_PUSH_REMOTE;
+    else process.env.MJ_NEXT_PUSH_REMOTE = prior;
+  }
+});
+
+test('nextPushRemote treats an empty or blank override as unset', () => {
+  // An unset secret or a `with:` that resolved to nothing yields '' — falling back to
+  // origin fails loudly on the protection rather than pushing to a remote named ''.
+  const prior = process.env.MJ_NEXT_PUSH_REMOTE;
+  for (const blank of ['', '   ']) {
+    process.env.MJ_NEXT_PUSH_REMOTE = blank;
+    assert.equal(nextPushRemote(), 'origin');
+  }
+  if (prior === undefined) delete process.env.MJ_NEXT_PUSH_REMOTE;
+  else process.env.MJ_NEXT_PUSH_REMOTE = prior;
 });

--- a/ci/backmerge-fallback.mjs
+++ b/ci/backmerge-fallback.mjs
@@ -121,10 +121,48 @@ export async function main(argv, { run = defaultRun, env = process.env, log = co
     run('git', ['fetch', '--no-tags', 'origin', 'main']);
     const mainSha = run('git', ['rev-parse', 'FETCH_HEAD']);
 
+    // Is there anything to back-merge at all?
+    //
+    // The back-merge step can fail for reasons that leave main already merged — a lockfile
+    // regeneration that died after the merge commit landed and pushed, say. Opening a PR
+    // then produces "No commits between next and <branch>", the fallback dies, and the
+    // operator is told to run `git merge origin/main` by hand — advice that is actively
+    // wrong, because there is nothing to merge.
+    //
+    // Tested by ANCESTRY rather than by matching that error string: a message-based check
+    // silently stops working the day GitHub rewords it, and this is the branch of the code
+    // nobody exercises until it matters.
+    run('git', ['fetch', '--no-tags', 'origin', args.base]);
+    const baseSha = run('git', ['rev-parse', 'FETCH_HEAD']);
+    let alreadyMerged = true;
+    try {
+        run('git', ['merge-base', '--is-ancestor', mainSha, baseSha]);
+    } catch (e) {
+        // 1 = "not an ancestor", i.e. a real back-merge is outstanding. Anything else is a
+        // broken repo state and must not be read as "there is work to do".
+        if (e.status !== 1) throw e;
+        alreadyMerged = false;
+    }
+    if (alreadyMerged) {
+        log(`::notice::main (${mainSha}) is already an ancestor of ${args.base} — nothing to back-merge.`);
+        if (env.GITHUB_OUTPUT) fs.appendFileSync(env.GITHUB_OUTPUT, 'nothing_to_merge=true\n');
+        if (env.GITHUB_STEP_SUMMARY) {
+            fs.appendFileSync(env.GITHUB_STEP_SUMMARY,
+                `### Back-merge step failed, but there is nothing to back-merge\n\n\`main\` is already an ancestor of \`${args.base}\`.\n`);
+        }
+        return null;
+    }
+
     let branchExists = true;
     try {
         run('git', ['ls-remote', '--exit-code', args.remote, `refs/heads/${branch}`]);
-    } catch {
+    } catch (e) {
+        // `--exit-code` returns 2 for "no matching ref" and 128 for "cannot reach the
+        // remote" (bad credential, network, wrong URL). Swallowing both would report a
+        // dead remote as "the branch does not exist yet" and then attempt a push that
+        // cannot succeed — a misleading error from the one script whose whole job is to
+        // diagnose a failure. Only 2 means absent.
+        if (e.status !== 2) throw e;
         branchExists = false;
     }
 

--- a/ci/backmerge-fallback.mjs
+++ b/ci/backmerge-fallback.mjs
@@ -1,0 +1,168 @@
+/**
+ * Fallback for a post-publish `main` -> `next` back-merge that could not be pushed.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * publish.yml's back-merge step is the LAST thing a release does, and it runs after the
+ * packages are already on npm. When it fails, the repo is left "published, not merged":
+ * recoverable, but only by someone reconstructing the release commits by hand. That has
+ * now happened twice — MJ#3658 (edge.1), MJ#3752 (edge.2) — and a third time at
+ * v6.1.0-edge.6 (MJ#4382), which is what prompted this.
+ *
+ * Two distinct things make the push fail, and a PR is the answer to both:
+ *
+ *   1. A CONFLICT. ci/back-merge.mjs refuses to guess at anything but the lockfile (see
+ *      the note there on why `-X theirs` was removed), so a real conflict aborts the merge
+ *      and leaves `next` untouched. No amount of credential fixing helps: a human has to
+ *      resolve it, and a PR is where they do that.
+ *   2. A REJECTED PUSH. `next` is protected; the release identity must hold a ruleset
+ *      bypass. That is fixed for now, but a bypass is configuration living outside this
+ *      repo — it can be revoked, expire with a credential, or be dropped in a future
+ *      ruleset edit, exactly as it was on 2026-09-03. This path is what turns that from a
+ *      manual salvage into a link.
+ *
+ * WHAT IT DOES NOT DO
+ * -------------------
+ * It does not resolve the conflict, and it does not make the release "done". The back-merge
+ * is still outstanding until a human merges the PR — so the caller is expected to fail the
+ * job after this runs. The value is that the recovery is a review instead of an
+ * archaeology exercise: the branch is main's actual tip, pushed by the workflow's own
+ * tooling, rather than commits reassembled by hand.
+ *
+ * Idempotent. Re-running a partially-completed publish reuses the branch and the open PR
+ * rather than stacking duplicates.
+ *
+ * Usage:
+ *   node ci/backmerge-fallback.mjs --version v6.1.0-edge.6 [--remote next-push] [--base next]
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+
+/**
+ * Branch name carrying the back-merge.
+ *
+ * Version-stamped, not timestamped: re-running the same failed publish must land on the
+ * same branch so the run is idempotent. Exactly one leading `v` regardless of how the
+ * caller spells the version — publish.yml has both forms in flight (`$VERSION` is
+ * `v`-prefixed, `${VERSION#v}` is not) and a branch pair differing only by a `v` would
+ * defeat the idempotency this exists for.
+ *
+ * @param {string} version
+ * @returns {string}
+ */
+export function backmergeBranchName(version) {
+    const v = String(version ?? '').trim();
+    if (v === '') throw new Error('a version is required to name the back-merge branch');
+    return `chore/backmerge-v${v.replace(/^v+/, '')}`;
+}
+
+/**
+ * Decide what still needs doing, given what already exists on the remote.
+ *
+ * Split out from the IO so the idempotency rules are testable without a network: the
+ * interesting cases are all "a previous run got part way".
+ *
+ * @param {{branchExists: boolean, openPrUrl: string|null}} state
+ * @returns {{pushBranch: boolean, createPr: boolean, note: string}}
+ */
+export function planFallback({ branchExists, openPrUrl }) {
+    if (openPrUrl) {
+        // The PR is the deliverable. If one is already open, the branch behind it is
+        // whatever a human has been working on — re-pushing main's tip over it could
+        // discard conflict resolutions already committed there.
+        return { pushBranch: false, createPr: false, note: `back-merge PR already open: ${openPrUrl}` };
+    }
+    if (branchExists) {
+        return { pushBranch: false, createPr: true, note: 'branch already pushed by an earlier run; opening the PR' };
+    }
+    return { pushBranch: true, createPr: true, note: 'creating the back-merge branch and PR' };
+}
+
+/** Body for the PR. Kept out of main() so a test can read it without running anything. */
+export function prBody({ version, branch, base, reason }) {
+    return [
+        `Automated fallback: publish.yml could not complete the post-publish \`main\` -> \`${base}\` back-merge for **${version}**.`,
+        '',
+        '```',
+        (reason || 'no failure detail was captured').trim(),
+        '```',
+        '',
+        `\`${branch}\` is \`main\`'s current tip, pushed by the workflow — not commits reassembled by hand.`,
+        '',
+        '**The release itself is fine.** Packages are on npm and the tag is pushed; only the back-merge is outstanding.',
+        'Verify against the registry rather than the run\'s exit code, then resolve any conflicts here and merge.',
+        '',
+        'The publish run is deliberately red while this is open — that is the signal the back-merge has not landed.',
+    ].join('\n');
+}
+
+/** @returns {string} stdout, trimmed */
+const defaultRun = (file, args) => execFileSync(file, args, { encoding: 'utf8' }).trim();
+
+export async function main(argv, { run = defaultRun, env = process.env, log = console.log } = {}) {
+    const args = { remote: 'origin', base: 'next', version: undefined, reason: '' };
+    // Pin gh to the repository explicitly. `origin` carries an embedded credential in CI,
+    // and letting gh infer the repo from a remote URL it has to parse is an avoidable
+    // dependency at the exact moment things are already going wrong.
+    const repoArgs = (env.GITHUB_REPOSITORY ?? '') !== '' ? ['--repo', env.GITHUB_REPOSITORY] : [];
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i] === '--version') args.version = argv[++i];
+        else if (argv[i] === '--remote') args.remote = argv[++i];
+        else if (argv[i] === '--base') args.base = argv[++i];
+        else if (argv[i] === '--reason') args.reason = argv[++i];
+    }
+    if (!args.version) throw new Error('usage: backmerge-fallback.mjs --version <vX.Y.Z> [--remote r] [--base b] [--reason text]');
+
+    const branch = backmergeBranchName(args.version);
+
+    // Read main from `origin`: the push remote exists only to satisfy the protection on
+    // `next` and is not guaranteed to have been fetched.
+    run('git', ['fetch', '--no-tags', 'origin', 'main']);
+    const mainSha = run('git', ['rev-parse', 'FETCH_HEAD']);
+
+    let branchExists = true;
+    try {
+        run('git', ['ls-remote', '--exit-code', args.remote, `refs/heads/${branch}`]);
+    } catch {
+        branchExists = false;
+    }
+
+    let openPrUrl = null;
+    const found = run('gh', ['pr', 'list', ...repoArgs, '--head', branch, '--base', args.base, '--state', 'open', '--json', 'url', '--jq', '.[0].url // ""']);
+    if (found) openPrUrl = found;
+
+    const plan = planFallback({ branchExists, openPrUrl });
+    log(`::notice::${plan.note}`);
+
+    if (plan.pushBranch) {
+        // Push main's tip straight to the new ref — no checkout, so the job's working tree
+        // (which still holds the aborted merge's aftermath) is irrelevant here.
+        run('git', ['push', args.remote, `${mainSha}:refs/heads/${branch}`]);
+        log(`pushed ${branch} at ${mainSha}`);
+    }
+
+    if (plan.createPr) {
+        const bodyFile = `${env.RUNNER_TEMP || '/tmp'}/backmerge-fallback-body.md`;
+        fs.writeFileSync(bodyFile, prBody({ version: args.version, branch, base: args.base, reason: args.reason }));
+        openPrUrl = run('gh', ['pr', 'create', ...repoArgs, '--base', args.base, '--head', branch,
+            '--title', `chore: back-merge main into ${args.base} after ${args.version}`,
+            '--body-file', bodyFile]);
+    }
+
+    log(`::notice::back-merge PR: ${openPrUrl}`);
+    if (env.GITHUB_OUTPUT) fs.appendFileSync(env.GITHUB_OUTPUT, `pr_url=${openPrUrl}\n`);
+    if (env.GITHUB_STEP_SUMMARY) {
+        fs.appendFileSync(env.GITHUB_STEP_SUMMARY,
+            `### Back-merge could not be pushed\n\nOpened ${openPrUrl} carrying \`main\` at \`${mainSha.slice(0, 10)}\`.\n`);
+    }
+    return openPrUrl;
+}
+
+// Entry point only when executed directly, so the tests can import this file.
+if (process.argv[1] && process.argv[1].endsWith('backmerge-fallback.mjs')) {
+    main(process.argv.slice(2)).catch((err) => {
+        console.error(`FAIL ${err.message}`);
+        process.exit(1);
+    });
+}

--- a/ci/backmerge-fallback.test.mjs
+++ b/ci/backmerge-fallback.test.mjs
@@ -1,0 +1,121 @@
+// Tests for ci/backmerge-fallback.mjs — run with: node --test "ci/*.test.mjs"
+// (also run in CI by .github/workflows/ci-scripts.yml, install-free)
+//
+// The behaviour under test is idempotency. This script runs on the unhappy path of an
+// ALREADY-PUBLISHED release, which is exactly when a human re-runs the job — so "a
+// previous attempt got part way" is the normal case, not an edge case. Stacking a second
+// branch or a duplicate PR on a re-run would make a bad moment worse.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { backmergeBranchName, planFallback, prBody, main } from './backmerge-fallback.mjs';
+
+test('branch name is version-stamped so re-runs reuse it', () => {
+  assert.equal(backmergeBranchName('v6.1.0-edge.6'), 'chore/backmerge-v6.1.0-edge.6');
+});
+
+test('branch name normalises the v prefix', () => {
+  // publish.yml has both spellings in flight — $VERSION is v-prefixed, ${VERSION#v} is
+  // not. A pair of branches differing only by a `v` would defeat the idempotency.
+  assert.equal(backmergeBranchName('6.1.0-edge.6'), backmergeBranchName('v6.1.0-edge.6'));
+  assert.equal(backmergeBranchName('vv6.1.0'), 'chore/backmerge-v6.1.0');
+});
+
+test('branch name refuses an empty version rather than making chore/backmerge-v', () => {
+  assert.throws(() => backmergeBranchName(''), /version is required/);
+  assert.throws(() => backmergeBranchName(undefined), /version is required/);
+});
+
+test('fresh failure: push the branch and open the PR', () => {
+  assert.deepEqual(planFallback({ branchExists: false, openPrUrl: null }),
+    { pushBranch: true, createPr: true, note: 'creating the back-merge branch and PR' });
+});
+
+test('branch survived a half-finished run: reuse it, still open the PR', () => {
+  const plan = planFallback({ branchExists: true, openPrUrl: null });
+  assert.equal(plan.pushBranch, false);
+  assert.equal(plan.createPr, true);
+});
+
+test('PR already open: touch nothing', () => {
+  // Re-pushing main's tip over the branch could discard conflict resolutions a human has
+  // already committed there — the whole point of the PR.
+  const plan = planFallback({ branchExists: true, openPrUrl: 'https://github.com/o/r/pull/1' });
+  assert.equal(plan.pushBranch, false);
+  assert.equal(plan.createPr, false);
+  assert.match(plan.note, /already open/);
+});
+
+test('PR body carries the failure reason and does not claim the release failed', () => {
+  const body = prBody({ version: 'v6.1.0-edge.6', branch: 'b', base: 'next', reason: 'CONFLICT in x.ts' });
+  assert.match(body, /CONFLICT in x\.ts/);
+  assert.match(body, /The release itself is fine/);
+  assert.match(body, /deliberately red/);
+});
+
+test('PR body survives an empty reason', () => {
+  assert.match(prBody({ version: 'v1', branch: 'b', base: 'next', reason: '' }), /no failure detail/);
+});
+
+/** Records every command so a test can assert on what the script actually did. */
+function fakeRun({ branchExists = false, existingPr = '', createdPr = 'https://github.com/o/r/pull/9' } = {}) {
+  const calls = [];
+  const run = (file, args) => {
+    calls.push([file, ...args]);
+    if (file === 'git' && args[0] === 'rev-parse') return 'abc123def456';
+    if (file === 'git' && args[0] === 'ls-remote') {
+      if (!branchExists) throw new Error('exit 2');
+      return 'abc123 refs/heads/x';
+    }
+    if (file === 'gh' && args[1] === 'list') return existingPr;
+    if (file === 'gh' && args[1] === 'create') return createdPr;
+    return '';
+  };
+  return { calls, run };
+}
+
+test('fresh failure pushes main\'s tip to the versioned ref and opens one PR', async () => {
+  const { calls, run } = fakeRun();
+  const url = await main(['--version', 'v6.1.0-edge.6', '--remote', 'next-push'], { run, env: {}, log: () => {} });
+  assert.equal(url, 'https://github.com/o/r/pull/9');
+
+  const push = calls.find((c) => c[0] === 'git' && c[1] === 'push');
+  // Pushes the resolved sha, not a local branch name: the working tree at this point
+  // still holds the aborted merge's aftermath and must not be the source of truth.
+  assert.deepEqual(push, ['git', 'push', 'next-push', 'abc123def456:refs/heads/chore/backmerge-v6.1.0-edge.6']);
+  assert.equal(calls.filter((c) => c[0] === 'gh' && c[2] === 'create').length, 1);
+});
+
+test('re-run with a PR already open pushes nothing and creates nothing', async () => {
+  const { calls, run } = fakeRun({ branchExists: true, existingPr: 'https://github.com/o/r/pull/4382' });
+  const url = await main(['--version', 'v6.1.0-edge.6'], { run, env: {}, log: () => {} });
+  assert.equal(url, 'https://github.com/o/r/pull/4382');
+  assert.equal(calls.some((c) => c[1] === 'push'), false);
+  assert.equal(calls.some((c) => c[0] === 'gh' && c[2] === 'create'), false);
+});
+
+test('main reads from origin even when pushing through another remote', async () => {
+  // The push remote exists only to satisfy the protection on `next`; it is not guaranteed
+  // to have been fetched, so `main` must be read from origin.
+  const { calls, run } = fakeRun();
+  await main(['--version', 'v1.0.0', '--remote', 'next-push'], { run, env: {}, log: () => {} });
+  assert.deepEqual(calls[0], ['git', 'fetch', '--no-tags', 'origin', 'main']);
+});
+
+test('a missing version fails loudly instead of guessing', async () => {
+  const { run } = fakeRun();
+  await assert.rejects(() => main([], { run, env: {}, log: () => {} }), /usage:/);
+});
+
+test('gh is pinned to the repo when the runner provides one', async () => {
+  const { calls, run } = fakeRun();
+  await main(['--version', 'v1.0.0'], { run, env: { GITHUB_REPOSITORY: 'o/r' }, log: () => {} });
+  for (const c of calls.filter((c) => c[0] === 'gh')) {
+    assert.ok(c.includes('--repo') && c[c.indexOf('--repo') + 1] === 'o/r', `missing --repo: ${c.join(' ')}`);
+  }
+});
+
+test('gh omits --repo when the runner provides none, rather than passing an empty one', async () => {
+  const { calls, run } = fakeRun();
+  await main(['--version', 'v1.0.0'], { run, env: {}, log: () => {} });
+  assert.equal(calls.filter((c) => c[0] === 'gh').some((c) => c.includes('--repo')), false);
+});

--- a/ci/backmerge-fallback.test.mjs
+++ b/ci/backmerge-fallback.test.mjs
@@ -7,6 +7,9 @@
 // branch or a duplicate PR on a re-run would make a bad moment worse.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { backmergeBranchName, planFallback, prBody, main } from './backmerge-fallback.mjs';
 
 test('branch name is version-stamped so re-runs reuse it', () => {
@@ -56,14 +59,46 @@ test('PR body survives an empty reason', () => {
   assert.match(prBody({ version: 'v1', branch: 'b', base: 'next', reason: '' }), /no failure detail/);
 });
 
-/** Records every command so a test can assert on what the script actually did. */
-function fakeRun({ branchExists = false, existingPr = '', createdPr = 'https://github.com/o/r/pull/9' } = {}) {
+
+/**
+ * An env whose RUNNER_TEMP is a throwaway directory. main() writes the PR body to a file,
+ * and without this the suite drops /tmp/backmerge-fallback-body.md on the developer's
+ * machine on every run.
+ */
+function withTmpEnv(extra = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bmf-'));
+  return { env: { RUNNER_TEMP: dir, ...extra }, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+/**
+ * Records every command so a test can assert on what the script actually did.
+ *
+ * Exit CODES matter here, not just success/failure: the script distinguishes `ls-remote`
+ * 2 (ref absent) from 128 (remote unreachable), and `merge-base --is-ancestor` 1 (work to
+ * do) from anything else. A fake that threw a bare Error for every failure would pass
+ * whether or not that logic exists, which is the opposite of useful.
+ */
+function fakeRun({
+  branchExists = false,
+  existingPr = '',
+  createdPr = 'https://github.com/o/r/pull/9',
+  lsRemoteStatus = 2,
+  alreadyMerged = false,
+  mergeBaseStatus = 1,
+} = {}) {
   const calls = [];
+  const fail = (status) => { const e = new Error(`exit ${status}`); e.status = status; throw e; };
   const run = (file, args) => {
     calls.push([file, ...args]);
-    if (file === 'git' && args[0] === 'rev-parse') return 'abc123def456';
+    if (file === 'git' && args[0] === 'rev-parse') {
+      // main and the base branch must differ, or every run looks already-merged.
+      return calls.filter((c) => c[1] === 'rev-parse').length === 1 ? 'abc123def456' : 'base9999';
+    }
+    if (file === 'git' && args[0] === 'merge-base') {
+      return alreadyMerged ? '' : fail(mergeBaseStatus);
+    }
     if (file === 'git' && args[0] === 'ls-remote') {
-      if (!branchExists) throw new Error('exit 2');
+      if (!branchExists) return fail(lsRemoteStatus);
       return 'abc123 refs/heads/x';
     }
     if (file === 'gh' && args[1] === 'list') return existingPr;
@@ -75,7 +110,8 @@ function fakeRun({ branchExists = false, existingPr = '', createdPr = 'https://g
 
 test('fresh failure pushes main\'s tip to the versioned ref and opens one PR', async () => {
   const { calls, run } = fakeRun();
-  const url = await main(['--version', 'v6.1.0-edge.6', '--remote', 'next-push'], { run, env: {}, log: () => {} });
+  const t = withTmpEnv();
+  const url = await main(['--version', 'v6.1.0-edge.6', '--remote', 'next-push'], { run, env: t.env, log: () => {} }).finally(t.cleanup);
   assert.equal(url, 'https://github.com/o/r/pull/9');
 
   const push = calls.find((c) => c[0] === 'git' && c[1] === 'push');
@@ -97,7 +133,8 @@ test('main reads from origin even when pushing through another remote', async ()
   // The push remote exists only to satisfy the protection on `next`; it is not guaranteed
   // to have been fetched, so `main` must be read from origin.
   const { calls, run } = fakeRun();
-  await main(['--version', 'v1.0.0', '--remote', 'next-push'], { run, env: {}, log: () => {} });
+  const t = withTmpEnv();
+  await main(['--version', 'v1.0.0', '--remote', 'next-push'], { run, env: t.env, log: () => {} }).finally(t.cleanup);
   assert.deepEqual(calls[0], ['git', 'fetch', '--no-tags', 'origin', 'main']);
 });
 
@@ -108,7 +145,8 @@ test('a missing version fails loudly instead of guessing', async () => {
 
 test('gh is pinned to the repo when the runner provides one', async () => {
   const { calls, run } = fakeRun();
-  await main(['--version', 'v1.0.0'], { run, env: { GITHUB_REPOSITORY: 'o/r' }, log: () => {} });
+  const t = withTmpEnv({ GITHUB_REPOSITORY: 'o/r' });
+  await main(['--version', 'v1.0.0'], { run, env: t.env, log: () => {} }).finally(t.cleanup);
   for (const c of calls.filter((c) => c[0] === 'gh')) {
     assert.ok(c.includes('--repo') && c[c.indexOf('--repo') + 1] === 'o/r', `missing --repo: ${c.join(' ')}`);
   }
@@ -116,6 +154,49 @@ test('gh is pinned to the repo when the runner provides one', async () => {
 
 test('gh omits --repo when the runner provides none, rather than passing an empty one', async () => {
   const { calls, run } = fakeRun();
-  await main(['--version', 'v1.0.0'], { run, env: {}, log: () => {} });
+  const t = withTmpEnv();
+  await main(['--version', 'v1.0.0'], { run, env: t.env, log: () => {} }).finally(t.cleanup);
   assert.equal(calls.filter((c) => c[0] === 'gh').some((c) => c.includes('--repo')), false);
+});
+
+// --- the failures that only show up when something else has already gone wrong ----------
+
+test('an unreachable remote is not reported as "the branch does not exist"', async () => {
+  // ls-remote --exit-code returns 2 for "no matching ref" and 128 for a dead remote. Reading
+  // 128 as "absent" would attempt a push that cannot succeed and bury the real cause.
+  const { run } = fakeRun({ lsRemoteStatus: 128 });
+  await assert.rejects(() => main(['--version', 'v1.0.0'], { run, env: {}, log: () => {} }),
+    (e) => e.status === 128);
+});
+
+test('main already merged: report nothing to do instead of opening an empty PR', async () => {
+  // gh would fail this with "No commits between ...", the fallback would die, and the
+  // operator would be told to `git merge origin/main` by hand — advice that is wrong,
+  // because there is nothing to merge.
+  const { calls, run } = fakeRun({ alreadyMerged: true });
+  const url = await main(['--version', 'v1.0.0'], { run, env: {}, log: () => {} });
+  assert.equal(url, null);
+  assert.equal(calls.some((c) => c[0] === 'gh'), false, 'must not touch gh at all');
+  assert.equal(calls.some((c) => c[1] === 'push'), false);
+});
+
+test('nothing_to_merge is reported to the workflow, not just logged', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bmf-'));
+  const out = path.join(dir, 'out');
+  fs.writeFileSync(out, '');
+  try {
+    const { run } = fakeRun({ alreadyMerged: true });
+    await main(['--version', 'v1.0.0'], { run, env: { GITHUB_OUTPUT: out }, log: () => {} });
+    assert.match(fs.readFileSync(out, 'utf8'), /nothing_to_merge=true/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a broken merge-base is not silently read as "there is work to do"', async () => {
+  // Exit 1 means "not an ancestor". Any other status is a broken repo state, and treating
+  // it as "not merged" would push a branch off a sha nothing has verified.
+  const { run } = fakeRun({ mergeBaseStatus: 129 });
+  await assert.rejects(() => main(['--version', 'v1.0.0'], { run, env: {}, log: () => {} }),
+    (e) => e.status === 129);
 });

--- a/ci/merge_main.mjs
+++ b/ci/merge_main.mjs
@@ -8,7 +8,7 @@
  * something to paper over.
  */
 import { simpleGit } from 'simple-git';
-import { mergeMainIntoNext, LOCKFILE } from './back-merge.mjs';
+import { mergeMainIntoNext, LOCKFILE, nextPushRemote } from './back-merge.mjs';
 
 const git = simpleGit();
 const { lockfileConflicted } = await mergeMainIntoNext(git);
@@ -21,5 +21,6 @@ if (lockfileConflicted) {
   process.exit(1);
 }
 
-console.log(`\nPushing to origin/next...`);
-await git.push('origin', 'HEAD:next');
+const remote = nextPushRemote();
+console.log(`\nPushing to ${remote}/next...`);
+await git.push(remote, 'HEAD:next');

--- a/ci/merge_main_and_update_lock.mjs
+++ b/ci/merge_main_and_update_lock.mjs
@@ -8,7 +8,7 @@
  * its tests can run with no install at all.
  */
 import { simpleGit } from 'simple-git';
-import { mergeMainIntoNext, refreshLockfile, LOCKFILE } from './back-merge.mjs';
+import { mergeMainIntoNext, refreshLockfile, LOCKFILE, nextPushRemote } from './back-merge.mjs';
 
 async function main() {
   const git = simpleGit();
@@ -21,8 +21,11 @@ async function main() {
 
   await refreshLockfile(git, { required: lockfileConflicted });
 
-  console.log('\nPushing to origin/next...');
-  await git.push('origin', 'HEAD:next');
+  // `next` is protected and only the release App may push to it — see nextPushRemote().
+  // The merge above still reads from `origin`; only the write is redirected.
+  const remote = nextPushRemote();
+  console.log(`\nPushing to ${remote}/next...`);
+  await git.push(remote, 'HEAD:next');
   console.log(`Successfully merged main and updated ${LOCKFILE} in next branch`);
 }
 

--- a/guides/RELEASE_ENGINEERING_RUNBOOK.md
+++ b/guides/RELEASE_ENGINEERING_RUNBOOK.md
@@ -16,6 +16,11 @@ There are four distinct operations. Know which one you're doing before you start
 | 3. LTS line patch release | as fixes land on a line | Cert owner | **One button** (`Publish LTS line release` workflow) |
 | 4. Certification flip | once per certification | Cert owner | Scripted-manual |
 
+> **Red publish run with an open `chore/backmerge-v*` PR?** That is a designed state, not a
+> broken one — the release shipped and only the back-merge is outstanding. Go straight to
+> [*Recovery: released, but the back-merge did not land*](#recovery-released-but-the-back-merge-did-not-land)
+> and do not re-run the release.
+
 ---
 
 ## 1. Routine Edge release
@@ -217,6 +222,55 @@ When the gates pass on a specific line build (say 6.1.2):
 
 ---
 
+## Recovery: released, but the back-merge did not land
+
+**A red publish run with an open `chore/backmerge-v*` PR is a designed state, not a broken
+one.** Read this before touching anything — the instinct to "fix" it by hand is how you end
+up with two competing back-merge branches.
+
+`publish.yml` does its last two jobs after the packages are already on npm: merge `main`
+back into `next`, and record the release in `release-lines.json`. If the back-merge cannot
+be completed, the release itself is **fine** — packages published, tag pushed, GitHub
+Release created — and only the merge is outstanding.
+
+Two things cause it, and the workflow responds to both the same way:
+
+| Cause | What it looks like |
+|---|---|
+| **A real conflict.** `ci/back-merge.mjs` refuses to auto-resolve anything but `pnpm-lock.yaml`, because `next` accumulates hours of merges while a release builds and guessing would silently discard them. | The step log names the conflicting paths. |
+| **A rejected push.** `next` is protected; the release App must hold a ruleset bypass, and that is GitHub configuration living outside this repo. | `GH013: Repository rule violations found for refs/heads/next`. |
+
+### What the workflow already did for you
+
+1. Opened **`chore/backmerge-v<version>` → `next`**, carrying `main`'s actual tip with the
+   failure output in the PR body. It is idempotent: re-running the job reuses the open PR
+   and will not push over a branch you have been resolving conflicts on.
+2. Recorded the release in `release-lines.json` anyway — that step is independent and does
+   not wait for the back-merge.
+3. **Failed the run deliberately.** The release is not complete until the PR merges, and a
+   green run would say otherwise.
+
+### What you do
+
+1. Open the PR. Resolve conflicts there and merge it. That is the whole recovery.
+2. If the run is red but there is **no** PR, the fallback itself failed — check its step,
+   then finish by hand: `git checkout next && git merge origin/main`.
+3. If the run warns *"main is already an ancestor of next — nothing to back-merge"*, the
+   merge had in fact landed before the step reported failure. Nothing is outstanding; read
+   the back-merge step's log to find out why it failed anyway.
+
+**Do not re-run the publish workflow to fix this.** The packages are already on npm; a
+re-run cannot republish them and will not help.
+
+### Preventing the rejected-push case
+
+[`DEPLOYMENT.md`](../DEPLOYMENT.md) Step 0 item 2 runs **Actions → "Verify the release App token"**. It is
+read-only, takes under a minute, and reports whether the App's bypass on `next` is still
+live. A revoked bypass is invisible until a release is half-done, which is exactly how
+v6.1.0-edge.6 went ([#4382](https://github.com/MemberJunction/MJ/pull/4382)).
+
+---
+
 ## Safety rails (all operations)
 
 - `latest` moves **only** in operation 4. No build ever publishes to it.
@@ -226,7 +280,8 @@ When the gates pass on a specific line build (say 6.1.2):
 - Lines never merge into `main` or `next`. Fixes flow `next` → line, never the reverse.
 - The post-publish `main` → `next` back-merge **aborts rather than auto-resolving** a
   conflict outside `pnpm-lock.yaml`. An abort means the release succeeded and only the
-  back-merge is outstanding — finish it by hand, don't re-run the release.
+  back-merge is outstanding — **never re-run the release**. `publish.yml` now opens a PR
+  for you; see *Recovery: released, but the back-merge did not land* above.
 - A green `docs.yml` does **not** mean your docs change shipped. It checks out `lts/5` on
   every trigger but an explicit-`ref` dispatch, so a `main` push rebuilds the LTS site and
   reports success while ignoring the commit that triggered it.


### PR DESCRIPTION
Closes the loop on the release automation that broke on 2026-09-03. Both halves touch the same steps in `publish.yml`, so they ship together rather than as two branches that would conflict with each other.

## 1. Push `next` as the release App

`next-protect` accepts only **roles, teams and GitHub Apps** as bypass actors — never an individual user. `MJ-GH-bot`, the account behind `MJ_GH_BOT_GITHUB_TOKEN`, is a repository **admin** but an **outside collaborator**: it cannot be granted a bypass, and cannot join a team to get one (org membership required; the org is at **42/42 seats**). When the ruleset swapped from `RepositoryRole 5` to the `break-glass` team, every push to `next` from this workflow began failing with `GH013`. v6.1.0-edge.6 published cleanly and died on step 22; #4382 recovered it by hand.

`blue-cypress-ci-bot` (`app_id 4705146`) is now a bypass actor, verified end-to-end by the workflow added in #4388/#4390 — identity, `contents: write`, and `can_bypass = always` each confirmed by running it, not by inspection.

This routes the **five** pushes targeting `next` through a second, App-authenticated remote:

| Site | Job |
|---|---|
| Back-merge (via `ci/merge_main_and_update_lock.mjs`) | edge |
| release-lines ledger | edge |
| line-release ledger | LTS |
| `candidate-cut push-next` | candidate cut |
| candidate ledger | candidate cut |

**A second remote, not a swap** — three reasons, each load-bearing:

- The App holds only `contents: write` + `pull_requests: write`. It **could not** perform the `gh issue create/close/comment` or `gh workflow run` calls elsewhere in this file. (Those already run on `${{ github.token }}`, so they're untouched either way — but a blanket token swap would have been a trap waiting for whoever tried it next.)
- Pushes to `main` and `lts/**` were never broken: `lts-lines` still bypasses on the repository-admin role. Moving them would be change for its own sake.
- `origin` keeps the PAT, so every read, the tag push, and all `gh release` calls behave exactly as before.

**Tokens are minted immediately before use, not at job start.** An installation token lives one hour; this job's budget is 120 minutes with a ~25 minute build. A token minted at checkout would routinely be expired by the time the back-merge runs — it is the *last* thing the job does. This is the kind of thing that works in testing and fails on the one release that runs slow.

For `candidate-cut`, `--remote` moves **both** the fetch and the push. `pushNext()` merges `<remote>/next` between retry attempts, so the ref it reads and the ref it writes have to be the same remote.

`nextPushRemote()` defaults to `origin`, so `pnpm run mergemain` by hand is unchanged, and treats a blank override as unset rather than pushing to a remote named `''`.

## 2. Fall back to a PR

**A bypass cannot fix the other way this step fails.** `ci/back-merge.mjs` refuses to guess at anything but the lockfile — deliberately, since `-X theirs` would silently discard the hours of merges `next` accumulates while a release builds. So a genuine conflict aborts the merge and leaves the repo *published, not merged*, recoverable only by reconstructing the release commits by hand. That has happened three times now: #3658, #3752, #4382.

A bypass is also configuration living outside this repo. It can be revoked, or dropped in a future ruleset edit — which is precisely what happened on 09-03.

`ci/backmerge-fallback.mjs` answers both cases: pushes `main`'s actual tip to a version-stamped branch and opens a PR into `next`, carrying the captured failure output. Idempotent — a re-run reuses an open PR and **will not re-push over a branch someone has been resolving conflicts on**.

**The run still ends red.** The back-merge isn't done until that PR merges, and this file's existing doctrine — that a red run is the only honest signal the ledger is behind — still holds. The fallback replaces the archaeology, not the alarm.

## 3. One failure should produce one symptom

The ledger step assumed the back-merge above had already pushed `HEAD:next`. That coupling is why **one** rejected push produced **two** unfinished steps at edge.6. It now resolves `next` itself — matching what the LTS path already did — so the two failures report independently instead of one masking the other.

## Testing

`node --test "ci/*.test.mjs"` → **95 pass, 0 fail**, including 13 new ones. The ones worth reading cover the unhappy path's unhappy path:

- A re-run with a PR already open pushes nothing and creates nothing
- The branch name normalises its `v` prefix — `publish.yml` has both `$VERSION` and `${VERSION#v}` in flight, and a branch pair differing only by a `v` would defeat the idempotency this exists for
- `main` is read from `origin` even when pushing through another remote
- A blank `MJ_NEXT_PUSH_REMOTE` falls back to `origin` rather than becoming a remote named `''`

`ci-scripts.yml` runs this suite install-free on any `ci/**` change, so it gates this PR.

## Scope boundary

**Only the edge back-merge gets a fallback.** The three `release-lines.json` ledger pushes (edge, LTS, candidate) stay fatal with no fallback. That is deliberate — redoing a two-field JSON edit by hand is trivial next to reconstructing a back-merge — but "every push to `next` now has a fallback" would be the wrong reading.

## What this does not prove

No test exercises a real push to `next` — the genuine end-to-end proof only arrives at the next release. The parts that *could* be verified ahead of time were: the App's bypass is live (`can_bypass = always`), and `ci/backmerge-fallback.mjs`'s orchestration is covered by injected-IO tests. The remaining risk is concentrated in the workflow wiring itself, which is why every non-obvious choice above carries an inline comment explaining what breaks if it's changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (commit 3)

An adversarial pass over this PR found four defects, all on the unhappy path — the only path this code ever runs on, so "works in the normal case" was never the bar. Two assumptions were re-derived by experiment rather than argued:

- **`--remote next-push` is safe for candidate-cut.** `pushNext()` merges `<remote>/next` between retries, so it collapses if a remote added via `git remote add` doesn't get its tracking ref updated by a *named* fetch. Confirmed against a throwaway repo pair: `git fetch next-push next` does create `refs/remotes/next-push/next`.
- **Decoupling the ledger step can't conflict with the fallback PR.** `release-lines.json` is written only on `next`, never on `main`, so main's copy is unchanged since the merge base and there is nothing for git to conflict.

Fixed:

| # | Defect |
|---|---|
| 1 | `ls-remote --exit-code` returns **2** for "ref absent" and **128** for "remote unreachable". The bare `catch` read both as absent, then attempted a doomed push that buried the real cause. |
| 2 | The failure gate carried an implicit `success()`, so a failure in the ledger step **skipped it** — losing the pointer to the fallback PR exactly when two things had gone wrong. Now `always() && …`. |
| 3 | If the back-merge failed with main **already merged**, `gh pr create` would fail with "No commits between …" and the operator would be told to `git merge origin/main` by hand — wrong advice, since nothing is outstanding. Now detected by **ancestry** (not by matching gh's error string, which stops working the day it's reworded) and reported as `nothing_to_merge`; the gate warns and exits 0. |
| 4 | The fallback's token was minted **before** the back-merge and could expire during it, producing precisely the state it exists to prevent. It now mints its own and repoints `next-push` — the remote URL still carried the stale token, so re-minting alone would have bought nothing. |

Also added: a **"Recovery: released, but the back-merge did not land"** section to the release runbook. A red publish run with an open `chore/backmerge-v*` PR is a *designed* state, and nothing told an operator that — the instinct to fix it by hand is how you end up with two competing back-merge branches. The superseded "finish it by hand" safety rail now points there.

Test hygiene: the command fake models exit **codes** rather than bare failures, so the new status checks are actually covered rather than passing vacuously, and `main()` tests no longer drop a file in `/tmp`. **99 pass** (was 95).
