### PR TITLE
Review follow-ups to #4358 and #4366: Deny rows are never grants; the dialog contract is written down

### DIFF
--- a/.changeset/rls-and-dialog-review-followups.md
+++ b/.changeset/rls-and-dialog-review-followups.md
@@ -1,0 +1,13 @@
+---
+"@memberjunction/core": patch
+"@memberjunction/ng-conversations": patch
+"@memberjunction/ng-ui-components": patch
+"@memberjunction/materialization": patch
+"@memberjunction/codegen-lib": patch
+---
+
+Review follow-ups to #4358 and #4366.
+
+- `EntityPermissionInfo.IsDeny` — one predicate for "this is a Deny row" (case- and whitespace-insensitive; blank Type is Allow), used by `GetUserPermisions` and now by both RLS readers: `UserExemptFromRowLevelSecurity` and `GetUserRowLevelSecurityInfo` skip Deny rows, so a set `Can*` flag on a Deny row is never read as a grant. Unreachable in practice (a user carrying a Deny row fails the permission gate first), but the methods now implement the invariant their docs state. Tests cover the Deny axis with typed builders.
+- The materialization leak gate's comments no longer claim parity with the runtime RLS reader; they say the gate is deliberately wider.
+- Input dialog: `box-sizing: border-box` parity with the rating dialog. The dialog container documents its contract — component bodies pad themselves.

--- a/packages/Angular/Generic/conversations/src/lib/components/dialogs/input-dialog.component.ts
+++ b/packages/Angular/Generic/conversations/src/lib/components/dialogs/input-dialog.component.ts
@@ -53,6 +53,12 @@ import { Component, Input } from '@angular/core';
          against the dialog edges while the header and footer were padded. Same inset as the sibling
          rating dialog, which already compensates for this. */
       padding: 4px 20px 8px;
+      /* Parity with the rating dialog: the Explorer shell's global reset makes this redundant, but a host
+         without that reset would let the 100%-wide inputs (padding + border, no local box-sizing) overflow. */
+      box-sizing: border-box;
+    }
+    .input-dialog-content * {
+      box-sizing: border-box;
     }
     .dialog-message {
       margin: 0 0 16px 0;

--- a/packages/Angular/Generic/ui-components/src/lib/dialog/dialog.service.ts
+++ b/packages/Angular/Generic/ui-components/src/lib/dialog/dialog.service.ts
@@ -177,6 +177,11 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 
     .mj-dialog-body {
       flex: 1;
+      /* CONTRACT: the body pads only STRING content (the "> p" rule below). A COMPONENT body arrives with no
+         inset and pads itself — see rating-dialog and input-dialog in ng-conversations, which both apply
+         4px 20px 8px. Padding here would double-pad them and break deliberately full-bleed bodies (About,
+         Profile, the action gallery, the sharing centre). If a third component rediscovers this, add a
+         padded setting to MJDialogSettings rather than a special case. */
       padding: 0;
       overflow: hidden;
       display: flex;

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -6609,7 +6609,10 @@ export class ManageMetadataBase {
    }
 
    /** Pure form of the role-RLS layer (see {@link entityHasRowLevelSecurity}). IO-free so it can be reused
-    *  verbatim by the runtime refresher's equivalent gate. */
+    *  verbatim by the runtime refresher's equivalent gate. Deliberately WIDER than the runtime's own reader
+    *  (`EntityInfo.GetUserRowLevelSecurityInfo` collects a filter only from an Allow row whose `CanRead` is
+    *  set, since #4358): a leftover filter beside a cleared flag still counts as "protected" here, which errs
+    *  conservative for a leak gate. */
    public static EntityHasRoleReadRLS(entity: EntityInfo): boolean {
       return entity.Permissions.some((p) => !!p.ReadRLSFilterID && p.ReadRLSFilterID.trim().length > 0);
    }

--- a/packages/MJCore/src/__tests__/entityInfo.rlsFilterCollection.test.ts
+++ b/packages/MJCore/src/__tests__/entityInfo.rlsFilterCollection.test.ts
@@ -27,7 +27,7 @@ function buildRLSFilter(id: string, filterText: string): RowLevelSecurityFilterI
     return new RowLevelSecurityFilterInfo({ ID: id, Name: `Filter-${id}`, FilterText: filterText, Description: 'Test filter' });
 }
 
-function buildPermission(overrides: Partial<Record<string, unknown>>): EntityPermissionInfo {
+function buildPermission(overrides: Partial<EntityPermissionInfo> & { RoleID: string }): EntityPermissionInfo {
     return new EntityPermissionInfo({
         ID: `perm-${overrides.RoleID}`,
         EntityID: ENTITY_ID,
@@ -128,5 +128,30 @@ describe('GetUserRowLevelSecurityInfo collects filters only from rows that GRANT
 
         expect(entity.GetUserRowLevelSecurityInfo(user, EntityPermissionType.Create)).toEqual([]);
         expect(entity.GetUserPermisions(user).CanCreate).toBe(false);
+    });
+});
+
+describe('Deny rows never read as grants (their Can* flags are denials)', () => {
+    it('a Deny row with CanCreate + a Create filter contributes no filter, even though its flag is set', () => {
+        const entity = buildEntityInfo([
+            buildPermission({ RoleID: ROLE_A_ID, CanCreate: true, CreateRLSFilterID: FILTER_1_ID }),
+            buildPermission({ RoleID: ROLE_B_ID, Type: 'Deny', CanCreate: true, CreateRLSFilterID: FILTER_2_ID }),
+        ]);
+        const ids = entity.GetUserRowLevelSecurityInfo(buildUser([ROLE_A_ID, ROLE_B_ID]), EntityPermissionType.Create).map((f) => f.ID);
+        expect(ids).toEqual([FILTER_1_ID]);
+    });
+
+    it('a Deny row with CanRead and no filter does NOT exempt the user from RLS', () => {
+        const entity = buildEntityInfo([
+            buildPermission({ RoleID: ROLE_A_ID, CanRead: true, ReadRLSFilterID: FILTER_1_ID }),
+            buildPermission({ RoleID: ROLE_B_ID, Type: 'Deny', CanRead: true, ReadRLSFilterID: null }),
+        ]);
+        expect(entity.UserExemptFromRowLevelSecurity(buildUser([ROLE_A_ID, ROLE_B_ID]), EntityPermissionType.Read)).toBe(false);
+    });
+
+    it('Type is compared case- and whitespace-insensitively, and a blank Type is Allow', () => {
+        expect(buildPermission({ RoleID: ROLE_A_ID, Type: ' DENY ' }).IsDeny).toBe(true);
+        expect(buildPermission({ RoleID: ROLE_A_ID, Type: '' }).IsDeny).toBe(false);
+        expect(buildPermission({ RoleID: ROLE_A_ID, Type: 'Allow' }).IsDeny).toBe(false);
     });
 });

--- a/packages/MJCore/src/generic/entityInfo.ts
+++ b/packages/MJCore/src/generic/entityInfo.ts
@@ -404,6 +404,16 @@ export class EntityPermissionInfo extends BaseInfo{
      * materialized before the column existed.
      */
     Type: string = 'Allow'
+
+    /**
+     * True when this row is a Deny row (`Type = 'Deny'`, compared case- and whitespace-insensitively;
+     * a null/blank Type — rows created before the column existed — is Allow). On a Deny row a set
+     * `Can*` flag means "deny that operation", so nothing that reads a `Can*` flag as a GRANT may
+     * look at a Deny row: `GetUserPermisions` subtracts these, and the RLS readers skip them.
+     */
+    public get IsDeny(): boolean {
+        return (this.Type || 'Allow').trim().toLowerCase() === 'deny';
+    }
     CanCreate: boolean = null
     CanRead: boolean = null
     CanUpdate: boolean = null
@@ -2952,7 +2962,7 @@ export class EntityInfo extends BaseInfo {
             const allow = { CanCreate: false, CanRead: false, CanUpdate: false, CanDelete: false };
             const deny = { CanCreate: false, CanRead: false, CanUpdate: false, CanDelete: false };
             for (const ep of permissionList) {
-                const isDeny = (ep.Type || 'Allow').trim().toLowerCase() === 'deny';
+                const isDeny = ep.IsDeny;
                 const bucket = isDeny ? deny : allow;
                 bucket.CanCreate = bucket.CanCreate || !!ep.CanCreate;
                 bucket.CanRead   = bucket.CanRead   || !!ep.CanRead;
@@ -2997,6 +3007,9 @@ export class EntityInfo extends BaseInfo {
     public UserExemptFromRowLevelSecurity(user: UserInfo, type: EntityPermissionType): boolean {
         for (let j: number = 0; j < this.Permissions.length; j++) {
             const ep: EntityPermissionInfo = this.Permissions[j];
+            if (ep.IsDeny) {
+                continue; // a Deny row's Can* flags are denials, never grants — it cannot exempt anyone
+            }
             const roleMatch: UserRoleInfo = user.UserRoles?.find((r) => UUIDsEqual(r.RoleID, ep.RoleID))
             if (roleMatch) { // user has this role 
                 switch (type) {
@@ -3026,8 +3039,11 @@ export class EntityInfo extends BaseInfo {
     /**
      * Returns RLS security info attributes for a given user and permission type.
      *
-     * Only permission rows that GRANT the operation (the matching `Can*` flag is true) contribute a
-     * filter. The filters of a user's roles are OR'd together by the caller, so a filter collected
+     * Only permission rows that GRANT the operation contribute a filter: an Allow row whose matching
+     * `Can*` flag is true. Deny rows are skipped outright — on a Deny row a set `Can*` flag means
+     * "deny that operation", and a user carrying one fails the permission gate before this runs
+     * (`GetUserPermisions` subtracts Deny from Allow), so reading it as a grant would be wrong even
+     * though it is unreachable. The filters of a user's roles are OR'd together by the caller, so a filter collected
      * from a row that does not grant the operation would WIDEN the clause: a user granted Create by
      * role A (bound to filter F1) would create against `F1 OR F2` when role B keeps a leftover
      * `CreateRLSFilterID = F2` beside `CanCreate = false`. `GetUserPermisions` aggregates the flags
@@ -3041,6 +3057,9 @@ export class EntityInfo extends BaseInfo {
         const rlsList: RowLevelSecurityFilterInfo[] = [];
         for (let j: number = 0; j < this.Permissions.length; j++) {
             const ep: EntityPermissionInfo = this.Permissions[j];
+            if (ep.IsDeny) {
+                continue; // never a grant — see the doc comment
+            }
             const roleMatch: UserRoleInfo = user.UserRoles?.find((r) => UUIDsEqual(r.RoleID, ep.RoleID))
             if (roleMatch) { // user has this role
                 let matchObject: RowLevelSecurityFilterInfo = null;

--- a/packages/Materialization/src/MaterializationRefresher.ts
+++ b/packages/Materialization/src/MaterializationRefresher.ts
@@ -828,9 +828,11 @@ export class MaterializationRefresher {
 
     /**
      * True if an entity is read-RLS-protected — any of its role permissions carries a non-empty `ReadRLSFilterID`.
-     * Matches CodeGenLib's `entityHasRowLevelSecurity` (and MJ's `GetUserRowLevelSecurityWhereClause`, which
-     * sources the read filter solely from `EntityPermission.ReadRLSFilterID`). Used by the runtime leak gate to
-     * refuse refreshing a local mirror of an EXTERNAL RLS-protected entity — a mirror can't reproduce remote RLS.
+     * Matches CodeGenLib's `entityHasRowLevelSecurity`. Deliberately WIDER than the runtime's own reader
+     * (`GetUserRowLevelSecurityInfo` since #4358 collects a filter only from an Allow row whose `CanRead` is set):
+     * a leftover filter beside a cleared flag counts here as "protected", which errs conservative for a leak
+     * gate. Used to refuse refreshing a local mirror of an EXTERNAL RLS-protected entity — a mirror can't
+     * reproduce remote RLS.
      */
     public static entityHasReadRLS(entity: EntityInfo): boolean {
         return entity.Permissions.some((p) => !!p.ReadRLSFilterID && p.ReadRLSFilterID.trim().length > 0);


### PR DESCRIPTION
Follow-ups from @rkihm-BC's reviews of #4358 and #4366 — the non-blocking notes, kept out of those PRs so their approvals stood.

**Stacked on #4358 and #4366:** this branch merges both, so until they land the diff here shows their changes too. Once they merge, only the commits below remain (`cf2484c26b`).

## From #4358

- **Deny rows are never grants.** `GetUserRowLevelSecurityInfo`'s new doc said "only rows that GRANT the operation", but a `Type = 'Deny'` row with `CanCreate = 1` and a filter would still have been collected. Now `EntityPermissionInfo.IsDeny` is the one predicate for a Deny row (case- and whitespace-insensitive; a blank `Type` — rows from before the column existed — is Allow), `GetUserPermisions` uses it instead of its inline expression, and both RLS readers skip Deny rows: `GetUserRowLevelSecurityInfo` (#4358) and `UserExemptFromRowLevelSecurity` (#4352, same shape). Unreachable in practice — a user carrying a Deny row fails the permission gate first — but the methods now implement the invariant their docs state.
- **Typed test builders.** `buildPermission` takes `Partial<EntityPermissionInfo> & { RoleID }`, so a mistyped override is a compile error rather than a silent no-op. Three Deny-axis tests: a Deny row's filter is not collected; a Deny row cannot exempt; the `Type` normalisation. The collection test goes red without the guard.
- **Comment drift.** `MaterializationRefresher.entityHasReadRLS` and `ManageMetadataBase.EntityHasRoleReadRLS` no longer claim parity with `GetUserRowLevelSecurityWhereClause`; they say the leak gate is deliberately *wider* than the runtime reader (a leftover filter beside a cleared flag still counts as "protected" there, which errs conservative).

Not in here, on purpose: the `rls-isolation` integration check needs seeded permission fixtures, and the durable fix — an `EntityPermission` server subclass that nulls `<Op>RLSFilterID` when `Can<Op>` is cleared, plus cleaning the nine stale rows — is its own issue as the review said.

## From #4366

- `.input-dialog-content` gets `box-sizing: border-box` on itself and its descendants, like the rating dialog — redundant under the Explorer shell's global reset, load-bearing for a host without it (the 100%-wide inputs carry padding and a border with no local `box-sizing`).
- `MJDialogContainerComponent` documents the contract beside `padding: 0`: the body pads only string content; a component body pads itself; if a third component rediscovers this, add a `padded` setting to `MJDialogSettings` rather than a special case.

## Testing

- `@memberjunction/core` 2329/2329 (the RLS collection suite 8/8; the Deny collection test fails with the guard removed).
- `@memberjunction/materialization` 118/118. `ng-ui-components` and `ng-conversations` build. `codegen-lib`: 654/654 tests pass; 56 test *files* fail to collect in this worktree with and without the change (environment, not the comment edit).
- Changeset: patch on the five packages (no migration).
