### PR TITLE
fix(storage,content-autotagging,search-engine): Dropbox refresh-token/team-space support, recursive cloud-storage listing, address vector indexes by ExternalID

### DIFF
--- a/.changeset/knowledge-hub-dropbox-index-externalid.md
+++ b/.changeset/knowledge-hub-dropbox-index-externalid.md
@@ -1,0 +1,11 @@
+---
+"@memberjunction/storage": patch
+"@memberjunction/content-autotagging": patch
+"@memberjunction/search-engine": patch
+---
+
+Knowledge Hub + universal search fixes found wiring a Dropbox team-space vault and a website crawl into Pinecone.
+
+- **storage (Dropbox):** the refresh-token constructor path now marks the driver configured (callers that only construct the driver, like `AutotagCloudStorage`, were rejected with "Missing: Access Token"); optional `STORAGE_DROPBOX_PATH_ROOT` applies an SDK `pathRoot` so Business team-space paths resolve.
+- **content-autotagging:** `AutotagCloudStorage` walks sub-folders under `PathPrefix` instead of one level; the vectorizer addresses the 3rd-party index by `VectorIndex.ExternalID` (fallback `Name`) instead of the display name; invalid-content deletions and failed content-item saves are now logged instead of silent.
+- **search-engine:** `VectorSearchProvider` uses `VectorIndex.ExternalID` for the provider-side index name — the Semantic lane 404'd against Pinecone on every query when the MJ display name differed from the index name.

--- a/packages/ContentAutotagging/src/CloudStorage/providers/AutotagCloudStorage.ts
+++ b/packages/ContentAutotagging/src/CloudStorage/providers/AutotagCloudStorage.ts
@@ -37,6 +37,9 @@ interface ICloudStorageSourceConfig {
  */
 @RegisterClass(AutotagBase, 'AutotagCloudStorage')
 export class AutotagCloudStorage extends AutotagBase {
+    /** Maximum folder depth ListModifiedObjects will descend below PathPrefix. */
+    private static readonly MAX_LIST_DEPTH = 16;
+
     private contextUser!: UserInfo;
     private engine!: AutotagBaseEngine;
     protected contentSourceTypeID!: string;
@@ -177,12 +180,28 @@ export class AutotagCloudStorage extends AutotagBase {
         lastRunDate: Date,
         includeExtensions?: string[]
     ): Promise<StorageObjectMetadata[]> {
-        const result = await driver.ListObjects(prefix);
         const extSet = includeExtensions?.length
             ? new Set(includeExtensions.map(ext => ext.toLowerCase()))
             : null;
 
-        return result.objects.filter(obj => {
+        // Walk the tree under the prefix: ListObjects returns one level (objects + child prefixes), so
+        // recurse into every child prefix. Guard against pathological depth and prefix loops.
+        const objects: StorageObjectMetadata[] = [];
+        const seen = new Set<string>();
+        const walk = async (current: string, depth: number): Promise<void> => {
+            const key = current.replace(/\/+$/, '');
+            if (seen.has(key) || depth > AutotagCloudStorage.MAX_LIST_DEPTH) return;
+            seen.add(key);
+            const result = await driver.ListObjects(current);
+            objects.push(...result.objects);
+            for (const child of result.prefixes ?? []) {
+                if (child.replace(/\/+$/, '') === key) continue; // provider echoed the folder itself
+                await walk(child, depth + 1);
+            }
+        };
+        await walk(prefix, 0);
+
+        return objects.filter(obj => {
             if (obj.isDirectory) return false;
             if (obj.lastModified <= lastRunDate) return false;
             if (extSet) {

--- a/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
+++ b/packages/ContentAutotagging/src/Engine/generic/AutotagBaseEngine.ts
@@ -1009,6 +1009,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
             await this.saveResultsToContentItemAttribute(LLMResults, contextUser);
             await this.saveContentItemTags(LLMResults.contentItemID as string, LLMResults, contextUser);
         } else if (LLMResults.isValidContent === false) {
+            LogStatus(`[Autotag] LLM judged content item ${LLMResults.contentItemID} INVALID — deleting it. Title: ${String(LLMResults.title ?? '')} | Reason/description: ${String(LLMResults.description ?? LLMResults.reason ?? '')}`.slice(0, 600));
             await this.deleteInvalidContentItem(LLMResults.contentItemID as string, contextUser);
         } else {
             LogError(`[Autotag] Unexpected LLM format for item ${LLMResults.contentItemID} — isValidContent missing. Keys: ${Object.keys(LLMResults).join(', ')}`);
@@ -2749,7 +2750,9 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         const driverClass = aiModel.DriverClass;
         const embeddingModelName = aiModel.APIName ?? aiModel.Name;
 
-        LogStatus(`VectorizeContentItems: USING embedding model "${aiModel.Name}" (${driverClass}), vector DB "${vectorDBClassKey}", index "${vectorIndex.Name}"`);
+        // The 3rd-party index is addressed by ExternalID (the provider-side name); Name is the MJ display label.
+        const externalIndexName = vectorIndex.ExternalID?.trim() || vectorIndex.Name;
+        LogStatus(`VectorizeContentItems: USING embedding model "${aiModel.Name}" (${driverClass}), vector DB "${vectorDBClassKey}", index "${externalIndexName}" (Vector Index "${vectorIndex.Name}")`);
 
         const embedding = this.createEmbeddingInstance(driverClass);
         const vectorDB = this.createVectorDBInstance(vectorDBClassKey);
@@ -2757,7 +2760,7 @@ export class AutotagBaseEngine extends BaseEngine<AutotagBaseEngine> {
         return {
             embedding,
             vectorDB,
-            indexName: vectorIndex.Name,
+            indexName: externalIndexName,
             embeddingModelName,
             embeddingModelID,
             dimensions: vectorIndex.Dimensions ?? undefined,

--- a/packages/ContentAutotagging/src/Websites/generic/AutotagWebsite.ts
+++ b/packages/ContentAutotagging/src/Websites/generic/AutotagWebsite.ts
@@ -424,7 +424,10 @@ export class AutotagWebsite extends AutotagBase {
             await contentItem.Load(existing.ID);
             contentItem.Checksum = newHash;
             contentItem.Text = text;
-            await contentItem.Save();
+            if (!await contentItem.Save()) {
+                console.error(`[autotag-website] Failed to update content item for ${url}: ${contentItem.LatestResult?.Message ?? 'unknown error'}`);
+                return null;
+            }
             return contentItem;
         }
 
@@ -440,7 +443,10 @@ export class AutotagWebsite extends AutotagBase {
         contentItem.Checksum = newHash;
         contentItem.URL = url;
         contentItem.Text = text;
-        await contentItem.Save();
+        if (!await contentItem.Save()) {
+            console.error(`[autotag-website] Failed to save content item for ${url}: ${contentItem.LatestResult?.Message ?? 'unknown error'}`);
+            return null;
+        }
         return contentItem;
     }
 

--- a/packages/MJStorage/src/drivers/DropboxFileStorage.ts
+++ b/packages/MJStorage/src/drivers/DropboxFileStorage.ts
@@ -113,6 +113,9 @@ function describeDropboxError(error: unknown): DropboxErrorDiagnostics {
  *
  * Optional configuration:
  * - STORAGE_DROPBOX_ROOT_PATH - Path within Dropbox to use as the root (defaults to empty which is the root)
+ * - STORAGE_DROPBOX_PATH_ROOT - Optional namespace id to use as the API path root (Dropbox-API-Path-Root header).
+ *   Needed for Dropbox Business team space: shared/team folders live in the team root namespace
+ *   (users/get_current_account -> root_info.root_namespace_id), not in the member's home namespace.
  *
  * @example
  * ```typescript
@@ -156,6 +159,17 @@ export class DropboxFileStorage extends FileStorageBase {
   private _rootPath: string;
 
   /**
+   * Adds the Dropbox-API-Path-Root header (via the SDK's `pathRoot` option) when STORAGE_DROPBOX_PATH_ROOT
+   * names a namespace id. Without it, a Dropbox Business member only sees their home folder and team
+   * folders such as a shared vault are `path/not_found`.
+   */
+  private static withPathRoot(options: DropboxOptions): DropboxOptions {
+    const namespaceId = env.get('STORAGE_DROPBOX_PATH_ROOT').default('').asString();
+    if (!namespaceId) return options;
+    return { ...options, pathRoot: JSON.stringify({ '.tag': 'root', root: namespaceId }) };
+  }
+
+  /**
    * Creates a new DropboxFileStorage instance
    *
    * This constructor initializes the Dropbox client using the provided credentials
@@ -185,7 +199,7 @@ export class DropboxFileStorage extends FileStorageBase {
         dropboxConfig.selectUser = config.selectUser as string;
       }
 
-      this._client = new Dropbox(dropboxConfig);
+      this._client = new Dropbox(DropboxFileStorage.withPathRoot(dropboxConfig));
     } else if (refreshToken && appKey && appSecret) {
       // Use refresh token with app credentials
       const dropboxConfig: DropboxOptions = {
@@ -199,7 +213,10 @@ export class DropboxFileStorage extends FileStorageBase {
         dropboxConfig.selectUser = config.selectUser as string;
       }
 
-      this._client = new Dropbox(dropboxConfig);
+      this._client = new Dropbox(DropboxFileStorage.withPathRoot(dropboxConfig));
+      // Same placeholder initialize() sets: IsConfigured must be true in refresh-token mode too,
+      // otherwise env-configured refresh tokens are rejected by callers that only construct the driver.
+      this._accessToken = 'refresh-token-mode';
     }
     // Note: If no credentials are available, client will be initialized in initialize() method
     // This allows for database-driven configuration to be passed after construction
@@ -266,7 +283,7 @@ export class DropboxFileStorage extends FileStorageBase {
         dropboxConfig.selectUser = config.selectUser;
       }
 
-      this._client = new Dropbox(dropboxConfig);
+      this._client = new Dropbox(DropboxFileStorage.withPathRoot(dropboxConfig));
       // Set a placeholder for IsConfigured check - the SDK will get a real token on first API call
       this._accessToken = 'refresh-token-mode';
     } else if (accessToken) {
@@ -280,7 +297,7 @@ export class DropboxFileStorage extends FileStorageBase {
         dropboxConfig.selectUser = config.selectUser;
       }
 
-      this._client = new Dropbox(dropboxConfig);
+      this._client = new Dropbox(DropboxFileStorage.withPathRoot(dropboxConfig));
     }
 
     // Update root path if provided

--- a/packages/SearchEngine/src/generic/VectorSearchProvider.ts
+++ b/packages/SearchEngine/src/generic/VectorSearchProvider.ts
@@ -323,7 +323,7 @@ export class VectorSearchProvider extends BaseSearchProvider {
         vectorDBInstance.TryWireColocatedHost(this.Provider);
         if (vectorDBInstance.SupportsColocatedQuery) {
             const colocated = await vectorDBInstance.ColocatedQuery({
-                indexName: vectorIndex.Name,
+                indexName: vectorIndex.ExternalID?.trim() || vectorIndex.Name, // provider-side index name; Name is the MJ label
                 vector: queryVector,
                 keyword: queryText,
                 topK,
@@ -344,7 +344,7 @@ export class VectorSearchProvider extends BaseSearchProvider {
         // use it to honor server-side row-level security when loading vectors
         // via RunView.
         const response: BaseResponse = await vectorDBInstance.QueryIndex({
-            id: vectorIndex.Name,
+            id: vectorIndex.ExternalID?.trim() || vectorIndex.Name,
             vector: queryVector,
             topK,
             includeMetadata: true,


### PR DESCRIPTION
## Summary

Five fixes found while wiring a Dropbox vault and a WordPress site into Knowledge Hub and then searching the result from Explorer's universal search. All were reproduced on `next` against a live Dropbox Business team space and a Pinecone serverless index; each fix was verified by re-running the pipeline / search after the change.

### `@memberjunction/storage` — Dropbox driver
- **Refresh-token mode reported `IsConfigured=false` from the constructor.** Only `initialize()` set the `_accessToken` placeholder, but `AutotagCloudStorage.CreateStorageDriver` (and anything else that only constructs the driver) never calls `initialize()`, so an env-configured refresh token was rejected with "Dropbox provider not configured. Missing: Access Token". The constructor's refresh-token branch now sets the same placeholder.
- **Business team spaces.** Paths under a team space 404 unless the SDK is given a `pathRoot`. New optional `STORAGE_DROPBOX_PATH_ROOT` (root namespace id) is applied to every `new Dropbox(...)` via `withPathRoot()`. No behaviour change when unset.

### `@memberjunction/content-autotagging`
- **`AutotagCloudStorage` listed one folder level only.** `ListModifiedObjects` called `driver.ListObjects(prefix)` once and dropped directories, so anything nested below the prefix was invisible ("no modified files"). It now walks child prefixes recursively (depth cap 16, loop guard).
- **Vectorizer addressed the 3rd-party index by the Vector Index display `Name`.** With `Name="More Cheese Content (Pinecone)"` and `ExternalID="morecheese-content"`, every upsert 404'd. `AutotagBaseEngine` now uses `ExternalID` (falls back to `Name` when blank) and logs both.
- **Invalid-content deletions were silent.** When the tagging model returns `isValidContent:false`, `saveLLMResults` deletes the item with no log line; the only trace was an unrelated `Error in BaseEntity.Load(MJ: Content Items …)` later. Now logged with the item id and title. (Observation for a follow-up, not changed here: the prompt only receives the Content Type *name*, so a terse type name makes the model reject legitimate pages — ~half of a blog crawl in our case.)
- **`AutotagWebsite.processSingleURL` ignored the `Save()` result.** Now logs `LatestResult.Message` and returns `null` on failure instead of yielding an unsaved item.

### `@memberjunction/search-engine`
- **`VectorSearchProvider` had the same Name-vs-ExternalID bug** in `queryOneIndex` (both the colocated and plain query paths), so the Semantic lane of universal search 404'd against Pinecone on every query while the engine reported success with 0 semantic hits. Now uses `ExternalID` with the same fallback.

## Test plan
- [x] Knowledge Hub pipeline (Explorer → Knowledge Hub → Run Pipeline) against a Dropbox team-space source with nested folders: 6 files found and tagged (previously 0).
- [x] Vectorization: 135 content items embedded and upserted to Pinecone index `morecheese-content` (previously `PineconeNotFoundError` on `/indexes/More%20Cheese%20Content%20(Pinecone)`).
- [x] Universal search "raw milk cheese safety rules": 50 semantic hits from Content Item Chunks (previously 0; log showed `Error querying index PineconeNotFoundError`).
- [x] Unit tests for the three packages (see below).
- [ ] Integration tier (`pnpm run test:integration`) — run by the author before marking ready; results appended.

## Notes
- Env additions used in testing, for the docs: `AI_VENDOR_API_KEY__GeminiEmbedding` and `AI_VENDOR_API_KEY__PineconeDatabase` (keys are looked up by driver class), `STORAGE_DROPBOX_PATH_ROOT` (team space).
- Related follow-ups not in this PR: Explorer Knowledge Hub "Retry Failed" is a placeholder; a vault that is both a Content Source and a File Storage Account shows the same file in two search lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
