### PR TITLE
fix(testing): stop the rig harness forwarding two symbols its package never exported

### DIFF
--- a/.changeset/harness-dead-reexports.md
+++ b/.changeset/harness-dead-reexports.md
@@ -1,0 +1,22 @@
+---
+'@memberjunction/integration-test-suite': patch
+'@memberjunction/testing-integration': patch
+---
+
+Stop `rigs/lib/harness.ts` forwarding two symbols the framework package does not export.
+
+The shim re-exported `createRunQueryFixtures` and `teardownRunQueryFixtures` from
+`@memberjunction/testing-integration`. They are defined in `@memberjunction/integration-test-suite`
+(`src/checks/runquery-cache.checks.ts`) — the framework package ships content-free by design — so
+the module threw `SyntaxError: The requested module '@memberjunction/testing-integration' does not
+provide an export named 'createRunQueryFixtures'` at load, taking down every rig that imports the
+shim before a single assertion ran. That is the nightly `Cross-server invalidation rig` failure,
+plus five hand-run `ps-live-*` rigs.
+
+Nothing consumed either symbol through the shim, and forwarding them contradicted the file's own
+stated rule ("Every symbol forwarded here is DEFINED in `@memberjunction/testing-integration`"), so
+they are removed rather than re-pointed. All 23 remaining forwarded symbols resolve against the
+package's 90 exports.
+
+Also removes the dangling comment in `testing-integration/src/index.ts` that still described the
+removed re-exports — that sentence is why a consumer went on importing a symbol that had moved.

--- a/packages/TestingFramework/integration-test-suite/rigs/cache-payload-materialization-tests.ts
+++ b/packages/TestingFramework/integration-test-suite/rigs/cache-payload-materialization-tests.ts
@@ -50,9 +50,10 @@ import type { MJAIAgentNoteEntity } from '@memberjunction/core-entities';
 import { RedisLocalStorageProvider } from '@memberjunction/redis-provider';
 import { AIEngineBase } from '@memberjunction/ai-engine-base';
 import { AIEngine } from '@memberjunction/aiengine';
-// Imported from the package directly, NOT via ./lib/harness — that shim currently re-exports a
-// symbol the package no longer provides (`createRunQueryFixtures`), so importing it throws at
-// module load. Direct import is also the shim's own documented end-state.
+// Imported from the package directly, NOT via ./lib/harness — direct import is the shim's own
+// documented end-state, and this rig got there first. (It originally had to: the shim forwarded
+// `createRunQueryFixtures`, which that package does not provide, so importing it threw at module
+// load. That is fixed — the reason to keep importing directly is the end-state, not the bug.)
 import { TestRunner, Assert, AssertEqual, bootstrapIntegrationServer } from '@memberjunction/testing-integration';
 
 /** Isolated key prefix so this rig can never collide with a real cache on the same Redis. */

--- a/packages/TestingFramework/integration-test-suite/rigs/lib/harness.ts
+++ b/packages/TestingFramework/integration-test-suite/rigs/lib/harness.ts
@@ -30,8 +30,12 @@ export {
     IntegrationCheckRegistry,
     bootstrapIntegrationServer,
     bootstrapIntegrationClient,
-    createRunQueryFixtures,
-    teardownRunQueryFixtures,
+    // NOTE: createRunQueryFixtures / teardownRunQueryFixtures are deliberately NOT forwarded.
+    // They live in @memberjunction/integration-test-suite (src/checks/runquery-cache.checks.ts),
+    // not in the package below — forwarding them violated this file's own rule two lines up and
+    // made the whole module throw `SyntaxError: does not provide an export named
+    // 'createRunQueryFixtures'` at load, killing every rig that imports this shim. Nothing
+    // consumed them through here. Import them from the suite package directly if ever needed.
     // RLS two-user discovery (the rls-isolation bundle's fixture) — DISCOVERED, not minted.
     discoverRlsFixture,
     // Tier gate predicate — the ONE source of truth honored by both the scripts and the driver.

--- a/packages/TestingFramework/testing-integration/src/index.ts
+++ b/packages/TestingFramework/testing-integration/src/index.ts
@@ -24,11 +24,14 @@ export * from './rls-fixture';
 export * from './types';
 export * from './IntegrationTestDriver';
 
-// Re-export the bundle arrays + RunQuery fixture helpers AND, as a side effect of
-// evaluating these modules, register every bundled check on the IntegrationCheckRegistry.
 // The @RegisterClass decorator on IntegrationTestDriver fires via the export above.
-
-// Side-effect only: the permanent Phase-0 smoke check (no exports of its own).
+//
+// This block used to also re-export the bundle arrays and the RunQuery fixture helpers
+// (createRunQueryFixtures / teardownRunQueryFixtures). Those exports were removed when the
+// content moved to @memberjunction/integration-test-suite — see the NOTE above — but the
+// sentence describing them was left behind, and it is why a consumer shim went on
+// forwarding `createRunQueryFixtures` from here long after it was gone, throwing at module
+// load. Do not reinstate them: this package ships content-free.
 
 /**
  * Tree-shake guard. Importing this module (or calling this function) ensures the


### PR DESCRIPTION
Fixes the nightly `Cross-server invalidation rig` failure on `next`.

```
SyntaxError: The requested module '@memberjunction/testing-integration'
does not provide an export named 'createRunQueryFixtures'
```

## Root cause: two similarly-named packages

| Package | Path | |
|---|---|---|
| `@memberjunction/integration-test-suite` | `packages/TestingFramework/integration-test-suite/` | **defines** `createRunQueryFixtures` (`src/checks/runquery-cache.checks.ts`) |
| `@memberjunction/testing-integration` | `packages/TestingFramework/testing-integration/` | what the shim imports from — ships **content-free by design** |

[`rigs/lib/harness.ts`](https://github.com/MemberJunction/MJ/blob/next/packages/TestingFramework/integration-test-suite/rigs/lib/harness.ts) forwards `createRunQueryFixtures` and `teardownRunQueryFixtures` from the framework package. They were never there. An ES module naming a missing export throws at **load**, so every rig importing the shim dies before a single assertion runs.

**Affected:** `cross-server-invalidation-tests.ts` (the nightly CI job) and five hand-run `ps-live-*` rigs. Only the first is wired into CI, which is why the other five have been broken without anyone noticing.

## Removed, not re-pointed

Three independent reasons:

1. The symbols belong to the **other** package.
2. Forwarding them contradicts the file's own rule, stated two lines above the import: *"Every symbol forwarded here is DEFINED in `@memberjunction/testing-integration` (not re-exported from a third package)."*
3. **Nothing consumed either symbol** through the shim.

## Verified exhaustively, not just for the symbol that threw

Walked all **14 modules** of the framework package transitively, collected its **90 exports**, and diffed against the **25** the shim forwarded. Exactly two missing; the remaining 23 all resolve.

The transitive part earned its keep: a one-level walk of `index.ts` misses `bootstrap-shared` (reached via `export * from './bootstrap-shared'` in `bootstrap.ts:41`) and produces a **false positive** on `installInstrumentedCacheFirst` — which would have wrongly implicated `mj test run` / `mj test suite`. That symbol is fine.

## Two comments fixed, because they are what kept this alive

- **`testing-integration/src/index.ts`** carried *"Re-export the bundle arrays + RunQuery fixture helpers…"* followed by **no exports at all**. The lines went when the content moved; the sentence stayed — and that sentence is why a consumer went on importing a symbol that had left.
- **`cache-payload-materialization-tests.ts`** documented its direct import as a workaround for *this bug*. After this change the rationale is stale but the practice is still right (it is the shim's documented end-state), so the comment now says the latter. Otherwise the next person deletes a correct workaround for a reason that no longer applies.

## Two things in the same log deliberately NOT fixed

- **`Error: command codegen:manifest not found`** — replayed Turbo cache output (`cache hit, replaying logs` on the line above), and the script self-handles it: *"Warning: workspace CLI not built yet… manifest will be generated on next build."* Not a live error.
- **`mj-querygen` ENOENT during install** — pnpm declining to link a bin pointing at `./dist/cli/index.js` before anything is built. Nothing in CI or MJCLI invokes `mj-querygen`. Cosmetic noise on every fresh install.

## What this does not prove

A static check cannot turn the rig green — it needs SQL Server, Redis and two MJAPI processes. Its job is `workflow_dispatch`-able (`github.event_name == 'workflow_dispatch'`), so **dispatch `integration.yml` once this lands** to confirm the rig actually runs rather than merely loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
