### PR TITLE
feat(release-notes): add a required TL;DR and gate the notes shape

### DIFF
--- a/.claude/commands/notes.md
+++ b/.claude/commands/notes.md
@@ -1,32 +1,23 @@
-You are a techncal analyst working as a release coordinator for MemberJunction. Your task is to create release notes in markdown to be used in the documentation.
+You are a technical analyst working as a release coordinator for MemberJunction. Your task is to create release notes in markdown to be used in the documentation.
+
+## Format
+
+**Read `releases/README.md` first.** It defines the template, the required `## TL;DR`
+section, and the house style, and it is the single source of that format — this command,
+and both jobs in `.github/workflows/generate-release-notes.yml`, all read it rather than
+carrying their own copy. Do not work from memory or from an older release file's shape.
 
 ## Process
 
-1. Compare next HEAD to the latest published version tag (using repo tags, `git fetch --tags && git --no-pager tag -l "v*" --sort=-version:refname | head -n1`) to get the changes in this 
-  release. 
-2. Figure out the next version (whether patch or minor) using `npx changeset status --since main` 
-3.Use both the diff contents and git commit messages to build up the context.  
-- The .changeset/ dir also has more focused human-entered notes you can use. 
-4. Write the release notes to releases/v<version>.md (the `releases/` directory at the repo root) following the template given below.
+1. Compare next HEAD to the latest published version tag (using repo tags, `git fetch --tags && git --no-pager tag -l "v*" --sort=-version:refname | head -n1`) to get the changes in this
+  release.
+2. Figure out the next version (whether patch or minor) using `npx changeset status --since main`
+3. Use both the diff contents and git commit messages to build up the context.
+- The .changeset/ dir also has more focused human-entered notes you can use.
+4. Write the release notes to releases/v<version>.md (the `releases/` directory at the repo root) following the format in `releases/README.md`.
 - You can add/remove bullets as needed and omit sections if there are no bullets.
-- This directory is rendered on the docs site automatically (docs.memberjunction.org/releases/), so the file IS the publication — commit it with the release. See releases/README.md.
+- This directory is rendered on the docs site automatically (docs.memberjunction.org/releases/), so the file IS the publication — commit it with the release.
 5. Verify that the file was written correctly and include its content in your final response.
-
-<template>
-# <6-10 word summary of the entire release>
-
-## New Features
-- <Detail>
-- <Detail>
-- <Detail>
-
-## Improvements
-- <Detail>
-- <Detail>
-- <Detail>
-
-## Bug Fixes
-- <Detail>
-- <Detail>
-- <Detail>
-</template>
+- Check specifically that it opens with an H1 and then `## TL;DR`, and that you have not
+  also written an unlabelled intro paragraph above the sections. The TL;DR replaces that
+  paragraph; having both is the most common way this format goes wrong.

--- a/.github/scripts/__tests__/check-release-notes-shape.test.mjs
+++ b/.github/scripts/__tests__/check-release-notes-shape.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { checkReleaseNotesShape, SELF_TEST_FIXTURES, DEFAULT_MIN_BYTES } from '../check-release-notes-shape.mjs';
+
+const pad = (s) => s + '\n<!-- '.padEnd(DEFAULT_MIN_BYTES, 'x') + ' -->\n';
+
+describe('check-release-notes-shape', () => {
+    it.each(SELF_TEST_FIXTURES)('%s → flagged: %s', (_name, shouldFlag, content) => {
+        expect(checkReleaseNotesShape(pad(content)).length > 0).toBe(shouldFlag);
+    });
+
+    // The defect this script exists for: a heading-ORDER check passes this, because the
+    // first `## ` is still the TL;DR. Only a preamble check catches it.
+    it('names the preamble as the problem when a stray paragraph precedes the TL;DR', () => {
+        const content = pad('# A release summary here\n\nThe seventh Edge build of the 6.1 line.\n\n## TL;DR\n- One.\n');
+        const codes = checkReleaseNotesShape(content).map((p) => p.code);
+        expect(codes).toContain('preamble');
+        expect(codes).not.toContain('tldr-first');
+    });
+
+    it('does not flag the standing-context line that follows the TL;DR bullets', () => {
+        const content = pad('# A release summary here\n\n## TL;DR\n- One.\n\nEdge builds are prereleases.\n\n## Bug Fixes\n- A fix.\n');
+        expect(checkReleaseNotesShape(content)).toEqual([]);
+    });
+
+    it('reports a thin file even when its shape is correct', () => {
+        const codes = checkReleaseNotesShape('# Short\n\n## TL;DR\n- One.\n').map((p) => p.code);
+        expect(codes).toEqual(['too-thin']);
+    });
+
+    it('reports every problem at once rather than stopping at the first', () => {
+        const codes = checkReleaseNotesShape('Not a heading.\n\n## New Features\n- x\n').map((p) => p.code);
+        expect(codes).toEqual(expect.arrayContaining(['too-thin', 'h1', 'tldr-first']));
+    });
+
+    it('tolerates CRLF line endings', () => {
+        const content = pad('# A release summary here\r\n\r\n## TL;DR\r\n- One.\r\n\r\n## Bug Fixes\r\n- A fix.\r\n');
+        expect(checkReleaseNotesShape(content)).toEqual([]);
+    });
+});

--- a/.github/scripts/check-release-notes-shape.mjs
+++ b/.github/scripts/check-release-notes-shape.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * check-release-notes-shape.mjs
+ *
+ * Verifies the SHAPE of generated release notes — the canonical `releases/v<version>.md`
+ * file, and the release PR body, which are produced by two different agents from the same
+ * material and must come out the same shape. It says nothing about whether the content is
+ * accurate; only a human can judge that.
+ *
+ * ── WHY ─────────────────────────────────────────────────────────────────────────
+ * The PR body is pasted into Teams verbatim as the release announcement, and most readers
+ * there stop after the TL;DR. A run that silently drops or misplaces that section ships an
+ * announcement missing the part most people read, and nobody finds out until it is in the
+ * channel. The agent's own report that it followed the format is not evidence.
+ *
+ * ── THE CHECK THAT IS EASY TO GET WRONG ─────────────────────────────────────────
+ * "The first `## ` heading is `## TL;DR`" is NOT sufficient. The failure this format is
+ * most prone to is the agent writing its OLD unlabelled intro paragraph *and* a TL;DR:
+ *
+ *     # Field-Level Security, AI Personas, and OpenAI Live realtime
+ *     The seventh Edge build of the 6.1 line. Its centrepiece is...   <- stray summary
+ *     ## TL;DR
+ *
+ * The first `## ` there is still the TL;DR, so a heading-order check passes it while the
+ * page carries three stacked summaries. The preamble must therefore be checked directly:
+ * between the H1 and the first `## `, only blank lines are allowed.
+ *
+ * A paragraph AFTER the TL;DR bullets is the standing-context line ("Edge builds are
+ * prereleases…") and is part of the template — it must not be flagged.
+ *
+ * Format definition: releases/README.md (the single source; the prompts read it too).
+ *
+ * ── USAGE ───────────────────────────────────────────────────────────────────────
+ *   node .github/scripts/check-release-notes-shape.mjs <file> [--min-bytes N]
+ */
+import { readFileSync } from 'node:fs';
+
+export const DEFAULT_MIN_BYTES = 400;
+const TLDR_HEADING = /^##[ \t]+TL;?DR[ \t]*$/i;
+const H2 = /^##[ \t]+\S/;
+
+/**
+ * @returns {{code: string, message: string}[]} every problem found, empty when well-formed.
+ */
+export function checkReleaseNotesShape(content, { minBytes = DEFAULT_MIN_BYTES } = {}) {
+    const problems = [];
+    const bytes = Buffer.byteLength(content, 'utf8');
+    if (bytes < minBytes) {
+        problems.push({ code: 'too-thin', message: `only ${bytes} bytes — too thin to publish (minimum ${minBytes}).` });
+    }
+
+    const lines = content.replace(/\r\n/g, '\n').split('\n');
+    const firstContentIndex = lines.findIndex((l) => l.trim() !== '');
+    if (firstContentIndex === -1) {
+        problems.push({ code: 'empty', message: 'the file is empty.' });
+        return problems;
+    }
+    if (!/^#[ \t]+\S/.test(lines[firstContentIndex])) {
+        problems.push({ code: 'h1', message: `does not open with an H1 summary (found "${lines[firstContentIndex].slice(0, 60)}").` });
+    }
+
+    const firstH2Index = lines.findIndex((l) => H2.test(l));
+    if (firstH2Index === -1) {
+        problems.push({ code: 'sections', message: 'has no `## ` section headings at all.' });
+        return problems;
+    }
+
+    // Everything between the H1 and the first section must be blank. See the header note:
+    // this is the check a heading-order comparison misses.
+    const preamble = lines.slice(firstContentIndex + 1, firstH2Index).filter((l) => l.trim() !== '');
+    if (preamble.length > 0) {
+        problems.push({
+            code: 'preamble',
+            message:
+                'has prose between the H1 and the first section. The TL;DR replaces the old unlabelled ' +
+                `intro paragraph — do not write both. Offending line(s): ${preamble.map((l) => JSON.stringify(l.trim().slice(0, 80))).join(', ')}`,
+        });
+    }
+
+    if (!TLDR_HEADING.test(lines[firstH2Index])) {
+        problems.push({
+            code: 'tldr-first',
+            message: `the first section is "${lines[firstH2Index].trim()}" — it must be "## TL;DR" (see releases/README.md).`,
+        });
+    }
+
+    return problems;
+}
+
+/** [name, shouldFlag, content] — exercised directly by the unit tests. */
+export const SELF_TEST_FIXTURES = [
+    ['canonical shape', false, '# A release summary here\n\n## TL;DR\n- One.\n- Two.\n\nEdge builds are prereleases.\n\n## Bug Fixes\n- A fix.\n'],
+    ['TLDR without the semicolon', false, '# A release summary here\n\n## TLDR\n- One.\n\n## Bug Fixes\n- A fix.\n'],
+    ['lowercase tl;dr', false, '# A release summary here\n\n## tl;dr\n- One.\n\n## Bug Fixes\n- A fix.\n'],
+    ['standing-context paragraph after the TL;DR is legitimate', false, '# A release summary here\n\n## TL;DR\n- One.\n\nEdge builds are prereleases and never move latest.\n\n## Bug Fixes\n- A fix.\n'],
+    ['stray intro paragraph ABOVE the TL;DR', true, '# A release summary here\n\nThe seventh Edge build of the 6.1 line.\n\n## TL;DR\n- One.\n\n## Bug Fixes\n- A fix.\n'],
+    ['no TL;DR at all', true, '# A release summary here\n\n## New Features\n- One.\n\n## Bug Fixes\n- A fix.\n'],
+    ['TL;DR present but not first', true, '# A release summary here\n\n## New Features\n- One.\n\n## TL;DR\n- Two.\n'],
+    ['no H1', true, '## TL;DR\n- One.\n\n## Bug Fixes\n- A fix.\n'],
+    ['no sections at all', true, '# A release summary here\n\nJust a paragraph and nothing else.\n'],
+    ['H3 TL;DR does not count as the section', true, '# A release summary here\n\n### TL;DR\n- One.\n\n## Bug Fixes\n- A fix.\n'],
+];
+
+// ── CLI ─────────────────────────────────────────────────────────────────────────
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+    const args = process.argv.slice(2);
+    const file = args.find((a) => !a.startsWith('--'));
+    const minIndex = args.indexOf('--min-bytes');
+    const minBytes = minIndex === -1 ? DEFAULT_MIN_BYTES : Number(args[minIndex + 1]);
+
+    if (!file) {
+        console.error('usage: check-release-notes-shape.mjs <file> [--min-bytes N]');
+        process.exit(2);
+    }
+    let content;
+    try {
+        content = readFileSync(file, 'utf8');
+    } catch (err) {
+        console.error(`::error::cannot read ${file}: ${err.message}`);
+        process.exit(1);
+    }
+
+    const problems = checkReleaseNotesShape(content, { minBytes });
+    if (problems.length === 0) {
+        console.log(`::notice::${file} is well-formed (${Buffer.byteLength(content, 'utf8')} bytes).`);
+        process.exit(0);
+    }
+    for (const p of problems) console.error(`::error::${file} ${p.message}`);
+    console.error(`\n--- ${file} (first 40 lines) ---`);
+    console.error(content.split('\n').slice(0, 40).join('\n'));
+    process.exit(1);
+}

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -139,14 +139,29 @@ jobs:
           prompt: |
             You are a technical analyst working as a release coordinator for MemberJunction. Your task is to create release notes in markdown and update the PR description.
 
+            ## Format
+
+            **Read `releases/README.md` before writing anything.** It defines the template, the
+            required `## TL;DR` section and the house style, and it is the single source of that
+            format. This prompt deliberately does not restate it: the format used to be written
+            out in four places, and three of them had drifted to describe a shape no release had
+            used since v5.51.1. Follow that file — not your memory of what a release note looks
+            like, and not the opening structure of an older file in `releases/`.
+
+            The PR description you produce is pasted into Teams verbatim by the build engineer,
+            and most readers there stop after the TL;DR. It is the release announcement, not
+            just a PR body.
+
             ## Process
 
             1. Compare next HEAD to the latest published version tag (using repo tags, `git fetch --tags && git --no-pager tag -l "v*" --sort=-version:refname | head -n1`) to get the changes in this release.
             2. Figure out the next version (whether patch or minor) using `npx changeset status --since main`
             3. Use both the diff contents and git commit messages to build up the context.
             - The .changeset/ dir also has more focused human-entered notes you can use.
-            4. Write the release notes to tmp/release-<version>.md following the template given below.
+            4. Write the release notes to tmp/release-<version>.md following the format in `releases/README.md`.
             - You can add/remove bullets as needed and omit sections if there are no bullets.
+            - `## TL;DR` is the one section that is never omitted. A later CI step reads the
+              published PR body back and fails the run if it has no TL;DR.
             5. Use the GitHub MCP server to update the PR description with the release notes.
 
             ## Steps to complete:
@@ -156,26 +171,33 @@ jobs:
                - Set the PR title to the version number (e.g., "v2.73.0")
                - Set the PR description to the generated release notes (replace entire description)
 
-            <template>
-            # <6-10 word summary of the entire release>
+            The generated release notes should become the entire PR description, not appended to existing content.
 
-            ## New Features
-            - <Detail>
-            - <Detail>
-            - <Detail>
-
-            ## Improvements
-            - <Detail>
-            - <Detail>
-            - <Detail>
-
-            ## Bug Fixes
-            - <Detail>
-            - <Detail>
-            - <Detail>
-            </template>
-
-            The generated release notes following the template above should become the entire PR description, not appended to existing content.
+      # The agent's own report is not evidence — the sibling job below says exactly that and
+      # then checks its artifact. This job never did, which was survivable while the PR body
+      # was read only by release reviewers. It stopped being survivable when the body became
+      # the release announcement: the build engineer pastes it into Teams verbatim, so a run
+      # that quietly drops the TL;DR ships an announcement missing the part most readers stop
+      # at, and nobody finds out until it is in the channel.
+      #
+      # Check the body that actually shipped, NOT tmp/release-<version>.md. The agent writes
+      # the file and updates the PR in two separate steps; only one of them is the artifact.
+      #
+      # PR path only: a workflow_dispatch carries no PR context at all (see the changeset-gate
+      # note above), so there is no published body to read back.
+      - name: Verify the PR body carries a TL;DR
+        if: github.event_name == 'pull_request' && steps.gemini-release-notes.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr view "$PR" --json body --jq '.body' > "$RUNNER_TEMP/pr-body.md"
+          # The same shape check the line job runs, so the two generators cannot drift into
+          # producing differently-shaped notes. Unit tested — including the case a naive
+          # "is there a TL;DR heading" grep silently passes:
+          # .github/scripts/__tests__/check-release-notes-shape.test.mjs
+          node .github/scripts/check-release-notes-shape.mjs "$RUNNER_TEMP/pr-body.md"
 
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -323,26 +345,27 @@ jobs:
             changesets are the highest-quality source: they are what the engineer wrote
             about their own change. Prefer them over commit subjects.
 
-            Read `releases/README.md` for the house format, and `releases/v5.51.1.md` as a
-            worked example of the expected depth and tone.
+            Read `releases/README.md` for the house format — it is authoritative. Use
+            `releases/v5.51.1.md` for the expected depth and tone of the section BULLETS
+            only: it was written before `## TL;DR` was required, so its opening is not a
+            model to copy.
 
             You may run read-only git commands for more detail (`git log`, `git show`,
             `git diff --stat`). Do not modify the repository except for the one file below.
 
             ## Write exactly one file: `releases/v${{ github.event.inputs.version }}.md`
 
-            Follow the house template: an H1 of 6-10 words summarising the release, a short
-            intro paragraph, then `## New Features` / `## Improvements` / `## Bug Fixes`.
-            OMIT any section with no content — a patch release usually has only bug fixes.
+            Follow the template and house style in `releases/README.md` exactly. It is the
+            single definition of both, shared with the two other generators, so there is
+            nothing to reconcile against your own recollection of the format.
 
-            House style, taken from the existing files:
-            - Each bullet opens with a **bolded claim**, then the affected packages in
-              parentheses as backticked names, then the explanation.
-            - Explain the DEFECT and its user-visible consequence, not the code change.
-              "Scheduled jobs silently stopped honouring their activation windows" beats
-              "changed a comparison in isJobDue".
-            - Add an `## Upgrade Notes` section ONLY if a deployment could have depended on
-              the old behaviour. Most patches need none. Do not invent one.
+            The two things this format most often gets wrong:
+            - `## TL;DR` is required, comes FIRST, and is three to five one-sentence bullets
+              that lead with the consequence rather than the code change. Do not ALSO write
+              an unlabelled intro paragraph above the sections — the TL;DR replaces it.
+            - OMIT any section with no content. A patch release usually has only `## TL;DR`
+              and `## Bug Fixes`; an `## Upgrade Notes` section belongs there only if a
+              deployment could have depended on the old behaviour. Do not invent one.
 
             ## Rules
 
@@ -361,13 +384,13 @@ jobs:
           set -euo pipefail
           F="releases/v$VERSION.md"
           [ -f "$F" ] || { echo "::error::$F was not written."; exit 1; }
-          BYTES=$(wc -c < "$F")
-          [ "$BYTES" -ge 400 ] || { echo "::error::$F is only $BYTES bytes — too thin to publish."; exit 1; }
-          head -1 "$F" | grep -q '^# ' || { echo "::error::$F does not start with an H1 summary."; exit 1; }
-          grep -q '^## ' "$F" || { echo "::error::$F has no section headings."; exit 1; }
+          # Shape is checked by the script shared with the Edge job above; see its header
+          # for why "the first ## is TL;DR" is not a sufficient check on its own.
+          node .github/scripts/check-release-notes-shape.mjs "$F"
+          # Scope, which is this job's own concern rather than the format's: the agent was
+          # told to write exactly one file.
           git diff --name-only --exit-code -- . ":(exclude)$F" || {
             echo "::error::the agent modified files other than $F (listed above)."; exit 1; }
-          echo "::notice::$F looks well-formed ($BYTES bytes)"
 
       # Pre-labelled, because the label is the entire point: the docs site builds the
       # line branch, so notes that stop at `next` are published nowhere.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ on:
       - '.github/scripts/backstop-alarm.mjs'
       - '.github/scripts/vitest.config.mts'
       - '.github/scripts/__tests__/**'
+      # The release-notes shape gate runs inside generate-release-notes.yml, not here, but
+      # its vitest suite lives in __tests__ — so an edit to the gate script alone must still
+      # run it. Without this entry the one change that most needs the suite skips it.
+      - '.github/scripts/check-release-notes-shape.mjs'
       # Same reasoning for the dynamic-replace guard (see that step). Without this
       # entry a PR editing only the gate script runs neither the gate nor its own
       # vitest suite — the one change that most needs both.

--- a/docs-site/scripts/lib/markdown.mjs
+++ b/docs-site/scripts/lib/markdown.mjs
@@ -13,6 +13,7 @@ import { rewriteThemePictures } from './theme-picture.mjs';
 
 const STRINGIFY_OPTIONS = { bullet: '-', fences: true, rule: '-', emphasis: '*', strong: '*' };
 const DESCRIPTION_MAX = 200;
+const TLDR_HEADING = /^TL;?DR$/i;
 
 /**
  * Transform one repo markdown file into a Starlight page body.
@@ -40,13 +41,42 @@ export function extractTitle(tree) {
   return mdastToString(heading).trim();
 }
 
-/** Plain text of the first paragraph, truncated for SEO/search snippets. */
+/**
+ * Plain text for the SEO/search snippet, truncated.
+ *
+ * Prefers a `TL;DR` section's content when the document has one, because release notes
+ * put their summary there (see releases/README.md) and their *first paragraph* is the
+ * standing-context line — "Edge builds are prereleases…" — which is identical on every
+ * release page and useless as a description. Everything else still uses its first
+ * paragraph, and so do release files written before the TL;DR was required.
+ */
 export function extractDescription(tree) {
-  const paragraph = tree.children.find((node) => node.type === 'paragraph');
-  if (!paragraph) return '';
-  const text = mdastToString(paragraph).replace(/\s+/g, ' ').trim();
+  const raw = tldrText(tree) ?? firstParagraphText(tree);
+  const text = raw.replace(/\s+/g, ' ').trim();
+  if (!text) return '';
   if (text.length <= DESCRIPTION_MAX) return text;
   return `${text.slice(0, DESCRIPTION_MAX - 1).trimEnd()}…`;
+}
+
+/** Text under the first `TL;DR` heading, or null if there is none with content. */
+function tldrText(tree) {
+  const index = tree.children.findIndex(
+    (node) => node.type === 'heading' && TLDR_HEADING.test(mdastToString(node).trim()),
+  );
+  if (index === -1) return null;
+  const node = tree.children[index + 1];
+  if (!node || node.type === 'heading') return null;
+  // A list stringifies to its items concatenated with NO separator, which would run the
+  // bullets together ("…claim their records.PostgreSQL deployments…"). Join explicitly.
+  const text = node.type === 'list'
+    ? node.children.map((item) => mdastToString(item).trim()).join(' ')
+    : mdastToString(node);
+  return text.trim() ? text : null;
+}
+
+function firstParagraphText(tree) {
+  const paragraph = tree.children.find((node) => node.type === 'paragraph');
+  return paragraph ? mdastToString(paragraph) : '';
 }
 
 /**

--- a/docs-site/scripts/lib/rewrite.test.mjs
+++ b/docs-site/scripts/lib/rewrite.test.mjs
@@ -168,3 +168,44 @@ test('description truncates long first paragraphs', () => {
   assert.ok(description.length <= 200);
   assert.match(description, /…$/);
 });
+
+// Release notes put their summary under `## TL;DR`; their first paragraph is the
+// standing-context line, which is identical on every release page (see releases/README.md).
+test('description prefers TL;DR bullets over the first paragraph', () => {
+  const source = [
+    '# Identity Claims and hardened networking',
+    '',
+    '## TL;DR',
+    '- Guest users can now claim their records.',
+    '- PostgreSQL deployments unblocked.',
+    '',
+    'Edge builds are prereleases. They publish under the `edge` dist-tag.',
+    '',
+    '## Bug Fixes',
+    '- Something was fixed.',
+  ].join('\n');
+  const { description } = transformRepoMarkdown(source, makeCtx({ srcRepoPath: 'releases/v6.1.0-edge.4.md' }));
+  assert.equal(description, 'Guest users can now claim their records. PostgreSQL deployments unblocked.');
+  assert.doesNotMatch(description, /Edge builds are prereleases/);
+  // Bullets must not be concatenated without a separator.
+  assert.doesNotMatch(description, /records\.PostgreSQL/);
+});
+
+test('description reads a TL;DR written as a paragraph', () => {
+  const source = ['# A release', '', '## TL;DR', '', 'One paragraph summary.', '', '## Bug Fixes', '- x'].join('\n');
+  const { description } = transformRepoMarkdown(source, makeCtx({ srcRepoPath: 'releases/v5.52.0.md' }));
+  assert.equal(description, 'One paragraph summary.');
+});
+
+test('description falls back to the first paragraph without a TL;DR', () => {
+  // The 13 release files written before the TL;DR was required must keep working.
+  const source = ['# An older release', '', 'The fifth Edge build of the 6.1 line.', '', '## Bug Fixes', '- x'].join('\n');
+  const { description } = transformRepoMarkdown(source, makeCtx({ srcRepoPath: 'releases/v6.1.0-edge.4.md' }));
+  assert.equal(description, 'The fifth Edge build of the 6.1 line.');
+});
+
+test('description falls back when a TL;DR heading has no content', () => {
+  const source = ['# A release', '', '## TL;DR', '', '## Bug Fixes', '', 'Fallback paragraph.'].join('\n');
+  const { description } = transformRepoMarkdown(source, makeCtx({ srcRepoPath: 'releases/v5.52.0.md' }));
+  assert.equal(description, 'Fallback paragraph.');
+});

--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "check:esm:test": "vitest run --config .github/scripts/vitest.config.mts",
     "check:claude-md": "node .github/scripts/check-claude-md.mjs",
     "check:codegen-tail": "node .github/scripts/check-codegen-tail.mjs",
+    "check:release-notes": "node .github/scripts/check-release-notes-shape.mjs",
+    "check:release-notes:test": "vitest run --config .github/scripts/vitest.config.mts __tests__/check-release-notes-shape",
     "check:codegen-tail:test": "vitest run --config .github/scripts/vitest.config.mts __tests__/check-codegen-tail",
     "check:browser-manifest": "node .github/scripts/check-browser-manifest-leakage.mjs",
     "check:browser-manifest:test": "vitest run --config .github/scripts/vitest.config.mts __tests__/check-browser-manifest-leakage",

--- a/releases/README.md
+++ b/releases/README.md
@@ -4,16 +4,34 @@ One markdown file per release, named `v<major>.<minor>.<patch>.md` (e.g. `v5.51.
 
 These files are the **canonical release notes**. The docs site renders every file in this
 directory automatically at [docs.memberjunction.org/releases/](https://docs.memberjunction.org/releases/),
-newest first, with an auto-generated index — no site changes needed. Posting the same
-content to Teams is optional; this directory is the record.
+newest first, with an auto-generated index — no site changes needed.
 
-## Authoring
+## The format is defined here, and only here
 
-The `/notes` skill (`.claude/commands/notes.md`) generates a release's notes from the
-diff, commit messages, and `.changeset/` entries, and writes the file here. Format:
+Three generators write release prose. All three read **this file** for the format instead
+of carrying their own copy:
+
+| Generator | Writes | Runs |
+|---|---|---|
+| `/notes` (`.claude/commands/notes.md`) | `releases/v<version>.md` for an Edge release | by hand, at DEPLOYMENT.md Step 11 |
+| `generate-release-notes.yml` — Edge job | the release **PR body** | in CI, when the PR into `main` opens |
+| `generate-release-notes.yml` — line job | `releases/v<version>.md` for an LTS line patch | in CI, after the line release publishes |
+
+Each of them used to restate the template inline, and the four copies had already drifted
+apart — three of them still described a format no release had used since v5.51.1. Change
+the format **here**; the prompts do not need editing.
+
+## Template
 
 ```markdown
 # <6-10 word summary of the release>
+
+## TL;DR
+- <consequence-first, one sentence>
+- <consequence-first, one sentence>
+- <consequence-first, one sentence>
+
+<standing context for the release line, if it has any — e.g. "Edge builds are prereleases.">
 
 ## New Features
 - ...
@@ -23,8 +41,51 @@ diff, commit messages, and `.changeset/` entries, and writes the file here. Form
 
 ## Bug Fixes
 - ...
+
+## Upgrade Notes
+- ...
 ```
 
-The H1 summary becomes part of the page title on the site (`v5.51.0: <summary>`).
-Commit the file as part of the release; the site deploy that follows the npm publish
-picks it up. This README itself is not rendered.
+Omit any section with no content — a patch release usually has only `## Bug Fixes`.
+`## Upgrade Notes` appears **only** when a deployment could have depended on the old
+behaviour; most patches need none, and inventing one is worse than omitting it.
+
+## Writing the TL;DR
+
+`## TL;DR` is required and comes first. It exists because the release PR body is pasted
+into Teams verbatim, and most readers there stop after it.
+
+- **Three to five bullets, one sentence each.** If a point needs two sentences, it belongs
+  in a section below.
+- **Lead with the consequence, not the change.** "Scheduled jobs silently stopped honouring
+  their activation windows" beats "changed a comparison in `isJobDue`."
+- **It is the only summary prose in the file.** Do not also write an unlabelled intro
+  paragraph — the TL;DR replaces it. The H1 is the one-line version, the TL;DR is the
+  thirty-second version, the sections are the full record. Three stacked summaries is the
+  failure mode this section exists to prevent.
+- **Point at `## Upgrade Notes`, never restate them.** When that section exists, say so in
+  one clause as the last bullet — "**Upgrade Notes apply** — two auth settings change
+  behaviour" — and leave the detail in the section.
+- **No marketing language.** No "we are excited to", no "a significant step forward". This
+  is a technical record for people who run the software.
+
+## House style for section bullets
+
+- Each bullet opens with a **bolded claim**, then the affected packages in parentheses as
+  backticked names, then the explanation.
+- Explain the defect and its user-visible consequence, not the code change.
+- Every claim must trace to the changesets, the commits, or the repo. Invent nothing — if
+  the material does not say *why* something changed, describe what changed and stop.
+- Do not mention npm dist-tags, CI, or the release process itself. Readers are users of the
+  packages, not of this repo.
+
+`releases/v5.51.1.md` is the worked example for section-bullet depth and tone. Take only
+the bullets from it: its top-of-file structure predates the TL;DR requirement, so follow
+the template above rather than that file's opening.
+
+## Publishing
+
+The H1 summary becomes part of the page title on the site (`v5.51.0: <summary>`), and the
+TL;DR becomes the page's search/SEO description (`docs-site/scripts/lib/markdown.mjs`).
+Commit the file as part of the release; the site deploy that follows the npm publish picks
+it up. This README itself is not rendered.


### PR DESCRIPTION
The release PR body is not an internal artifact. The build engineer copies it verbatim into Teams, which makes it **the release announcement** — and it had no summary section. Readers who want the shape of a release without the 100-bullet inventory (the ask that started this: "helpful to the people that are interested in the MJ release but get overwhelmed by the details") had nowhere to stop.

No issue — this came out of a conversation between @AN-BC and @amith-mj about adding an executive summary to release announcements. `TL;DR` rather than `Executive Summary` deliberately: this section is written by an LLM, and the heading is part of the prompt. "Executive Summary" co-occurs with consultant prose and invites *"this release represents a significant step forward"*; `TL;DR` invites compression. The repo's own house rule is already "no marketing language, this is a technical record," so the shorter name pulls with that grain instead of against it.

## It replaces the intro paragraph rather than stacking on it

9 of the 12 files in `releases/` — every release since `v5.51.1` — already open with an unlabelled paragraph that *is* a TL;DR. It was never in the template; it was author habit. So this does not add a third summary under the H1, it names the one that exists and makes it required.

That habit survived because **the format was written out in four places** — `releases/README.md`, `.claude/commands/notes.md`, and both prompts in `generate-release-notes.yml` — and three of those four still described an H1-then-sections shape that no release had used in months. `releases/README.md` is now the single definition, and all three generators read it instead of restating it.

## The gate, and why it is a script

The Edge job had **no verification at all**: it let the agent overwrite the PR title and body through MCP, unchecked. That was survivable while the body was read by release reviewers. It is not survivable now that the body is pasted into a channel, so both jobs run `.github/scripts/check-release-notes-shape.mjs` — against the *published PR body* via `gh pr view`, not `tmp/release-<version>.md`, because the agent writes the file and updates the PR in two separate steps and only one of them is the artifact that ships.

It is a script rather than inline shell in two jobs because the obvious check is wrong, and duplicating a wrong check is worse than writing it once. My first version asserted "the first \`## \` heading is \`## TL;DR\`". A smoke test caught that this passes clean:

\`\`\`markdown
# Field-Level Security, AI Personas, and OpenAI Live realtime
The seventh Edge build of the 6.1 line...    <- stray second summary
## TL;DR
\`\`\`

The stray paragraph sits *above* the heading, so heading order never sees it — the exact stacked-summary case the check existed to catch. The preamble is now checked directly, and both that case and its inverse (the standing-context line that legitimately *follows* the TL;DR, which must not be flagged) are pinned by unit tests.

## docs-site

`extractDescription` prefers TL;DR content. Without this, a bulleted TL;DR pushes the standing-context line — *"Edge builds are prereleases…"* — into the SEO description of every release page, identical across all of them. Files predating the requirement keep their existing descriptions through the first-paragraph fallback.

## Revised after review

The first version of this defined the TL;DR as three to five consequence-first bullets. On the same release that produced **131 words** where a reviewer would have written 20. The cause was one rule applied in the wrong place: "lead with the consequence, not the change" is right for section bullets and wrong here, because leading with the consequence means explaining, and explaining is what the sections already do. The TL;DR was the document again at higher altitude, which is no use to the reader trying to skip the document.

It is now **one to three sentences of prose**: user-facing features first, fixes and improvements as one clause afterwards, names rather than explanations. `## Upgrade Notes` moved from a trailing bullet to its own flag line, because a breaking change is the highest-value thing a scanning reader can hit and does not belong in a list beside the nice things. Regenerated on the same material, 131 words became 80 including that flag.

**No verification changed.** The gate takes its entire opinion about TL;DR *content* from `releases/README.md` — it checks the heading, the preamble and section order, never bullets-versus-prose — and the docs-site extractor already handled prose with a test pinning it. Two files, one of them documentation.

## Evidence

Generated real notes for the next Edge build from real material — 73 commits and 13 changesets since `v6.1.0-edge.6` — then ran the actual gate and the actual ingest against them.

| Check | Well-formed notes | Old format (no TL;DR) | Stray ¶ above TL;DR |
|---|---|---|---|
| Shape gate, line job | exit 0 | exit 1 | exit 1 |
| Shape gate, Edge job / PR body | exit 0 | exit 1 | exit 1 |

That third column is exit 0 on my first implementation and exit 1 now; it is the reason the gate got extracted and tested.

| Suite | Result |
|---|---|
| `vitest --config .github/scripts/vitest.config.mts` | 589 passed, 23 files |
| `docs-site` `node --test` | 37 passed |
| new `check-release-notes-shape` tests | 15 passed |
| `docs-site` `npm run build` | 374 pages, clean |

docs-site ingest on the generated file produced the title `v6.1.0-edge.7: Field-Level Security, AI Personas, and OpenAI Live realtime`, a description drawn from the TL;DR rather than the standing-context line, and a correct index entry. Artifacts removed afterwards.

## What a reviewer should watch

**A release PR can now go red where it previously went green.** The Edge job fails the run if the published body has no TL;DR. That is the intent — an announcement missing the part most people read is a failed run, not a cosmetic miss — but it is a new failure mode on the release path, and the fix when it fires is to re-run or write the section by hand before merging.

**The model bump is verified and is deliberately its own commit.** `gemini-3.8-flash` is in the MJ model catalog and, checked against the live API with the local key, **is served** (the model list returns 3.5, 3.6, 3.7 and 3.8 flash). An earlier revision of this description said that was unverifiable from here; it was not, and the commit message on the bump still carries the stale wording. It stays a separate commit so that if output quality drops, the cause is not ambiguous between the new instruction and the new model, and either reverts alone.

**`gemini-command.yml` is deliberately left on 3.6** — separate workflow, its own rationale comment, and bumping it here would turn this into a repo-wide model migration.

**The format was run through the real model.** gemini-3.8-flash, real key, the 50 changesets of `v6.1.0-edge.6` and separately the 13 of the pending range. Output passed the gate both times, in prose, with the upgrade flag on its own line. It found three defects in the spec, all fixed in `4fe7f1aaee`: the worked example was the TL;DR of the release being tested (so an agent would copy it, and the copy would look like compliance) and is now taken from shipped `v5.51.2`; "one short clause" produced a clause naming five areas and is capped at three; and "no marketing language" did not stop "critical cache-poisoning fixes", so intensifiers are named explicitly. After the fixes: **32 words, 2 sentences**, no intensifiers, example not copied. The hand-written first attempt was 131 words.

**Still untested: whether the model fetches `releases/README.md` when told to.** This ran through the REST API with the file inlined, because driving the agentic CLI locally needs unrestricted tool execution. The line job is the existing evidence that it does read it.

**Three prompts read their format from a file.** If the Edge job proves flakier at that than the line job, the fallback is to inline the template in that one prompt and document the second copy as intentional.

Unrelated and pre-existing: `npm run check:claude-md` fails on `next` already (root `CLAUDE.md` is 19475 bytes against an 18000 ceiling). This branch does not touch that file.

