### PR TITLE
feat(integration): per-connection catalog — resolution API, scope and writer

### DIFF
--- a/.changeset/per-connection-catalog-engine.md
+++ b/.changeset/per-connection-catalog-engine.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/integration-engine-base": minor
+"@memberjunction/integration-engine": minor
+---
+
+Per-connection integration catalog, engine half: a resolution API and catalog scope (`WithCatalogScope`/`RunInCatalogScope`), a `CatalogSource` flag (`Shared` | `PerConnection`, per connection or via `MJ_INTEGRATION_CATALOG_SOURCE`), and a catalog writer that persists discovery into the connection's own rows and rebases them from the declared definition. Flag off is byte-identical behaviour. `MJ_INTEGRATION_CATALOG_STRICT=1` makes the declared catalog read-only at runtime.

--- a/packages/Integration/engine-base/src/CompanyIntegrationCatalog.ts
+++ b/packages/Integration/engine-base/src/CompanyIntegrationCatalog.ts
@@ -44,12 +44,13 @@ export const CATALOG_OBJECT_COLUMNS = [
 ] as const;
 
 /**
- * Columns the field projection reads. `IntegrationObjectID` and `RelatedIntegrationObjectID` are
- * NOT stored columns on the per-connection field table — the view exposes them as aliases of
- * `CompanyIntegrationObjectID` and `RelatedCompanyIntegrationObjectID`, registered as virtual
- * fields. That alias is what lets a connector resolving a dependency edge
- * (`f.RelatedIntegrationObjectID` matched against its sibling objects) get a per-connection answer
- * with no change to its code.
+ * Columns the field projection reads. These are all REAL columns on the per-connection field
+ * table — the legacy names `IntegrationObjectID` / `RelatedIntegrationObjectID` are NOT here and
+ * must not be: they are derived in `projectCatalogFields` (see FIELD_READ_ALIASES).
+ *
+ * They are derived in TypeScript rather than aliased in the base view because the view is
+ * CodeGen-generated: a hand-added alias column would be silently dropped the next time CodeGen
+ * regenerates it, and the loss would only surface as a schema-mismatch throw much later.
  */
 export const CATALOG_FIELD_COLUMNS = [
     'ID', 'Name', 'DisplayName', 'Description', 'Category', 'Type', 'Length', 'Precision', 'Scale',
@@ -58,8 +59,18 @@ export const CATALOG_FIELD_COLUMNS = [
     'MetadataSource', 'CompanyIntegrationObjectID', 'RelatedCompanyIntegrationObjectID',
     'IntegrationObjectFieldID', 'Provenance', 'ProvenanceDetail', 'IsSelected', 'SelectedAt',
     'FirstSeenAt', 'LastSeenAt', 'LastSampledAt', 'ObservedMaxLength',
-    // view aliases — virtual, never written
-    'IntegrationObjectID', 'RelatedIntegrationObjectID',
+] as const;
+
+/**
+ * Legacy read names mapped onto their per-connection columns.
+ *
+ * A connector resolving a dependency edge reads `f.RelatedIntegrationObjectID` and matches it
+ * against its sibling objects (e.g. Rhythm, PathLMS). Deriving these keeps that code working
+ * unchanged while the value it gets is the per-connection id.
+ */
+const FIELD_READ_ALIASES: ReadonlyArray<readonly [alias: string, source: string]> = [
+    ['IntegrationObjectID', 'CompanyIntegrationObjectID'],
+    ['RelatedIntegrationObjectID', 'RelatedCompanyIntegrationObjectID'],
 ] as const;
 
 /** Where a per-connection row's shape came from. */
@@ -187,7 +198,11 @@ export function projectCatalogFields(rows: BaseEntity[]): CompanyIntegrationObje
     if (rows.length > 0) {
         assertCatalogColumns(ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS, rows[0], CATALOG_FIELD_COLUMNS);
     }
-    return rows.map(r => project<CompanyIntegrationObjectFieldRow>(r, CATALOG_FIELD_COLUMNS));
+    return rows.map(r => {
+        const projected = project<Record<string, unknown>>(r, CATALOG_FIELD_COLUMNS);
+        for (const [alias, source] of FIELD_READ_ALIASES) projected[alias] = projected[source];
+        return projected as unknown as CompanyIntegrationObjectFieldRow;
+    });
 }
 
 /**

--- a/packages/Integration/engine-base/src/CompanyIntegrationCatalog.ts
+++ b/packages/Integration/engine-base/src/CompanyIntegrationCatalog.ts
@@ -1,0 +1,212 @@
+import type { BaseEntity } from '@memberjunction/core';
+import type { MJIntegrationObjectEntity, MJIntegrationObjectFieldEntity } from '@memberjunction/core-entities';
+
+/**
+ * The per-connection catalog: read-side types, column contract, and projection.
+ *
+ * Every connector and every engine read site names an IntegrationObject's properties directly —
+ * `io.Name` appears 241 times across the connectors repository, `io.Fields` 93, `io.APIPath` 52.
+ * A row loaded for an entity with no registered subclass is a plain `BaseEntity`: it carries its
+ * values in `Fields` and exposes them through `Get()`, and every one of those property reads is
+ * `undefined`. So the cache cannot hand connectors the entity rows themselves.
+ *
+ * It hands them PROJECTIONS instead — plain objects carrying exactly the property surface the read
+ * sites use. That is not a new idea here: `IntegrationEngineBase.SeedForTesting` already seeds the
+ * shared catalog with "plain objects shaped like the entity (property reads only)" for the same
+ * reason, and the replay tiers exercise metadata-driven connectors through them.
+ *
+ * Writes are the other half and do NOT come through here — they go through the store in
+ * `@memberjunction/integration-engine`, which holds real entity rows and uses `Get()`/`Set()`
+ * exclusively. Assigning `row.Name = x` on a subclass-less `BaseEntity` silently creates an own
+ * property, `Save()` sends nothing, and the write is lost with no error anywhere.
+ */
+
+export const ENTITY_COMPANY_INTEGRATION_OBJECTS = 'MJ: Company Integration Objects';
+export const ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS = 'MJ: Company Integration Object Fields';
+
+/**
+ * Columns the object projection reads. The first 43 are IntegrationObject's own, copied verbatim so
+ * a per-connection row answers every question a shared row answers; the rest are what per-connection
+ * rows add. `IntegrationID` is deliberately among the first group and denormalised onto the table:
+ * connectors read it off the object, and a join per read would be the wrong trade.
+ */
+export const CATALOG_OBJECT_COLUMNS = [
+    'ID', 'IntegrationID', 'Name', 'DisplayName', 'Description', 'Category', 'APIPath',
+    'ResponseDataKey', 'DefaultPageSize', 'SupportsPagination', 'PaginationType',
+    'SupportsIncrementalSync', 'SupportsWrite', 'DefaultQueryParams', 'Configuration', 'Sequence',
+    'Status', 'WriteAPIPath', 'WriteMethod', 'DeleteMethod', 'IsCustom', 'CreateAPIPath',
+    'CreateMethod', 'CreateBodyShape', 'CreateBodyKey', 'CreateIDLocation', 'UpdateAPIPath',
+    'UpdateMethod', 'UpdateBodyShape', 'UpdateBodyKey', 'UpdateIDLocation', 'DeleteAPIPath',
+    'DeleteIDLocation', 'IncrementalWatermarkField', 'MetadataSource', 'SupportsCreate',
+    'SupportsUpdate', 'SupportsDelete', 'SyncStrategy', 'ContentHashApplicable', 'StableOrderingKey',
+    'CompanyIntegrationID', 'IntegrationObjectID', 'Provenance', 'ProvenanceDetail', 'IsSelected',
+    'SelectedAt', 'FirstSeenAt', 'LastSeenAt', 'LastSampledAt',
+] as const;
+
+/**
+ * Columns the field projection reads. `IntegrationObjectID` and `RelatedIntegrationObjectID` are
+ * NOT stored columns on the per-connection field table — the view exposes them as aliases of
+ * `CompanyIntegrationObjectID` and `RelatedCompanyIntegrationObjectID`, registered as virtual
+ * fields. That alias is what lets a connector resolving a dependency edge
+ * (`f.RelatedIntegrationObjectID` matched against its sibling objects) get a per-connection answer
+ * with no change to its code.
+ */
+export const CATALOG_FIELD_COLUMNS = [
+    'ID', 'Name', 'DisplayName', 'Description', 'Category', 'Type', 'Length', 'Precision', 'Scale',
+    'AllowsNull', 'DefaultValue', 'IsPrimaryKey', 'IsUniqueKey', 'IsReadOnly', 'IsRequired',
+    'RelatedIntegrationObjectFieldName', 'Sequence', 'Configuration', 'Status', 'IsCustom',
+    'MetadataSource', 'CompanyIntegrationObjectID', 'RelatedCompanyIntegrationObjectID',
+    'IntegrationObjectFieldID', 'Provenance', 'ProvenanceDetail', 'IsSelected', 'SelectedAt',
+    'FirstSeenAt', 'LastSeenAt', 'LastSampledAt', 'ObservedMaxLength',
+    // view aliases — virtual, never written
+    'IntegrationObjectID', 'RelatedIntegrationObjectID',
+] as const;
+
+/** Where a per-connection row's shape came from. */
+export type CatalogProvenance = 'Declared' | 'Endpoint' | 'Sampled';
+
+/**
+ * A per-connection object as read sites see it: every IntegrationObject property, plus the
+ * per-connection additions. Structurally assignable to `MJIntegrationObjectEntity` for the property
+ * reads connectors perform, which is what makes the swap invisible to them.
+ */
+export type CompanyIntegrationObjectRow = Pick<
+    MJIntegrationObjectEntity,
+    'ID' | 'IntegrationID' | 'Name' | 'DisplayName' | 'Description' | 'Category' | 'APIPath'
+    | 'ResponseDataKey' | 'DefaultPageSize' | 'SupportsPagination' | 'PaginationType'
+    | 'SupportsIncrementalSync' | 'SupportsWrite' | 'DefaultQueryParams' | 'Configuration'
+    | 'Sequence' | 'Status' | 'WriteAPIPath' | 'WriteMethod' | 'DeleteMethod' | 'IsCustom'
+    | 'CreateAPIPath' | 'CreateMethod' | 'CreateBodyShape' | 'CreateBodyKey' | 'CreateIDLocation'
+    | 'UpdateAPIPath' | 'UpdateMethod' | 'UpdateBodyShape' | 'UpdateBodyKey' | 'UpdateIDLocation'
+    | 'DeleteAPIPath' | 'DeleteIDLocation' | 'IncrementalWatermarkField' | 'MetadataSource'
+    | 'SupportsCreate' | 'SupportsUpdate' | 'SupportsDelete' | 'SyncStrategy'
+    | 'ContentHashApplicable' | 'StableOrderingKey'
+> & {
+    /** The connection this row belongs to. The axis the whole design exists for. */
+    CompanyIntegrationID: string;
+    /** The declared row this was matched to, or null when the object exists only for this connection. */
+    IntegrationObjectID: string | null;
+    Provenance: CatalogProvenance;
+    /** Per-attribute merge log the persist already computes and currently discards. */
+    ProvenanceDetail: string | null;
+    /**
+     * Catalog membership and sync selection are separate axes. Conflating them is what made a
+     * newly-discovered object arrive `Disabled` and therefore vanish from schema introspection, key
+     * inference and migration — the customer saw it in the picker, selected it, and got nothing.
+     */
+    IsSelected: boolean;
+    SelectedAt: Date | null;
+    FirstSeenAt: Date | null;
+    LastSeenAt: Date | null;
+    LastSampledAt: Date | null;
+};
+
+/**
+ * A per-connection field as read sites see it. `IntegrationObjectID` and
+ * `RelatedIntegrationObjectID` carry per-connection ids through the view aliases.
+ */
+export type CompanyIntegrationObjectFieldRow = Pick<
+    MJIntegrationObjectFieldEntity,
+    'ID' | 'IntegrationObjectID' | 'Name' | 'DisplayName' | 'Description' | 'Category' | 'Type'
+    | 'Length' | 'Precision' | 'Scale' | 'AllowsNull' | 'DefaultValue' | 'IsPrimaryKey'
+    | 'IsUniqueKey' | 'IsReadOnly' | 'IsRequired' | 'RelatedIntegrationObjectID'
+    | 'RelatedIntegrationObjectFieldName' | 'Sequence' | 'Configuration' | 'Status' | 'IsCustom'
+    | 'MetadataSource'
+> & {
+    CompanyIntegrationObjectID: string;
+    RelatedCompanyIntegrationObjectID: string | null;
+    IntegrationObjectFieldID: string | null;
+    Provenance: CatalogProvenance;
+    ProvenanceDetail: string | null;
+    IsSelected: boolean;
+    SelectedAt: Date | null;
+    FirstSeenAt: Date | null;
+    LastSeenAt: Date | null;
+    LastSampledAt: Date | null;
+    /**
+     * The raw sampled maximum, kept apart from `Length`, which carries the padded width the DDL
+     * uses. Without both, a width complaint cannot be told from a padding complaint.
+     */
+    ObservedMaxLength: number | null;
+};
+
+/**
+ * Thrown when the loaded entity is missing columns this code requires — the migration is absent or
+ * an older version of it ran. Failing here names the problem; letting it through would produce rows
+ * whose per-connection columns are all `undefined`, which reads downstream as "no selection, no
+ * provenance, never seen" and is indistinguishable from a legitimately empty catalog.
+ */
+export class CompanyIntegrationCatalogSchemaMismatch extends Error {
+    public readonly Code = 'PER_CONNECTION_CATALOG_SCHEMA_MISMATCH';
+    constructor(entityName: string, missing: string[]) {
+        super(
+            `${entityName} is missing ${missing.length} required column(s): ${missing.join(', ')}. `
+            + `The per-connection catalog migration has not been applied to this database, or the `
+            + `applied version predates these columns.`
+        );
+        this.name = 'CompanyIntegrationCatalogSchemaMismatch';
+    }
+}
+
+/** Names present on a loaded row, whether the value is set or not. */
+function fieldNamesOf(row: BaseEntity): Set<string> {
+    return new Set((row.Fields ?? []).map(f => f.Name));
+}
+
+/**
+ * Verify a loaded row carries every column we read. Called once per array load — the cost is one
+ * pass over one row's field list, and the alternative is a silent wrong answer.
+ */
+export function assertCatalogColumns(entityName: string, row: BaseEntity, required: readonly string[]): void {
+    const present = fieldNamesOf(row);
+    const missing = required.filter(c => !present.has(c));
+    if (missing.length > 0) throw new CompanyIntegrationCatalogSchemaMismatch(entityName, missing);
+}
+
+function project<T>(row: BaseEntity, columns: readonly string[]): T {
+    const out: Record<string, unknown> = {};
+    for (const c of columns) out[c] = row.Get(c);
+    return out as T;
+}
+
+/**
+ * Project loaded object rows for the read path. Validates the column set against the FIRST row
+ * only: every row in the array is the same entity, so one is proof, and an empty array proves
+ * nothing and needs no check — a connection with no catalog rows is the ordinary pre-discovery
+ * state, not a schema problem.
+ */
+export function projectCatalogObjects(rows: BaseEntity[]): CompanyIntegrationObjectRow[] {
+    if (rows.length > 0) {
+        assertCatalogColumns(ENTITY_COMPANY_INTEGRATION_OBJECTS, rows[0], CATALOG_OBJECT_COLUMNS);
+    }
+    return rows.map(r => project<CompanyIntegrationObjectRow>(r, CATALOG_OBJECT_COLUMNS));
+}
+
+/** Project loaded field rows for the read path. Same validation rule as the object projection. */
+export function projectCatalogFields(rows: BaseEntity[]): CompanyIntegrationObjectFieldRow[] {
+    if (rows.length > 0) {
+        assertCatalogColumns(ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS, rows[0], CATALOG_FIELD_COLUMNS);
+    }
+    return rows.map(r => project<CompanyIntegrationObjectFieldRow>(r, CATALOG_FIELD_COLUMNS));
+}
+
+/**
+ * Present a projection to code typed against the shared catalog entities.
+ *
+ * The two casts below are the ONLY place this narrowing happens, deliberately, so the reasoning
+ * sits in one auditable spot. A projection carries every property the read sites touch and none of
+ * `BaseEntity`'s behaviour — no `Save()`, no `Fields`, no dirty tracking. That is safe here and
+ * nowhere else, because reads are all this cache serves: the per-connection write path holds real
+ * entity rows and never receives one of these.
+ *
+ * Calling `.Save()` on the result would throw at runtime rather than corrupt anything, which is the
+ * failure mode to want if this contract is ever broken.
+ */
+export function asReadOnlyObject(row: CompanyIntegrationObjectRow): MJIntegrationObjectEntity {
+    return row as unknown as MJIntegrationObjectEntity;
+}
+
+/** See {@link asReadOnlyObject}. */
+export function asReadOnlyField(row: CompanyIntegrationObjectFieldRow): MJIntegrationObjectFieldEntity {
+    return row as unknown as MJIntegrationObjectFieldEntity;
+}

--- a/packages/Integration/engine-base/src/CompanyIntegrationCatalog.ts
+++ b/packages/Integration/engine-base/src/CompanyIntegrationCatalog.ts
@@ -73,6 +73,41 @@ const FIELD_READ_ALIASES: ReadonlyArray<readonly [alias: string, source: string]
     ['RelatedIntegrationObjectID', 'RelatedCompanyIntegrationObjectID'],
 ] as const;
 
+/**
+ * Columns whose value the CONNECTOR declares (metadata/ folder), as opposed to columns the
+ * connection owns or discovery decides.
+ *
+ * plan.md requires that a schema refresh treat IO/IOF as the source of truth and REPLACE what is
+ * in CIO/CIOF rather than layering on it: "it will use IO/IOF as the SOT before then replacing
+ * what is in the respective CIO/CIOF, it will not do the changes on top of CIO/CIOF since it is
+ * stale metadata". Without that, an open-app upgrade that changes a declared APIPath or page size
+ * would never reach a connection that had already discovered once — the stale per-connection value
+ * would win every subsequent overlay.
+ *
+ * Derived by SUBTRACTION so it cannot drift when a column is added: anything not explicitly
+ * identity, per-connection state, or discovery-owned lifecycle is connector-declared.
+ * Description / DisplayName / IncrementalWatermarkField are deliberately IN this set — they are
+ * rebased from the declaration and then discovery overlays them if it reports a value, which is
+ * exactly the documented precedence.
+ */
+const NOT_DECLARED_OWNED = new Set<string>([
+    // identity and linkage
+    'ID', 'IntegrationID', 'Name',
+    'CompanyIntegrationID', 'IntegrationObjectID',
+    'CompanyIntegrationObjectID', 'RelatedCompanyIntegrationObjectID', 'IntegrationObjectFieldID',
+    // per-connection state
+    'Provenance', 'ProvenanceDetail', 'IsSelected', 'SelectedAt',
+    'FirstSeenAt', 'LastSeenAt', 'LastSampledAt', 'ObservedMaxLength',
+    // decided by discovery, not declared
+    'Status', 'IsCustom', 'MetadataSource',
+]);
+
+export const DECLARED_OWNED_OBJECT_COLUMNS: readonly string[] =
+    CATALOG_OBJECT_COLUMNS.filter(c => !NOT_DECLARED_OWNED.has(c));
+
+export const DECLARED_OWNED_FIELD_COLUMNS: readonly string[] =
+    CATALOG_FIELD_COLUMNS.filter(c => !NOT_DECLARED_OWNED.has(c));
+
 /** Where a per-connection row's shape came from. */
 export type CatalogProvenance = 'Declared' | 'Endpoint' | 'Sampled';
 

--- a/packages/Integration/engine-base/src/IntegrationEngineBase.ts
+++ b/packages/Integration/engine-base/src/IntegrationEngineBase.ts
@@ -231,6 +231,13 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
         CompanyIntegrations?: Array<Partial<MJCompanyIntegrationEntity>>;
         EntityMaps?: Array<Partial<MJCompanyIntegrationEntityMapEntity>>;
         FieldMaps?: Array<Partial<MJCompanyIntegrationFieldMapEntity>>;
+        /**
+         * Per-connection catalog rows, as LOADED rows rather than projections — they go through
+         * `projectCatalogObjects`/`projectCatalogFields` exactly as the real load does, so a seed
+         * that omits a required column fails the same way production would.
+         */
+        CompanyIntegrationObjects?: BaseEntity[];
+        CompanyIntegrationObjectFields?: BaseEntity[];
     }): void {
         if (seed.Integrations) this._integrations = seed.Integrations as MJIntegrationEntity[];
         if (seed.IntegrationObjects) this._integrationObjects = seed.IntegrationObjects as MJIntegrationObjectEntity[];
@@ -238,6 +245,8 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
         if (seed.CompanyIntegrations) this._companyIntegrations = seed.CompanyIntegrations as MJCompanyIntegrationEntity[];
         if (seed.EntityMaps) this._entityMaps = seed.EntityMaps as MJCompanyIntegrationEntityMapEntity[];
         if (seed.FieldMaps) this._fieldMaps = seed.FieldMaps as MJCompanyIntegrationFieldMapEntity[];
+        if (seed.CompanyIntegrationObjects) this._companyIntegrationObjects = seed.CompanyIntegrationObjects;
+        if (seed.CompanyIntegrationObjectFields) this._companyIntegrationObjectFields = seed.CompanyIntegrationObjectFields;
     }
 
     // ── Public Accessors ──────────────────────────────────────────────
@@ -379,9 +388,31 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
         );
     }
 
-    /** Get a specific IntegrationObject by its ID. */
+    /**
+     * Get a specific IntegrationObject by its ID, from EITHER catalog.
+     *
+     * Id-polymorphic for exactly the reason `GetIntegrationObjectFields` is: object ids are UUIDs
+     * from two disjoint tables and cannot collide, so the id itself says which catalog the caller
+     * meant, and a caller holding an id needs no scope to resolve it. The field side was made
+     * polymorphic and this one was not, which left a hole precisely where the two sides meet — a
+     * parent object resolved through a per-connection FK edge.
+     *
+     * The hole, measured on the sandbox 2026-09-12: a connector's nested fetch resolves a child's
+     * parent to a per-connection object id (`RelatedCompanyIntegrationObjectID`, surfaced on the
+     * per-connection field as `RelatedIntegrationObjectID`), then asks for that object by id here.
+     * The shared-only lookup returned undefined and `LoadParentIDs` threw
+     * "Parent IntegrationObject not found: <id>" for EVERY child object — twenty of PheedLoop's
+     * twenty-seven — so each of them fetched nothing while the run still reported success: 330 rows
+     * where the same connector had synced about sixteen hundred. A parent that cannot be resolved
+     * is the one case where an over-broad shared answer is not available as a fallback, because the
+     * id is not in the shared table at all.
+     *
+     * Shared first, so a shared id costs exactly the scan it always did.
+     */
     public GetIntegrationObjectByID(objectID: string): MJIntegrationObjectEntity | undefined {
-        return this._integrationObjects.find(o => UUIDsEqual(o.ID, objectID));
+        const shared = this._integrationObjects.find(o => UUIDsEqual(o.ID, objectID));
+        if (shared) return shared;
+        return this.GetCompanyIntegrationObjectByID(objectID);
     }
 
     /**

--- a/packages/Integration/engine-base/src/IntegrationEngineBase.ts
+++ b/packages/Integration/engine-base/src/IntegrationEngineBase.ts
@@ -1,4 +1,4 @@
-import { BaseEngine, BaseEnginePropertyConfig, IMetadataProvider, UserInfo, RegisterForStartup } from '@memberjunction/core';
+import { BaseEngine, BaseEnginePropertyConfig, BaseEntity, IMetadataProvider, UserInfo, RegisterForStartup } from '@memberjunction/core';
 import { UUIDsEqual } from '@memberjunction/global';
 import type {
     MJIntegrationEntity,
@@ -10,6 +10,33 @@ import type {
     MJIntegrationObjectEntity,
     MJIntegrationObjectFieldEntity,
 } from '@memberjunction/core-entities';
+import {
+    CATALOG_FIELD_COLUMNS,
+    CATALOG_OBJECT_COLUMNS,
+    CompanyIntegrationObjectFieldRow,
+    CompanyIntegrationObjectRow,
+    ENTITY_COMPANY_INTEGRATION_OBJECTS,
+    ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
+    asReadOnlyField,
+    asReadOnlyObject,
+    projectCatalogFields,
+    projectCatalogObjects,
+} from './CompanyIntegrationCatalog.js';
+
+/**
+ * How a catalog read was answered. Returned alongside the rows so a caller — and a support
+ * transcript — can tell a per-connection answer from the shared fallback without inferring it.
+ */
+export type CatalogSource = 'PerConnection' | 'Shared';
+
+/** The resolved catalog for one connection. */
+export interface ResolvedCompanyIntegrationCatalog {
+    Objects: MJIntegrationObjectEntity[];
+    FieldsByObjectID: Map<string, MJIntegrationObjectFieldEntity[]>;
+    Source: CatalogSource;
+    /** Count of per-connection objects by provenance. Empty when `Source` is `Shared`. */
+    Provenance: { Declared: number; Endpoint: number; Sampled: number };
+}
 
 /**
  * IntegrationEngineBase provides cached metadata for the MJ integration subsystem.
@@ -40,6 +67,31 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
      */
     private _fieldsByObjectID: Map<string, MJIntegrationObjectFieldEntity[]> = new Map();
     private _fieldsByObjectIDSource: MJIntegrationObjectFieldEntity[] | null = null;
+    /**
+     * Second invalidation source for the field index. The index spans both field arrays, so
+     * keying it on the shared array alone would leave it stale whenever only the per-connection
+     * array reloaded — which is precisely what a discovery does.
+     */
+    private _fieldsByObjectIDScopedSource: CompanyIntegrationObjectFieldRow[] | null = null;
+
+    /**
+     * Per-connection catalog rows, loaded as plain `BaseEntity` because no generated subclass
+     * exists for these entities — see CompanyIntegrationCatalog.ts. They are projected on first
+     * read and the projections are what every read site receives.
+     */
+    private _companyIntegrationObjects: BaseEntity[] = [];
+    private _companyIntegrationObjectFields: BaseEntity[] = [];
+
+    /**
+     * Lazily-built projections, invalidated exactly the way the field index is: by the identity of
+     * the array they were built from. Every load path replaces these arrays rather than mutating
+     * them, so a new array is a new projection with no invalidation hook to forget — which matters
+     * because `RefreshCatalog` bypasses `AdditionalLoading` and would otherwise leave them stale.
+     */
+    private _cioProjected: CompanyIntegrationObjectRow[] | null = null;
+    private _cioProjectedSource: BaseEntity[] | null = null;
+    private _ciofProjected: CompanyIntegrationObjectFieldRow[] | null = null;
+    private _ciofProjectedSource: BaseEntity[] | null = null;
 
     // ── BaseEngine Config ─────────────────────────────────────────────
 
@@ -85,6 +137,16 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
                 EntityName: 'MJ: Integration Object Fields',
                 CacheLocal: true,
             },
+            {
+                PropertyName: '_companyIntegrationObjects',
+                EntityName: ENTITY_COMPANY_INTEGRATION_OBJECTS,
+                CacheLocal: true,
+            },
+            {
+                PropertyName: '_companyIntegrationObjectFields',
+                EntityName: ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
+                CacheLocal: true,
+            },
         ];
 
         return await this.Load(params, provider, forceRefresh, contextUser);
@@ -100,7 +162,16 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
      * ARRAY IDENTITY, so they rebuild lazily on first read after the swap.
      */
     public async RefreshCatalog(contextUser?: UserInfo): Promise<void> {
-        for (const prop of ['_integrationObjects', '_integrationObjectFields']) {
+        // All FOUR arrays, not just the shared pair. The two-pass discovery heal re-reads the
+        // catalog mid-run and overlays what the first pass persisted; if the per-connection arrays
+        // were left stale the second pass would overlay against rows that no longer exist and the
+        // heal would silently regress for every per-connection row.
+        for (const prop of [
+            '_integrationObjects',
+            '_integrationObjectFields',
+            '_companyIntegrationObjects',
+            '_companyIntegrationObjectFields',
+        ]) {
             const cfg = this.Configs.find(c => c.PropertyName === prop);
             if (cfg) await this.LoadSingleConfig(cfg, (contextUser ?? this.ContextUser) as UserInfo, /*bypassCache*/ true);
         }
@@ -290,20 +361,33 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
             return this._integrationObjectFields.filter(f => UUIDsEqual(f.IntegrationObjectID, objectID));
         }
 
-        if (this._fieldsByObjectIDSource !== this._integrationObjectFields) {
+        // The index spans BOTH field arrays, so this one method answers for a shared object id and
+        // a per-connection one alike. That is what lets the field side need no scope at all: object
+        // ids are UUIDs from disjoint tables and cannot collide, so the id itself says which
+        // catalog the caller meant. Every read site that resolves fields from an object it already
+        // holds therefore needs no change.
+        const projectedFields = this.CompanyIntegrationObjectFields;
+        if (
+            this._fieldsByObjectIDSource !== this._integrationObjectFields ||
+            this._fieldsByObjectIDScopedSource !== projectedFields
+        ) {
             const index = new Map<string, MJIntegrationObjectFieldEntity[]>();
-            for (const field of this._integrationObjectFields) {
-                const id = field.IntegrationObjectID;
-                if (id == null) continue;
+            const add = (key: string | null | undefined, field: MJIntegrationObjectFieldEntity) => {
+                if (key == null) return;
                 // Normalised the same way UUIDsEqual compares, so SQL Server's uppercase and
                 // PostgreSQL's lowercase land on the same bucket.
-                const key = id.trim().toLowerCase();
-                const bucket = index.get(key);
+                const k = key.trim().toLowerCase();
+                const bucket = index.get(k);
                 if (bucket) bucket.push(field);
-                else index.set(key, [field]);
-            }
+                else index.set(k, [field]);
+            };
+            for (const field of this._integrationObjectFields) add(field.IntegrationObjectID, field);
+            // The per-connection view aliases CompanyIntegrationObjectID as IntegrationObjectID, so
+            // both arrays key on the same property name and the loop body is identical.
+            for (const field of projectedFields) add(field.IntegrationObjectID, asReadOnlyField(field));
             this._fieldsByObjectID = index;
             this._fieldsByObjectIDSource = this._integrationObjectFields;
+            this._fieldsByObjectIDScopedSource = projectedFields;
         }
 
         return this._fieldsByObjectID.get(objectID.trim().toLowerCase())?.slice() ?? [];
@@ -396,6 +480,221 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
         }
 
         return sorted;
+    }
+
+    // ── Per-connection catalog ──────────────────────────────────────
+
+    /**
+     * Resolves the connection whose catalog a read belongs to, when one is in scope.
+     *
+     * Dependency inversion, deliberately: the scope itself is `AsyncLocalStorage`, which is a Node
+     * built-in this package must not import — it is loaded into the Angular client too. So the
+     * server package installs a resolver here at module load and the client never sets one, leaving
+     * every read on the shared catalog exactly as before.
+     *
+     * Same shape as the custom-column promoter registration the server already installs.
+     */
+    public static CatalogScopeResolver: (() => string | undefined) | undefined = undefined;
+
+    private static currentScope(): string | undefined {
+        try {
+            return IntegrationEngineBase.CatalogScopeResolver?.();
+        } catch {
+            // A scope lookup must never be able to fail a read. Falling back to the shared catalog
+            // is the pre-existing behaviour, and it is the safe direction: a shared answer where a
+            // per-connection one was wanted is over-broad, never wrong about what exists.
+            return undefined;
+        }
+    }
+
+    /** Per-connection objects, projected for reading. See CompanyIntegrationCatalog.ts. */
+    private get CompanyIntegrationObjects(): CompanyIntegrationObjectRow[] {
+        if (this._cioProjectedSource !== this._companyIntegrationObjects || this._cioProjected === null) {
+            this._cioProjected = projectCatalogObjects(this._companyIntegrationObjects);
+            this._cioProjectedSource = this._companyIntegrationObjects;
+        }
+        return this._cioProjected;
+    }
+
+    /** Per-connection fields, projected for reading. */
+    private get CompanyIntegrationObjectFields(): CompanyIntegrationObjectFieldRow[] {
+        if (this._ciofProjectedSource !== this._companyIntegrationObjectFields || this._ciofProjected === null) {
+            this._ciofProjected = projectCatalogFields(this._companyIntegrationObjectFields);
+            this._ciofProjectedSource = this._companyIntegrationObjectFields;
+        }
+        return this._ciofProjected;
+    }
+
+    /** Does this connection have a per-connection catalog at all? */
+    public HasCompanyIntegrationCatalog(companyIntegrationID: string): boolean {
+        return this.CompanyIntegrationObjects.some(o => UUIDsEqual(o.CompanyIntegrationID, companyIntegrationID));
+    }
+
+    /** All per-connection objects for a connection. */
+    public GetCompanyIntegrationObjects(companyIntegrationID: string): MJIntegrationObjectEntity[] {
+        return this.CompanyIntegrationObjects
+            .filter(o => UUIDsEqual(o.CompanyIntegrationID, companyIntegrationID))
+            .map(asReadOnlyObject);
+    }
+
+    /**
+     * One per-connection object by name.
+     *
+     * Matches rows of EVERY status, `Disabled` included, because the overlay reactivates a
+     * previously-absent object rather than inserting a second one — the unique constraint on
+     * (connection, name) is what makes that necessary and what makes a name-match on active rows
+     * only a constraint violation waiting to happen.
+     */
+    public GetCompanyIntegrationObject(companyIntegrationID: string, objectName: string): MJIntegrationObjectEntity | undefined {
+        const row = this.CompanyIntegrationObjects.find(
+            o => UUIDsEqual(o.CompanyIntegrationID, companyIntegrationID) && o.Name === objectName
+        );
+        return row ? asReadOnlyObject(row) : undefined;
+    }
+
+    /** One per-connection object by its own id. */
+    public GetCompanyIntegrationObjectByID(objectID: string): MJIntegrationObjectEntity | undefined {
+        const row = this.CompanyIntegrationObjects.find(o => UUIDsEqual(o.ID, objectID));
+        return row ? asReadOnlyObject(row) : undefined;
+    }
+
+    /** Active per-connection objects, sorted by Sequence. Mirrors GetActiveIntegrationObjects. */
+    public GetActiveCompanyIntegrationObjects(companyIntegrationID: string): MJIntegrationObjectEntity[] {
+        return this.CompanyIntegrationObjects
+            .filter(o => UUIDsEqual(o.CompanyIntegrationID, companyIntegrationID) && o.Status === 'Active')
+            .sort((a, b) => a.Sequence - b.Sequence)
+            .map(asReadOnlyObject);
+    }
+
+    /**
+     * Per-connection dependency order. Same Kahn sort and same Sequence-order fallback on a cycle
+     * as the shared version, over this connection's own edges: a field's
+     * RelatedCompanyIntegrationObjectID points at an object belonging to the same connection, so
+     * two connections of one connector can legitimately disagree about the shape of the graph.
+     */
+    public GetCompanyIntegrationObjectsInDependencyOrder(companyIntegrationID: string): MJIntegrationObjectEntity[] {
+        const objects = this.GetActiveCompanyIntegrationObjects(companyIntegrationID);
+        const objectMap = new Map(objects.map(o => [o.ID.toUpperCase(), o]));
+
+        const deps = new Map<string, Set<string>>();
+        for (const obj of objects) deps.set(obj.ID.toUpperCase(), new Set());
+
+        for (const field of this.CompanyIntegrationObjectFields) {
+            if (!field.RelatedCompanyIntegrationObjectID) continue;
+            const parentKey = field.CompanyIntegrationObjectID.toUpperCase();
+            const depKey = field.RelatedCompanyIntegrationObjectID.toUpperCase();
+            if (deps.has(parentKey) && objectMap.has(depKey) && parentKey !== depKey) {
+                deps.get(parentKey)!.add(depKey);
+            }
+        }
+
+        return this.topologicalSort(objects, deps);
+    }
+
+    /**
+     * THE CUTOVER SEAM. Every read that wants "this connection's catalog" comes through here, and
+     * this is the one place that decides whether that means the per-connection tables or the shared
+     * ones.
+     *
+     * With `preferPerConnection` false — the default at deploy — the answer is byte-for-byte what
+     * the shared catalog returns today, so the tables can exist, be backfilled and be verified
+     * against production traffic before anything reads them.
+     *
+     * @param opts.preferPerConnection  Read per-connection rows when they exist.
+     * @param opts.requirePerConnection Refuse rather than fall back. Set it wherever a silent
+     *   shared answer would be indistinguishable from success — a shared answer carries objects
+     *   this connection never discovered and omits the ones only it has, and a sync would run on it
+     *   reporting no error at all.
+     */
+    public ResolveCompanyIntegrationCatalog(
+        companyIntegrationID: string,
+        opts?: { preferPerConnection?: boolean; requirePerConnection?: boolean }
+    ): ResolvedCompanyIntegrationCatalog {
+        const wantPerConnection = opts?.preferPerConnection === true || opts?.requirePerConnection === true;
+        const have = wantPerConnection && this.HasCompanyIntegrationCatalog(companyIntegrationID);
+
+        if (opts?.requirePerConnection === true && !have) {
+            throw new Error(
+                `PER_CONNECTION_CATALOG_MISSING: connection ${companyIntegrationID} is configured for the `
+                + `per-connection catalog but has no rows in ${ENTITY_COMPANY_INTEGRATION_OBJECTS}. `
+                + `Run the catalog backfill for this connection, or set its catalog source back to shared. `
+                + `Refusing rather than reading the shared catalog, which would silently sync a different `
+                + `set of objects and report success.`
+            );
+        }
+
+        const fieldsByObjectID = new Map<string, MJIntegrationObjectFieldEntity[]>();
+
+        if (!have) {
+            const ci = this.GetCompanyIntegrationByID(companyIntegrationID);
+            const objects = ci ? this.GetActiveIntegrationObjects(ci.IntegrationID) : [];
+            for (const o of objects) fieldsByObjectID.set(o.ID, this.GetIntegrationObjectFields(o.ID));
+            return {
+                Objects: objects,
+                FieldsByObjectID: fieldsByObjectID,
+                Source: 'Shared',
+                Provenance: { Declared: 0, Endpoint: 0, Sampled: 0 },
+            };
+        }
+
+        const rows = this.CompanyIntegrationObjects
+            .filter(o => UUIDsEqual(o.CompanyIntegrationID, companyIntegrationID) && o.Status === 'Active')
+            .sort((a, b) => a.Sequence - b.Sequence);
+        const provenance = { Declared: 0, Endpoint: 0, Sampled: 0 };
+        for (const r of rows) {
+            if (r.Provenance === 'Declared' || r.Provenance === 'Endpoint' || r.Provenance === 'Sampled') {
+                provenance[r.Provenance]++;
+            }
+        }
+        const objects = rows.map(asReadOnlyObject);
+        for (const o of objects) fieldsByObjectID.set(o.ID, this.GetIntegrationObjectFields(o.ID));
+
+        return { Objects: objects, FieldsByObjectID: fieldsByObjectID, Source: 'PerConnection', Provenance: provenance };
+    }
+
+    /**
+     * Resolve one object by name for the connection currently in scope, falling back to the shared
+     * catalog when there is no scope or no per-connection catalog.
+     *
+     * This is what the connector chokepoints call. A connector passes the integration id it has
+     * always passed and gets a per-connection answer when one exists — the whole reason no
+     * connector in the Integrations repository needs a line changed.
+     */
+    public ResolveScopedObject(integrationID: string, objectName: string): MJIntegrationObjectEntity | undefined {
+        const ciID = IntegrationEngineBase.currentScope();
+        if (ciID) {
+            const scoped = this.GetCompanyIntegrationObject(ciID, objectName);
+            if (scoped) return scoped;
+            // Only fall through when this connection has NO per-connection catalog at all. Once it
+            // has one, a missing name means the object genuinely is not in this connection's
+            // catalog, and answering from the shared one would resurrect an object the connection
+            // does not have.
+            if (this.HasCompanyIntegrationCatalog(ciID)) return undefined;
+        }
+        return this.GetIntegrationObject(integrationID, objectName);
+    }
+
+    /** Scoped counterpart of GetActiveIntegrationObjects. See {@link ResolveScopedObject}. */
+    public ResolveScopedActiveObjects(integrationID: string): MJIntegrationObjectEntity[] {
+        const ciID = IntegrationEngineBase.currentScope();
+        if (ciID && this.HasCompanyIntegrationCatalog(ciID)) return this.GetActiveCompanyIntegrationObjects(ciID);
+        return this.GetActiveIntegrationObjects(integrationID);
+    }
+
+    /** Scoped counterpart of GetIntegrationObjectsByIntegrationID. */
+    public ResolveScopedObjects(integrationID: string): MJIntegrationObjectEntity[] {
+        const ciID = IntegrationEngineBase.currentScope();
+        if (ciID && this.HasCompanyIntegrationCatalog(ciID)) return this.GetCompanyIntegrationObjects(ciID);
+        return this.GetIntegrationObjectsByIntegrationID(integrationID);
+    }
+
+    /** Scoped counterpart of GetObjectsInDependencyOrder. */
+    public ResolveScopedObjectsInDependencyOrder(integrationID: string): MJIntegrationObjectEntity[] {
+        const ciID = IntegrationEngineBase.currentScope();
+        if (ciID && this.HasCompanyIntegrationCatalog(ciID)) {
+            return this.GetCompanyIntegrationObjectsInDependencyOrder(ciID);
+        }
+        return this.GetObjectsInDependencyOrder(integrationID);
     }
 
     // ── Singleton ─────────────────────────────────────────────────────

--- a/packages/Integration/engine-base/src/IntegrationEngineBase.ts
+++ b/packages/Integration/engine-base/src/IntegrationEngineBase.ts
@@ -137,17 +137,35 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
                 EntityName: 'MJ: Integration Object Fields',
                 CacheLocal: true,
             },
-            {
-                PropertyName: '_companyIntegrationObjects',
-                EntityName: ENTITY_COMPANY_INTEGRATION_OBJECTS,
-                CacheLocal: true,
-            },
-            {
-                PropertyName: '_companyIntegrationObjectFields',
-                EntityName: ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
-                CacheLocal: true,
-            },
         ];
+
+        // The per-connection catalog is loaded ONLY when its entities are actually registered.
+        //
+        // This is not defensive tidiness — without it the engine cannot start on a workspace that
+        // has the code but not the migration. A configured dataset whose entity does not exist
+        // fails its RunView; BaseEngine treats an unknown entity as readable ("let the normal
+        // not-found handling apply"), so the failure is classified TRANSIENT, the property is left
+        // `loadedSuccessfully: false`, and every Config()/EnsureLoaded() retries it forever. The
+        // whole integration engine would sit permanently not-loaded, and the symptom would point
+        // at the network rather than at a missing table.
+        //
+        // Being conditional also removes an ordering constraint from the rollout: the patch is safe
+        // to deploy before the migration, and safe on a workspace that never receives it — those
+        // read the shared catalog exactly as they do today, which is the default anyway.
+        const md = provider ?? this.ProviderToUse;
+        const registered = (name: string): boolean => {
+            try {
+                return !!md?.EntityByName(name);
+            } catch {
+                return false;
+            }
+        };
+        if (registered(ENTITY_COMPANY_INTEGRATION_OBJECTS) && registered(ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS)) {
+            params.push(
+                { PropertyName: '_companyIntegrationObjects', EntityName: ENTITY_COMPANY_INTEGRATION_OBJECTS, CacheLocal: true },
+                { PropertyName: '_companyIntegrationObjectFields', EntityName: ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS, CacheLocal: true },
+            );
+        }
 
         return await this.Load(params, provider, forceRefresh, contextUser);
     }
@@ -166,6 +184,8 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
         // catalog mid-run and overlays what the first pass persisted; if the per-connection arrays
         // were left stale the second pass would overlay against rows that no longer exist and the
         // heal would silently regress for every per-connection row.
+        // The per-connection pair is absent from Configs on a workspace without the migration —
+        // the `if (cfg)` below is what makes that a no-op rather than a crash.
         for (const prop of [
             '_integrationObjects',
             '_integrationObjectFields',

--- a/packages/Integration/engine-base/src/IntegrationEngineBase.ts
+++ b/packages/Integration/engine-base/src/IntegrationEngineBase.ts
@@ -321,13 +321,39 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
 
     // ── Integration Object Lookups ──────────────────────────────────
 
-    /** Get all IntegrationObjects for a given Integration ID. */
+    /**
+     * Get all IntegrationObjects for a given Integration ID.
+     *
+     * SCOPE-AWARE. When a connection is in scope AND has a per-connection catalog, this answers
+     * from that catalog; otherwise it answers exactly as it always has. The scoping lives HERE, on
+     * the existing getters, rather than at the call sites — which is the only version that reaches
+     * the connectors in the separate Integrations repository. Two of them call these getters
+     * directly rather than going through the REST base, so a new method name would have left them
+     * reading the shared catalog forever while every other path was per-connection.
+     */
     public GetIntegrationObjectsByIntegrationID(integrationID: string): MJIntegrationObjectEntity[] {
+        const scoped = this.scopedObjects();
+        if (scoped) return scoped;
         return this._integrationObjects.filter(o => UUIDsEqual(o.IntegrationID, integrationID));
     }
 
-    /** Get a specific IntegrationObject by integration ID and object name. */
+    /**
+     * The connection in scope's objects, or undefined when there is no scope or no per-connection
+     * catalog for it. One place, so every getter below scopes identically.
+     */
+    private scopedObjects(): MJIntegrationObjectEntity[] | undefined {
+        const ciID = IntegrationEngineBase.currentScope();
+        if (!ciID || !this.HasCompanyIntegrationCatalog(ciID)) return undefined;
+        return this.GetCompanyIntegrationObjects(ciID);
+    }
+
+    /** Get a specific IntegrationObject by integration ID and object name. SCOPE-AWARE. */
     public GetIntegrationObject(integrationID: string, objectName: string): MJIntegrationObjectEntity | undefined {
+        const scoped = this.scopedObjects();
+        // Once a connection HAS a per-connection catalog, a missing name means the object genuinely
+        // is not in this connection's catalog. Falling back to the shared one there would resurrect
+        // an object the connection does not have.
+        if (scoped) return scoped.find(o => o.Name === objectName);
         return this._integrationObjects.find(
             o => UUIDsEqual(o.IntegrationID, integrationID) && o.Name === objectName
         );
@@ -393,10 +419,30 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
         return this._fieldsByObjectID.get(objectID.trim().toLowerCase())?.slice() ?? [];
     }
 
-    /** Get active IntegrationObjects for an integration, sorted by Sequence. */
+    /** Get active IntegrationObjects for an integration, sorted by Sequence. SCOPE-AWARE. */
     public GetActiveIntegrationObjects(integrationID: string): MJIntegrationObjectEntity[] {
         return this.GetIntegrationObjectsByIntegrationID(integrationID)
             .filter(o => o.Status === 'Active')
+            .sort((a, b) => a.Sequence - b.Sequence);
+    }
+
+    /**
+     * SHARED objects, ignoring any scope.
+     *
+     * Two callers need this and both would be WRONG with the scoped answer. The declared floor a
+     * discovery overlays onto is by definition the shared, curated definition — reading the
+     * per-connection rows there would make a discovery overlay its own previous output and lose
+     * the link back to the declared row. And the Shared branch of
+     * {@link ResolveCompanyIntegrationCatalog} was explicitly asked not to read per-connection rows.
+     */
+    public GetSharedIntegrationObjects(integrationID: string): MJIntegrationObjectEntity[] {
+        return this._integrationObjects.filter(o => UUIDsEqual(o.IntegrationID, integrationID));
+    }
+
+    /** See {@link GetSharedIntegrationObjects}. Active only, sorted by Sequence. */
+    public GetActiveSharedIntegrationObjects(integrationID: string): MJIntegrationObjectEntity[] {
+        return this._integrationObjects
+            .filter(o => UUIDsEqual(o.IntegrationID, integrationID) && o.Status === 'Active')
             .sort((a, b) => a.Sequence - b.Sequence);
     }
 
@@ -409,6 +455,12 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
      * @returns Objects sorted in dependency order (parents before children)
      */
     public GetObjectsInDependencyOrder(integrationID: string): MJIntegrationObjectEntity[] {
+        // SCOPE-AWARE. Two connections of one connector can legitimately disagree about the shape
+        // of this graph, because each edge is a field pointing at an object in the SAME catalog.
+        const ciID = IntegrationEngineBase.currentScope();
+        if (ciID && this.HasCompanyIntegrationCatalog(ciID)) {
+            return this.GetCompanyIntegrationObjectsInDependencyOrder(ciID);
+        }
         const objects = this.GetActiveIntegrationObjects(integrationID);
         const objectMap = new Map(objects.map(o => [o.ID.toUpperCase(), o]));
 
@@ -627,7 +679,7 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
 
         if (!have) {
             const ci = this.GetCompanyIntegrationByID(companyIntegrationID);
-            const objects = ci ? this.GetActiveIntegrationObjects(ci.IntegrationID) : [];
+            const objects = ci ? this.GetActiveSharedIntegrationObjects(ci.IntegrationID) : [];
             for (const o of objects) fieldsByObjectID.set(o.ID, this.GetIntegrationObjectFields(o.ID));
             return {
                 Objects: objects,
@@ -652,50 +704,9 @@ export class IntegrationEngineBase extends BaseEngine<IntegrationEngineBase> {
         return { Objects: objects, FieldsByObjectID: fieldsByObjectID, Source: 'PerConnection', Provenance: provenance };
     }
 
-    /**
-     * Resolve one object by name for the connection currently in scope, falling back to the shared
-     * catalog when there is no scope or no per-connection catalog.
-     *
-     * This is what the connector chokepoints call. A connector passes the integration id it has
-     * always passed and gets a per-connection answer when one exists — the whole reason no
-     * connector in the Integrations repository needs a line changed.
-     */
-    public ResolveScopedObject(integrationID: string, objectName: string): MJIntegrationObjectEntity | undefined {
-        const ciID = IntegrationEngineBase.currentScope();
-        if (ciID) {
-            const scoped = this.GetCompanyIntegrationObject(ciID, objectName);
-            if (scoped) return scoped;
-            // Only fall through when this connection has NO per-connection catalog at all. Once it
-            // has one, a missing name means the object genuinely is not in this connection's
-            // catalog, and answering from the shared one would resurrect an object the connection
-            // does not have.
-            if (this.HasCompanyIntegrationCatalog(ciID)) return undefined;
-        }
-        return this.GetIntegrationObject(integrationID, objectName);
-    }
 
-    /** Scoped counterpart of GetActiveIntegrationObjects. See {@link ResolveScopedObject}. */
-    public ResolveScopedActiveObjects(integrationID: string): MJIntegrationObjectEntity[] {
-        const ciID = IntegrationEngineBase.currentScope();
-        if (ciID && this.HasCompanyIntegrationCatalog(ciID)) return this.GetActiveCompanyIntegrationObjects(ciID);
-        return this.GetActiveIntegrationObjects(integrationID);
-    }
 
-    /** Scoped counterpart of GetIntegrationObjectsByIntegrationID. */
-    public ResolveScopedObjects(integrationID: string): MJIntegrationObjectEntity[] {
-        const ciID = IntegrationEngineBase.currentScope();
-        if (ciID && this.HasCompanyIntegrationCatalog(ciID)) return this.GetCompanyIntegrationObjects(ciID);
-        return this.GetIntegrationObjectsByIntegrationID(integrationID);
-    }
 
-    /** Scoped counterpart of GetObjectsInDependencyOrder. */
-    public ResolveScopedObjectsInDependencyOrder(integrationID: string): MJIntegrationObjectEntity[] {
-        const ciID = IntegrationEngineBase.currentScope();
-        if (ciID && this.HasCompanyIntegrationCatalog(ciID)) {
-            return this.GetCompanyIntegrationObjectsInDependencyOrder(ciID);
-        }
-        return this.GetObjectsInDependencyOrder(integrationID);
-    }
 
     // ── Singleton ─────────────────────────────────────────────────────
 

--- a/packages/Integration/engine-base/src/__tests__/CatalogFieldAliases.test.ts
+++ b/packages/Integration/engine-base/src/__tests__/CatalogFieldAliases.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The per-connection field table stores `CompanyIntegrationObjectID` and
+ * `RelatedCompanyIntegrationObjectID`. Connector code resolving a dependency edge reads the LEGACY
+ * names (`f.RelatedIntegrationObjectID` matched against sibling objects — Rhythm, PathLMS), so the
+ * projection has to answer to both.
+ *
+ * These were once expected to come from alias columns on the base view. They cannot: that view is
+ * CodeGen-generated, so a hand-added alias is dropped the next time CodeGen runs. The derivation
+ * lives in `projectCatalogFields` instead, and this file is what pins it there.
+ */
+import { describe, it, expect } from 'vitest';
+import { projectCatalogFields, CATALOG_FIELD_COLUMNS } from '../CompanyIntegrationCatalog';
+import type { BaseEntity } from '@memberjunction/core';
+
+/** A stand-in for a loaded row: `Get` answers only for columns the VIEW really has. */
+function rowWith(values: Record<string, unknown>): BaseEntity {
+    return {
+        Fields: Object.keys(values).map(Name => ({ Name })),
+        Get: (c: string) => values[c],
+    } as unknown as BaseEntity;
+}
+
+const REAL_COLUMNS = () => {
+    const v: Record<string, unknown> = {};
+    for (const c of CATALOG_FIELD_COLUMNS) v[c] = null;
+    v['CompanyIntegrationObjectID'] = 'obj-1';
+    v['RelatedCompanyIntegrationObjectID'] = 'obj-2';
+    return v;
+};
+
+describe('per-connection field read aliases', () => {
+    it('derives the legacy names from the per-connection columns', () => {
+        const [row] = projectCatalogFields([rowWith(REAL_COLUMNS())]);
+        expect(row.IntegrationObjectID).toBe('obj-1');
+        expect(row.RelatedIntegrationObjectID).toBe('obj-2');
+    });
+
+    it('carries a null related edge through as null rather than undefined', () => {
+        const vals = REAL_COLUMNS();
+        vals['RelatedCompanyIntegrationObjectID'] = null;
+        const [row] = projectCatalogFields([rowWith(vals)]);
+        expect(row.RelatedIntegrationObjectID).toBeNull();
+    });
+
+    it('does not require the aliases to exist as columns on the row', () => {
+        // The generated view exposes neither name. Projection must still succeed - if the alias
+        // names were in the validated column set this would throw a schema mismatch.
+        const vals = REAL_COLUMNS();
+        expect(Object.keys(vals)).not.toContain('IntegrationObjectID');
+        expect(Object.keys(vals)).not.toContain('RelatedIntegrationObjectID');
+        expect(() => projectCatalogFields([rowWith(vals)])).not.toThrow();
+    });
+
+    it('still fails loud when a REAL column is missing (guard not weakened)', () => {
+        const vals = REAL_COLUMNS();
+        delete vals['ObservedMaxLength'];
+        expect(() => projectCatalogFields([rowWith(vals)])).toThrow(/ObservedMaxLength/);
+    });
+});

--- a/packages/Integration/engine-base/src/__tests__/ObjectByIdSpansBothCatalogs.test.ts
+++ b/packages/Integration/engine-base/src/__tests__/ObjectByIdSpansBothCatalogs.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `GetIntegrationObjectByID` must answer for a per-connection object id as well as a shared one.
+ *
+ * THE INCIDENT (sandbox, 2026-09-12). The fields lookup was made id-polymorphic, and the reasoning
+ * written into it was that object ids are UUIDs from two disjoint tables and cannot collide, so the
+ * id itself says which catalog the caller meant and no call site needs changing. The OBJECT lookup
+ * by id was left shared-only, which put a hole exactly where the two sides meet.
+ *
+ * A connector's nested fetch resolves a child's parent through the per-connection FK edge
+ * (`RelatedCompanyIntegrationObjectID`, surfaced on the field as `RelatedIntegrationObjectID`) and
+ * then asks for that object by id. The shared-only lookup returned undefined and the connector
+ * threw `Parent IntegrationObject not found: <id>` for EVERY child object — twenty of PheedLoop's
+ * twenty-seven — so each fetched nothing while the run still reported Success. The three objects
+ * with no parent (Members 312, Tickets 21, Events 5) synced; the total was 338 where the same
+ * connector had previously synced about sixteen hundred, and each dead object carried only
+ * INCOMPLETE/persistent-error rather than a failure anyone had to look at.
+ *
+ * A parent id is the one case with no safe fallback: it is not in the shared table at all, so an
+ * over-broad shared answer is not available and the lookup simply has to reach the other catalog.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { IntegrationEngineBase } from '../IntegrationEngineBase';
+import { CATALOG_OBJECT_COLUMNS } from '../CompanyIntegrationCatalog';
+import type { BaseEntity } from '@memberjunction/core';
+
+const INTEGRATION = 'AAAAAAAA-1111-2222-3333-444444444444';
+const SHARED_EVENTS = '2ECE575C-9443-4627-B03D-23429DA3EC24';
+const CIO_EVENTS = 'BBBBBBBB-1111-2222-3333-444444444444';
+const CONNECTION = 'CCCCCCCC-1111-2222-3333-444444444444';
+
+/** A stand-in for a loaded per-connection row: `Get` answers for the real view columns. */
+function catalogRow(values: Record<string, unknown>): BaseEntity {
+    const all: Record<string, unknown> = {};
+    for (const c of CATALOG_OBJECT_COLUMNS) all[c] = null;
+    Object.assign(all, values);
+    return {
+        Fields: Object.keys(all).map(Name => ({ Name })),
+        Get: (c: string) => all[c],
+    } as unknown as BaseEntity;
+}
+
+describe('GetIntegrationObjectByID spans both catalogs', () => {
+    let engine: IntegrationEngineBase;
+
+    beforeEach(() => {
+        engine = IntegrationEngineBase.Instance;
+        engine.SeedForTesting({
+            IntegrationObjects: [
+                { ID: SHARED_EVENTS, IntegrationID: INTEGRATION, Name: 'Events', Status: 'Active' },
+            ] as never,
+            CompanyIntegrationObjects: [
+                catalogRow({
+                    ID: CIO_EVENTS,
+                    CompanyIntegrationID: CONNECTION,
+                    IntegrationID: INTEGRATION,
+                    Name: 'Events',
+                    Status: 'Active',
+                    Sequence: 1,
+                }),
+            ],
+        });
+    });
+
+    it('resolves a per-connection object id — the parent edge that threw', () => {
+        const parent = engine.GetIntegrationObjectByID(CIO_EVENTS);
+        expect(parent).toBeDefined();
+        expect(parent?.Name).toBe('Events');
+    });
+
+    it('still resolves a shared object id', () => {
+        expect(engine.GetIntegrationObjectByID(SHARED_EVENTS)?.Name).toBe('Events');
+    });
+
+    it('matches case-insensitively on either side, as UUIDsEqual does', () => {
+        // SQL Server hands back uppercase ids, PostgreSQL lowercase.
+        expect(engine.GetIntegrationObjectByID(CIO_EVENTS.toLowerCase())?.Name).toBe('Events');
+        expect(engine.GetIntegrationObjectByID(SHARED_EVENTS.toLowerCase())?.Name).toBe('Events');
+    });
+
+    it('is still undefined for an id in neither catalog', () => {
+        expect(engine.GetIntegrationObjectByID('99999999-9999-9999-9999-999999999999')).toBeUndefined();
+    });
+
+    it('prefers the shared row when an id somehow appears in both, so a shared id costs its old scan', () => {
+        engine.SeedForTesting({
+            IntegrationObjects: [
+                { ID: SHARED_EVENTS, IntegrationID: INTEGRATION, Name: 'SharedEvents', Status: 'Active' },
+            ] as never,
+            CompanyIntegrationObjects: [
+                catalogRow({
+                    ID: SHARED_EVENTS,
+                    CompanyIntegrationID: CONNECTION,
+                    IntegrationID: INTEGRATION,
+                    Name: 'PerConnectionEvents',
+                    Status: 'Active',
+                    Sequence: 1,
+                }),
+            ],
+        });
+        expect(engine.GetIntegrationObjectByID(SHARED_EVENTS)?.Name).toBe('SharedEvents');
+    });
+});

--- a/packages/Integration/engine-base/src/index.ts
+++ b/packages/Integration/engine-base/src/index.ts
@@ -1,1 +1,3 @@
 export { IntegrationEngineBase } from './IntegrationEngineBase.js';
+export type { CatalogSource, ResolvedCompanyIntegrationCatalog } from './IntegrationEngineBase.js';
+export * from './CompanyIntegrationCatalog.js';

--- a/packages/Integration/engine/src/CatalogScope.ts
+++ b/packages/Integration/engine/src/CatalogScope.ts
@@ -1,0 +1,84 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
+
+/**
+ * Which connection's catalog the code currently running belongs to.
+ *
+ * The problem this solves: every read of the integration catalog is keyed by INTEGRATION id, which
+ * is shared by every connection of a connector. Threading a connection id down to each of them is
+ * not viable — there are twenty-two call sites inside the REST connector base alone, and the
+ * connectors that call them live in a separate repository and must keep compiling unchanged.
+ *
+ * So the connection id travels out of band. An operation that belongs to one connection runs inside
+ * `RunInCatalogScope`, and the reads underneath it resolve per-connection without being told.
+ *
+ * This is the same mechanism the sync loop already uses for its own run context, in this very
+ * package — `IntegrationEngine` imports `AsyncLocalStorage` for `runContext` and enters it around
+ * each run and each write batch. Async context propagates across `await`, `Promise.all` and timer
+ * callbacks, so a scope entered at the top of a run covers everything the run does.
+ *
+ * WHAT IT DOES NOT COVER, and why that is safe: a callback scheduled OUTSIDE the scope and invoked
+ * inside it sees no scope, and so does a task handed to a worker thread or another process. Both
+ * fall back to the shared catalog, which is the pre-existing behaviour — over-broad, never wrong
+ * about what exists. The failure mode of a missed scope is therefore the old behaviour, not a
+ * corrupt one. The failure mode that WOULD be dangerous — a per-connection write landing on the
+ * shared rows — cannot happen here, because the write path takes an explicit connection id and
+ * never consults this scope.
+ */
+export interface CatalogScopeState {
+    companyIntegrationID: string;
+}
+
+const storage = new AsyncLocalStorage<CatalogScopeState>();
+
+/** The connection currently in scope, or undefined when there is none. */
+export function CurrentCatalogCI(): string | undefined {
+    return storage.getStore()?.companyIntegrationID;
+}
+
+/**
+ * Run `fn` with `companyIntegrationID` in scope.
+ *
+ * Nesting is allowed and the innermost wins, which is what a batch operation over several
+ * connections needs: it enters one scope per connection and each iteration's reads resolve to that
+ * connection alone.
+ */
+export function RunInCatalogScope<T>(companyIntegrationID: string, fn: () => T): T {
+    if (!companyIntegrationID) return fn();
+    return storage.run({ companyIntegrationID }, fn);
+}
+
+/**
+ * `RunInCatalogScope` for an async body — the ordinary case. Separate only so the return type is
+ * a promise rather than a promise-shaped generic, which makes a forgotten `await` a type error.
+ */
+export function WithCatalogScope<T>(companyIntegrationID: string, fn: () => Promise<T>): Promise<T> {
+    if (!companyIntegrationID) return fn();
+    return storage.run({ companyIntegrationID }, fn);
+}
+
+/**
+ * Run `fn` with NO connection in scope, so its reads see the shared catalog.
+ *
+ * One deliberate caller: action generation. An Action describes the vendor's API, not one tenant's
+ * projection of it, so generating actions from whichever connection happened to be in scope would
+ * make the generated surface depend on who ran it. Stated here rather than left implicit, because
+ * from inside the generator the shared read looks like an oversight.
+ */
+export function RunOutsideCatalogScope<T>(fn: () => T): T {
+    return storage.exit(fn);
+}
+
+/**
+ * Install the scope resolver on the client-safe engine base.
+ *
+ * Dependency inversion: `integration-engine-base` is bundled into the Angular client and cannot
+ * import a Node built-in, so it declares a hook and this package fills it in. Called at module
+ * load, so importing this package is enough — no ordering requirement on callers, and the client
+ * never sets it, leaving every read on the shared catalog exactly as before.
+ */
+export function InstallCatalogScopeResolver(): void {
+    IntegrationEngineBase.CatalogScopeResolver = CurrentCatalogCI;
+}
+
+InstallCatalogScopeResolver();

--- a/packages/Integration/engine/src/CatalogSource.ts
+++ b/packages/Integration/engine/src/CatalogSource.ts
@@ -1,0 +1,117 @@
+import { IMetadataProvider, LogError, UserInfo } from '@memberjunction/core';
+import type { MJCompanyIntegrationEntity } from '@memberjunction/core-entities';
+import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
+import { CatalogWriter, PerConnectionCatalogWriter, SharedCatalogWriter } from './CatalogWriter.js';
+
+/**
+ * THE ONE PLACE that decides whether a connection reads and writes the shared integration catalog
+ * or its own.
+ *
+ * Deliberately one place. A flag consulted in several is a flag that will eventually disagree with
+ * itself, and here the two answers are not merely different — a shared write during a
+ * per-connection run puts one tenant's discovery into every other tenant's catalog and reports
+ * success.
+ *
+ * Two levers, in precedence order:
+ *
+ *  1. `CompanyIntegration.Configuration.catalogSource` — per connection. This is the primary
+ *     control, and it is per-connection rather than per-process for two reasons: it survives a
+ *     deploy (an environment variable set on the box does not — a deploy rewrites the env file),
+ *     and it lets one process run some connections each way at once, which is what makes cutting
+ *     over one connector at a time possible.
+ *  2. `MJ_INTEGRATION_CATALOG_SOURCE` — a global override, and the reason it exists is rollback:
+ *     it is the only lever that does not require reaching a connection's Configuration through a
+ *     workspace that may be the thing that is broken. Keep it after the fleet cuts over.
+ *
+ * Default is 'Shared'. The tables can therefore exist, be backfilled and be verified against live
+ * traffic before anything reads or writes them.
+ */
+export type CatalogSource = 'Shared' | 'PerConnection';
+
+const CONFIG_KEY = 'catalogSource';
+const ENV_KEY = 'MJ_INTEGRATION_CATALOG_SOURCE';
+
+function normalise(value: unknown): CatalogSource | undefined {
+    if (typeof value !== 'string') return undefined;
+    const v = value.trim().toLowerCase();
+    if (v === 'perconnection' || v === 'per-connection') return 'PerConnection';
+    if (v === 'shared') return 'Shared';
+    return undefined;
+}
+
+/** The global override, or undefined when unset. */
+export function GlobalCatalogSourceOverride(): CatalogSource | undefined {
+    return normalise(process.env[ENV_KEY]);
+}
+
+/**
+ * Which catalog this connection uses.
+ *
+ * An unparseable `Configuration` is treated as "no opinion" rather than as an error: that column
+ * carries a dozen unrelated settings, and letting one bad character anywhere in it flip a
+ * connection's catalog would be a far worse failure than ignoring it.
+ */
+export function ResolveCatalogSource(companyIntegration: MJCompanyIntegrationEntity): CatalogSource {
+    const override = GlobalCatalogSourceOverride();
+    if (override) return override;
+    const raw = companyIntegration.Configuration;
+    if (!raw) return 'Shared';
+    try {
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        return normalise(parsed?.[CONFIG_KEY]) ?? 'Shared';
+    } catch {
+        return 'Shared';
+    }
+}
+
+/**
+ * The writer for this connection's catalog.
+ *
+ * FAIL-LOUD, not fail-safe. A connection set to 'PerConnection' that has entity maps but no
+ * per-connection catalog rows has not been backfilled, and answering from the shared catalog would
+ * be indistinguishable from success: the sync would run, on a different set of objects, and report
+ * nothing wrong. So it refuses, and the message names the connection, what it found, and the way
+ * out.
+ *
+ * The "has entity maps" part matters. A brand-new connection legitimately has neither maps nor
+ * catalog rows — that is the state right before its first discovery, not a missing backfill — so
+ * requiring rows there would refuse every new connector on the very flag that is supposed to be
+ * safe to turn on.
+ */
+export function BuildCatalogWriter(
+    md: IMetadataProvider,
+    companyIntegration: MJCompanyIntegrationEntity,
+    contextUser: UserInfo,
+    source?: CatalogSource,
+): CatalogWriter {
+    const resolved = source ?? ResolveCatalogSource(companyIntegration);
+    if (resolved === 'Shared') {
+        return new SharedCatalogWriter(md, companyIntegration.IntegrationID, contextUser);
+    }
+
+    const engine = IntegrationEngineBase.Instance;
+    const hasCatalog = engine.HasCompanyIntegrationCatalog(companyIntegration.ID);
+    if (!hasCatalog) {
+        const mapCount = engine.GetEntityMapsForCompanyIntegration(companyIntegration.ID).length;
+        if (mapCount > 0) {
+            throw new Error(
+                `PER_CONNECTION_CATALOG_MISSING: connection ${companyIntegration.ID} `
+                + `("${companyIntegration.Name ?? 'unnamed'}") is set to the per-connection catalog and has `
+                + `${mapCount} entity map(s), but no rows in its own catalog. It has not been backfilled. `
+                + `Run the catalog backfill for this connection, or set its Configuration.${CONFIG_KEY} `
+                + `back to "shared". Refusing to read the shared catalog, which carries objects this `
+                + `connection never discovered and omits the ones only it has — the sync would run on the `
+                + `wrong set and report success.`,
+            );
+        }
+        // No maps and no rows: a connection that has not discovered anything yet. Nothing to fall
+        // back FROM, so this is the ordinary pre-discovery state and the per-connection writer is
+        // exactly right — it is about to create the rows.
+        LogError(
+            `[CatalogSource] Connection ${companyIntegration.ID} is per-connection with an empty catalog `
+            + `and no entity maps — treating as pre-discovery.`,
+        );
+    }
+    return new PerConnectionCatalogWriter(
+        md, companyIntegration.ID, companyIntegration.IntegrationID, contextUser, new Date());
+}

--- a/packages/Integration/engine/src/CatalogWriter.ts
+++ b/packages/Integration/engine/src/CatalogWriter.ts
@@ -152,7 +152,7 @@ export interface CatalogWriter {
      * `if` at the call site:
      *   - SHARED rows are DISABLED, never deleted. They are the declared metadata every other
      *     connection of the connector still reads, and a missing row there is unrecoverable.
-     *   - PER-CONNECTION rows are DELETED. plan.md: "Removed tables are more than deselected,
+     *   - PER-CONNECTION OBJECTS are DELETED. plan.md: "Removed tables are more than deselected,
      *     they just dont exist, its likely a cascade delete." Nothing else owns them, and leaving
      *     tombstones would make the connection's catalog drift from its source forever.
      *
@@ -422,8 +422,28 @@ export class PerConnectionCatalogWriter implements CatalogWriter {
         return { ok: await row.Delete(), deleted: true };
     }
 
+    /**
+     * DISABLE, never delete — unlike the object above.
+     *
+     * The delete rule is dictated for TABLES and only tables: plan.md says "for tables only, if
+     * its not there after discovery algorithm, just removes it", and again "columns that are in
+     * MJC already never get removed, tables maybe if discovery objects doesnt find them, NEVER
+     * columns".
+     *
+     * The reason is in everything.txt: "sometimes, a column may be missing. If that is the case,
+     * then it doesnt automatically conclude the column no longer exist ... typically just may mean
+     * there is no more values". A column absent from one sample is absent from a SAMPLE, not from
+     * the source. Deleting the row destroys what only this connection knows about it — the
+     * observed width, the provenance, the selection state — so the next sample that does see it
+     * starts from nothing instead of reactivating. Disabling keeps all of it and reverses itself
+     * on rediscovery, which is what the shared catalog has always done.
+     *
+     * A field DOES get deleted when its OBJECT is removed; that cascade lives in RetireObject and
+     * is the table rule, not this one.
+     */
     public async RetireField(row: MJIntegrationObjectFieldEntity): Promise<{ ok: boolean; deleted: boolean }> {
-        return { ok: await row.Delete(), deleted: true };
+        row.Status = 'Disabled';
+        return { ok: await row.Save(), deleted: false };
     }
 
     public MarkSeen(row: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity, sampled: boolean): void {

--- a/packages/Integration/engine/src/CatalogWriter.ts
+++ b/packages/Integration/engine/src/CatalogWriter.ts
@@ -7,6 +7,8 @@ import {
     CompanyIntegrationCatalogSchemaMismatch,
     ENTITY_COMPANY_INTEGRATION_OBJECTS,
     ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
+    DECLARED_OWNED_OBJECT_COLUMNS,
+    DECLARED_OWNED_FIELD_COLUMNS,
 } from '@memberjunction/integration-engine-base';
 
 /**
@@ -157,6 +159,19 @@ export interface CatalogWriter {
      * Returns whether the row is gone (`deleted`) so the caller can report honestly; the mirror
      * TABLE and its data are never touched either way.
      */
+    /**
+     * Reset the connector-DECLARED columns of an existing row from the declared definition,
+     * before discovery overlays it.
+     *
+     * plan.md: a refresh uses IO/IOF as the source of truth and REPLACES what is in CIO/CIOF,
+     * because the per-connection row is a projection, not an accumulator. Without this an open-app
+     * upgrade that changes a declared APIPath or page size never reaches a connection that has
+     * already discovered once. Shared writers no-op: there the row IS the declaration.
+     */
+    RebaseFromDeclared(row: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity,
+                       declared: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity | null,
+                       kind: 'object' | 'field'): string[];
+
     RetireObject(row: MJIntegrationObjectEntity): Promise<{ ok: boolean; deleted: boolean }>;
     RetireField(row: MJIntegrationObjectFieldEntity): Promise<{ ok: boolean; deleted: boolean }>;
 }
@@ -253,6 +268,9 @@ export class SharedCatalogWriter implements CatalogWriter {
         /* the parent object id is the only ownership a shared field row carries */
     }
 
+    /** The shared row IS the declaration; there is nothing to rebase it from. */
+    public RebaseFromDeclared(): string[] { return []; }
+
     /** Shared rows are the declared floor for every other connection — disable, never delete. */
     public async RetireObject(row: MJIntegrationObjectEntity): Promise<{ ok: boolean; deleted: boolean }> {
         row.Status = 'Disabled';
@@ -343,6 +361,31 @@ export class PerConnectionCatalogWriter implements CatalogWriter {
         w.IsSelected = false;
         w.FirstSeenAt = this.seenAt;
         w.LastSeenAt = this.seenAt;
+    }
+
+    /**
+     * Copy the declared columns back over this connection's row so discovery overlays a CURRENT
+     * declaration rather than its own previous output. Returns the columns that actually moved,
+     * for the merge log. A row with no declared match (an object that exists only for this
+     * connection) has nothing to rebase from and is left alone.
+     */
+    public RebaseFromDeclared(
+        row: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity,
+        declared: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity | null,
+        kind: 'object' | 'field'
+    ): string[] {
+        if (!declared) return [];
+        const cols = kind === 'object' ? DECLARED_OWNED_OBJECT_COLUMNS : DECLARED_OWNED_FIELD_COLUMNS;
+        const target = row as unknown as Record<string, unknown>;
+        const source = declared as unknown as Record<string, unknown>;
+        const moved: string[] = [];
+        for (const c of cols) {
+            const next = source[c] ?? null;
+            if ((target[c] ?? null) === next) continue;
+            target[c] = next;
+            moved.push(c);
+        }
+        return moved;
     }
 
     /**

--- a/packages/Integration/engine/src/CatalogWriter.ts
+++ b/packages/Integration/engine/src/CatalogWriter.ts
@@ -1,0 +1,325 @@
+import { BaseEntity, CompositeKey, DatabaseProviderBase, IMetadataProvider, RunView, UserInfo } from '@memberjunction/core';
+import type { MJIntegrationObjectEntity, MJIntegrationObjectFieldEntity } from '@memberjunction/core-entities';
+import {
+    CATALOG_FIELD_COLUMNS,
+    CATALOG_OBJECT_COLUMNS,
+    CatalogProvenance,
+    CompanyIntegrationCatalogSchemaMismatch,
+    ENTITY_COMPANY_INTEGRATION_OBJECTS,
+    ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
+} from '@memberjunction/integration-engine-base';
+
+/**
+ * One write interface over BOTH integration catalogs — the one shared by every connection of a
+ * connector, and the one belonging to a single connection.
+ *
+ * The persistence logic is identical for both: the same per-attribute overlay deciders, the same
+ * two-pass object-then-field ordering, the same reactivate-on-rediscover rule, the same
+ * absent-deactivation pass. Only the entity name, the scope filter and a few ownership columns
+ * differ. This abstracts exactly those and leaves the merge logic untouched.
+ *
+ * ── Why the rows are proxies ───────────────────────────────────────────────────────────────────
+ *
+ * The per-connection entities are registered by a migration, not by CodeGen (tenant CodeGen
+ * excludes the core schema), so they have NO generated subclass. On such a row:
+ *
+ *     row.Description = 'x';   // creates an own property beside the entity's field list
+ *     await row.Save();        // returns true, sends nothing, logs nothing
+ *
+ * There is no accessor to intercept the assignment. Across a discovery persisting hundreds of rows
+ * that presents as a source that returned less than expected — a vendor problem, not a code one.
+ *
+ * A proxy closes that gap without touching the merge logic. Property access it cannot find on the
+ * row falls through to `Get`/`Set`, which is exactly what a generated accessor does:
+ *
+ *     get Description() { return this.Get('Description'); }
+ *     set Description(v) { this.Set('Description', v); }
+ *
+ * So for the SHARED catalog the proxy is transparent — the real accessor is found on the prototype
+ * and used. For the per-connection catalog it supplies the accessor that was never generated. The
+ * alternative was rewriting ~50 assignments in a 1,181-line file whose orchestration has no test
+ * coverage at all; this way the delicate part does not move.
+ *
+ * Methods are bound to the underlying row rather than the proxy, so `Save()` runs against the real
+ * entity and cannot recurse back through this handler.
+ */
+
+/** Write-side column aliases, mirroring what the per-connection VIEW already does for reads. */
+const FIELD_WRITE_ALIASES: Readonly<Record<string, string>> = {
+    // A field's parent and its dependency-edge target are named for the shared catalog throughout
+    // the persistence code. On the per-connection tables the real columns carry the per-connection
+    // names, and the view exposes the shared names as aliases. Mapping them here means the merge
+    // logic keeps writing `field.IntegrationObjectID` and lands on the right column.
+    IntegrationObjectID: 'CompanyIntegrationObjectID',
+    RelatedIntegrationObjectID: 'RelatedCompanyIntegrationObjectID',
+};
+
+/**
+ * Wrap a row so property access resolves through `Get`/`Set`, with an optional column allowlist and
+ * alias map.
+ *
+ * `required` is set only for the per-connection entities and does two jobs. On wrap it asserts the
+ * loaded entity carries every column this code writes, so an absent or stale migration fails here,
+ * named, instead of as scattered missing values hours later in a run that reported success. On each
+ * write it checks the column against the ROW'S OWN field list — not against `required` — because
+ * those answer different questions: `required` is what we expect, the field list is what the
+ * database actually has, and it is the gap between them that loses writes silently.
+ *
+ * The shared entities are left unguarded: their generated subclass turns a bad column name into a
+ * compile error long before this point.
+ */
+function proxyRow<T>(
+    row: BaseEntity,
+    entityName: string,
+    required: readonly string[] | null,
+    aliases: Readonly<Record<string, string>> | null
+): T {
+    const columns = required === null ? null : new Set((row.Fields ?? []).map(f => f.Name));
+    if (required !== null && columns !== null) {
+        const missing = required.filter(c => !columns.has(c));
+        if (missing.length > 0) throw new CompanyIntegrationCatalogSchemaMismatch(entityName, missing);
+    }
+    return new Proxy(row, {
+        get(target, prop, receiver) {
+            if (typeof prop !== 'string') return Reflect.get(target, prop, receiver);
+            if (prop in target) {
+                const value = Reflect.get(target, prop, target);
+                // Bind to the REAL row: an unbound method called on the proxy would run its own
+                // internals back through this handler.
+                return typeof value === 'function' ? value.bind(target) : value;
+            }
+            return target.Get(aliases?.[prop] ?? prop);
+        },
+        set(target, prop, value, receiver) {
+            if (typeof prop !== 'string') return Reflect.set(target, prop, value, receiver);
+            if (prop in target) return Reflect.set(target, prop, value, target);
+            const column = aliases?.[prop] ?? prop;
+            if (columns && !columns.has(column)) {
+                throw new Error(
+                    `${entityName} has no column '${column}'`
+                    + (column === prop ? '' : ` (aliased from '${prop}')`)
+                    + `. Writing it would create a property beside the entity's field list and `
+                    + `Save() would report success while writing nothing.`
+                );
+            }
+            target.Set(column, value);
+            return true;
+        },
+    }) as unknown as T;
+}
+
+/**
+ * Reads and creates for one catalog, scoped to whatever "this connector" means for it.
+ *
+ * `ObjectsInScope` deliberately returns rows of EVERY status. Disabled rows are load-bearing: an
+ * object the source dropped is disabled rather than deleted, and if it reappears the overlay must
+ * find and reactivate that row. Matching active rows only would attempt a second row with the same
+ * name and hit the unique constraint instead.
+ *
+ * These read straight from the database rather than the engine cache, deliberately. The cache is
+ * refreshed between discovery passes, not within one, so the write path must be able to see rows a
+ * previous pass of the SAME run just persisted. It is also what makes the per-connection catalog
+ * writable at all: its cached rows are read-only projections with no `Save()`.
+ */
+export interface CatalogWriter {
+    readonly Source: 'Shared' | 'PerConnection';
+
+    ObjectsInScope(): Promise<MJIntegrationObjectEntity[]>;
+    FieldsForObject(objectID: string): Promise<MJIntegrationObjectFieldEntity[]>;
+    NewObjectRow(): Promise<MJIntegrationObjectEntity>;
+    NewFieldRow(): Promise<MJIntegrationObjectFieldEntity>;
+    LoadObject(objectID: string): Promise<MJIntegrationObjectEntity | null>;
+    LoadField(fieldID: string): Promise<MJIntegrationObjectFieldEntity | null>;
+
+    /**
+     * Write the columns saying who a newly-created object belongs to and where its shape came from.
+     * A no-op on the shared catalog beyond the integration id, which is the only ownership it has.
+     */
+    StampNewObject(row: MJIntegrationObjectEntity, declaredObjectID: string | null, provenance: CatalogProvenance): void;
+
+    /** The field counterpart of {@link StampNewObject}. */
+    StampNewField(row: MJIntegrationObjectFieldEntity, declaredFieldID: string | null, provenance: CatalogProvenance): void;
+
+    /** Record that this row was seen — and optionally sampled — by the discovery now running. */
+    MarkSeen(row: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity, sampled: boolean): void;
+}
+
+/**
+ * Escape a value for an ExtraFilter literal. These are UUIDs from our own tables, so this is
+ * belt-and-braces rather than a live hazard — but the surrounding engine escapes its filter values
+ * and an unescaped one here would be the odd exception a reader has to stop and think about.
+ */
+function lit(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+async function newRow<T>(
+    md: IMetadataProvider, entityName: string, contextUser: UserInfo,
+    guard: readonly string[] | null, aliases: Readonly<Record<string, string>> | null
+): Promise<T> {
+    const row = await md.GetEntityObject<BaseEntity>(entityName, contextUser);
+    if (!row) throw new CompanyIntegrationCatalogSchemaMismatch(entityName, ['<entity not registered>']);
+    row.NewRecord();
+    return proxyRow<T>(row, entityName, guard, aliases);
+}
+
+async function loadRow<T>(
+    md: IMetadataProvider, entityName: string, contextUser: UserInfo, id: string,
+    guard: readonly string[] | null, aliases: Readonly<Record<string, string>> | null
+): Promise<T | null> {
+    const row = await md.GetEntityObject<BaseEntity>(entityName, contextUser);
+    if (!row) return null;
+    // `Load(id)` is a generated-subclass convenience; this is the base entry point, and the only
+    // one available for an entity a migration registered rather than CodeGen.
+    const ok = await row.InnerLoad(CompositeKey.FromID(id));
+    return ok ? proxyRow<T>(row, entityName, guard, aliases) : null;
+}
+
+async function viewRows<T>(
+    entityName: string, filter: string, contextUser: UserInfo, provider: IMetadataProvider | undefined,
+    guard: readonly string[] | null, aliases: Readonly<Record<string, string>> | null
+): Promise<T[]> {
+    // Server-side providers are DatabaseProviderBase, which implements IRunViewProvider; the
+    // narrower IMetadataProvider we are handed does not declare it. Same narrowing, and the same
+    // reason, as IntegrationEngine's own RunView construction in this package.
+    const rv = new RunView(provider as DatabaseProviderBase | undefined);
+    const res = await rv.RunView<BaseEntity>(
+        { EntityName: entityName, ExtraFilter: filter, ResultType: 'entity_object' }, contextUser);
+    if (!res?.Success) return [];
+    return (res.Results ?? []).map(r => proxyRow<T>(r, entityName, guard, aliases));
+}
+
+/** The catalog shared by every connection of a connector. Today's behaviour, unchanged. */
+export class SharedCatalogWriter implements CatalogWriter {
+    public readonly Source = 'Shared' as const;
+    private static readonly OBJECTS = 'MJ: Integration Objects';
+    private static readonly FIELDS = 'MJ: Integration Object Fields';
+
+    constructor(
+        private readonly md: IMetadataProvider,
+        private readonly integrationID: string,
+        private readonly contextUser: UserInfo
+    ) {}
+
+    public ObjectsInScope(): Promise<MJIntegrationObjectEntity[]> {
+        return viewRows(SharedCatalogWriter.OBJECTS, `IntegrationID = '${lit(this.integrationID)}'`,
+                        this.contextUser, this.md, null, null);
+    }
+
+    public FieldsForObject(objectID: string): Promise<MJIntegrationObjectFieldEntity[]> {
+        return viewRows(SharedCatalogWriter.FIELDS, `IntegrationObjectID = '${lit(objectID)}'`,
+                        this.contextUser, this.md, null, null);
+    }
+
+    public NewObjectRow(): Promise<MJIntegrationObjectEntity> {
+        return newRow(this.md, SharedCatalogWriter.OBJECTS, this.contextUser, null, null);
+    }
+
+    public NewFieldRow(): Promise<MJIntegrationObjectFieldEntity> {
+        return newRow(this.md, SharedCatalogWriter.FIELDS, this.contextUser, null, null);
+    }
+
+    public LoadObject(id: string): Promise<MJIntegrationObjectEntity | null> {
+        return loadRow(this.md, SharedCatalogWriter.OBJECTS, this.contextUser, id, null, null);
+    }
+
+    public LoadField(id: string): Promise<MJIntegrationObjectFieldEntity | null> {
+        return loadRow(this.md, SharedCatalogWriter.FIELDS, this.contextUser, id, null, null);
+    }
+
+    /** The shared catalog records ownership as the integration id and nothing else. */
+    public StampNewObject(row: MJIntegrationObjectEntity): void {
+        row.IntegrationID = this.integrationID;
+    }
+
+    public StampNewField(): void {
+        /* the parent object id is the only ownership a shared field row carries */
+    }
+
+    public MarkSeen(): void {
+        /* the shared catalog has no seen timestamps */
+    }
+}
+
+/** One connection's own catalog. */
+export class PerConnectionCatalogWriter implements CatalogWriter {
+    public readonly Source = 'PerConnection' as const;
+
+    constructor(
+        private readonly md: IMetadataProvider,
+        private readonly companyIntegrationID: string,
+        private readonly integrationID: string,
+        private readonly contextUser: UserInfo,
+        /** Stamped on every row this run touches, so "when did we last see this" is answerable. */
+        private readonly seenAt: Date
+    ) {}
+
+    public ObjectsInScope(): Promise<MJIntegrationObjectEntity[]> {
+        return viewRows(ENTITY_COMPANY_INTEGRATION_OBJECTS,
+                        `CompanyIntegrationID = '${lit(this.companyIntegrationID)}'`,
+                        this.contextUser, this.md, CATALOG_OBJECT_COLUMNS, null);
+    }
+
+    public FieldsForObject(objectID: string): Promise<MJIntegrationObjectFieldEntity[]> {
+        return viewRows(ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
+                        `CompanyIntegrationObjectID = '${lit(objectID)}'`,
+                        this.contextUser, this.md, CATALOG_FIELD_COLUMNS, FIELD_WRITE_ALIASES);
+    }
+
+    public NewObjectRow(): Promise<MJIntegrationObjectEntity> {
+        return newRow(this.md, ENTITY_COMPANY_INTEGRATION_OBJECTS, this.contextUser,
+                      CATALOG_OBJECT_COLUMNS, null);
+    }
+
+    public NewFieldRow(): Promise<MJIntegrationObjectFieldEntity> {
+        return newRow(this.md, ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS, this.contextUser,
+                      CATALOG_FIELD_COLUMNS, FIELD_WRITE_ALIASES);
+    }
+
+    public LoadObject(id: string): Promise<MJIntegrationObjectEntity | null> {
+        return loadRow(this.md, ENTITY_COMPANY_INTEGRATION_OBJECTS, this.contextUser, id,
+                       CATALOG_OBJECT_COLUMNS, null);
+    }
+
+    public LoadField(id: string): Promise<MJIntegrationObjectFieldEntity | null> {
+        return loadRow(this.md, ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS, this.contextUser, id,
+                       CATALOG_FIELD_COLUMNS, FIELD_WRITE_ALIASES);
+    }
+
+    /**
+     * A new per-connection object records the connection it belongs to, the declared row it was
+     * matched to (null when the object exists only for this connection — the case the shared
+     * catalog cannot represent at all), where its shape came from, and when it was first seen.
+     *
+     * `IsSelected` starts FALSE. Catalog membership is not sync selection, and keeping them apart
+     * is the point of the table: conflating them is why a newly-discovered object arriving disabled
+     * disappeared from schema introspection, key inference and migration, with no error anywhere.
+     */
+    public StampNewObject(row: MJIntegrationObjectEntity, declaredObjectID: string | null, provenance: CatalogProvenance): void {
+        const w = row as unknown as Record<string, unknown>;
+        w.CompanyIntegrationID = this.companyIntegrationID;
+        w.IntegrationID = this.integrationID;
+        w.IntegrationObjectID = declaredObjectID;
+        w.Provenance = provenance;
+        w.IsSelected = false;
+        w.FirstSeenAt = this.seenAt;
+        w.LastSeenAt = this.seenAt;
+    }
+
+    public StampNewField(row: MJIntegrationObjectFieldEntity, declaredFieldID: string | null, provenance: CatalogProvenance): void {
+        // Written through the raw column name: on the FIELD entity `IntegrationObjectFieldID` is a
+        // real provenance column, not one of the aliases above.
+        const w = row as unknown as Record<string, unknown>;
+        w.IntegrationObjectFieldID = declaredFieldID;
+        w.Provenance = provenance;
+        w.IsSelected = false;
+        w.FirstSeenAt = this.seenAt;
+        w.LastSeenAt = this.seenAt;
+    }
+
+    public MarkSeen(row: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity, sampled: boolean): void {
+        const w = row as unknown as Record<string, unknown>;
+        w.LastSeenAt = this.seenAt;
+        if (sampled) w.LastSampledAt = this.seenAt;
+    }
+}

--- a/packages/Integration/engine/src/CatalogWriter.ts
+++ b/packages/Integration/engine/src/CatalogWriter.ts
@@ -222,6 +222,34 @@ async function viewRows<T>(
 }
 
 /** The catalog shared by every connection of a connector. Today's behaviour, unchanged. */
+/**
+ * `MJ_INTEGRATION_CATALOG_STRICT=1` makes the DECLARED catalog read-only at runtime.
+ *
+ * `MJ: Integration Object(Field)s` are the connector's shipped metadata, and they are not merely
+ * reference data: `PerConnectionCatalogWriter.RebaseFromDeclared` copies their columns onto every
+ * per-connection row on every discovery, so they are the FLOOR every connection is rebuilt from.
+ * A single connection left on the shared catalog writes its own sampled shape into that floor, and
+ * every later connection of the same connector then inherits one account's widths and columns as
+ * though the vendor had declared them.
+ *
+ * Observed on the sandbox, 2026-09-11: one discovery on a `Shared` connection added 69 sampled
+ * columns and overwrote 4 columns on 487 declared fields. The run reported success and nothing
+ * anywhere recorded that the declared catalog had changed — it was only provable because a
+ * snapshot had been taken beforehand.
+ *
+ * Deliberately OFF by default and enabled per environment: a connection legitimately on the shared
+ * catalog (one that predates the per-connection tables and has not been backfilled) writes here by
+ * design, and would start failing. Turn it on where every connection is already per-connection —
+ * the sandbox — so a regression is a loud failure rather than silent corruption. Reads are
+ * untouched; only the row-producing calls throw, so the declared floor stays readable.
+ */
+const STRICT_ENV = 'MJ_INTEGRATION_CATALOG_STRICT';
+
+function strictDeclaredCatalog(): boolean {
+    const v = process.env[STRICT_ENV];
+    return v === '1' || (typeof v === 'string' && v.trim().toLowerCase() === 'true');
+}
+
 export class SharedCatalogWriter implements CatalogWriter {
     public readonly Source = 'Shared' as const;
     private static readonly OBJECTS = 'MJ: Integration Objects';
@@ -243,19 +271,42 @@ export class SharedCatalogWriter implements CatalogWriter {
                         this.contextUser, this.md, null, null);
     }
 
+    /**
+     * The four calls below exist to hand the caller a row it is about to mutate and Save, so they
+     * are the write boundary — guarding them, rather than the reads above, keeps the declared floor
+     * readable while making a runtime write to it impossible. See `strictDeclaredCatalog`.
+     */
+    private refuseIfStrict(what: string): void {
+        if (!strictDeclaredCatalog()) return;
+        throw new Error(
+            `DECLARED_CATALOG_READONLY: refusing to ${what} in the shared/declared catalog for `
+            + `integration ${this.integrationID}. ${STRICT_ENV} is set, which makes `
+            + `"MJ: Integration Object(Field)s" read-only at runtime — they hold the connector's `
+            + `DECLARED metadata, and every per-connection catalog is rebased from them, so a `
+            + `discovery writing here would put one account's shape into every other connection of `
+            + `this connector. Set this connection's Configuration.catalogSource to "perConnection" `
+            + `(MJ Central stamps that at create), or unset ${STRICT_ENV} if this environment still `
+            + `has connections that legitimately use the shared catalog.`
+        );
+    }
+
     public NewObjectRow(): Promise<MJIntegrationObjectEntity> {
+        this.refuseIfStrict('create an object');
         return newRow(this.md, SharedCatalogWriter.OBJECTS, this.contextUser, null, null);
     }
 
     public NewFieldRow(): Promise<MJIntegrationObjectFieldEntity> {
+        this.refuseIfStrict('create a field');
         return newRow(this.md, SharedCatalogWriter.FIELDS, this.contextUser, null, null);
     }
 
     public LoadObject(id: string): Promise<MJIntegrationObjectEntity | null> {
+        this.refuseIfStrict('modify an object');
         return loadRow(this.md, SharedCatalogWriter.OBJECTS, this.contextUser, id, null, null);
     }
 
     public LoadField(id: string): Promise<MJIntegrationObjectFieldEntity | null> {
+        this.refuseIfStrict('modify a field');
         return loadRow(this.md, SharedCatalogWriter.FIELDS, this.contextUser, id, null, null);
     }
 

--- a/packages/Integration/engine/src/CatalogWriter.ts
+++ b/packages/Integration/engine/src/CatalogWriter.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, CompositeKey, DatabaseProviderBase, IMetadataProvider, RunView, UserInfo } from '@memberjunction/core';
+import { BaseEntity, CompositeKey, DatabaseProviderBase, IMetadataProvider, LogError, RunView, UserInfo } from '@memberjunction/core';
 import type { MJIntegrationObjectEntity, MJIntegrationObjectFieldEntity } from '@memberjunction/core-entities';
 import {
     CATALOG_FIELD_COLUMNS,
@@ -142,6 +142,23 @@ export interface CatalogWriter {
 
     /** Record that this row was seen — and optionally sampled — by the discovery now running. */
     MarkSeen(row: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity, sampled: boolean): void;
+
+    /**
+     * Retire an object/field that an AUTHORITATIVE discovery no longer returns.
+     *
+     * The two catalogs differ here on purpose, which is why this is a writer method and not an
+     * `if` at the call site:
+     *   - SHARED rows are DISABLED, never deleted. They are the declared metadata every other
+     *     connection of the connector still reads, and a missing row there is unrecoverable.
+     *   - PER-CONNECTION rows are DELETED. plan.md: "Removed tables are more than deselected,
+     *     they just dont exist, its likely a cascade delete." Nothing else owns them, and leaving
+     *     tombstones would make the connection's catalog drift from its source forever.
+     *
+     * Returns whether the row is gone (`deleted`) so the caller can report honestly; the mirror
+     * TABLE and its data are never touched either way.
+     */
+    RetireObject(row: MJIntegrationObjectEntity): Promise<{ ok: boolean; deleted: boolean }>;
+    RetireField(row: MJIntegrationObjectFieldEntity): Promise<{ ok: boolean; deleted: boolean }>;
 }
 
 /**
@@ -236,6 +253,17 @@ export class SharedCatalogWriter implements CatalogWriter {
         /* the parent object id is the only ownership a shared field row carries */
     }
 
+    /** Shared rows are the declared floor for every other connection — disable, never delete. */
+    public async RetireObject(row: MJIntegrationObjectEntity): Promise<{ ok: boolean; deleted: boolean }> {
+        row.Status = 'Disabled';
+        return { ok: await row.Save(), deleted: false };
+    }
+
+    public async RetireField(row: MJIntegrationObjectFieldEntity): Promise<{ ok: boolean; deleted: boolean }> {
+        row.Status = 'Disabled';
+        return { ok: await row.Save(), deleted: false };
+    }
+
     public MarkSeen(): void {
         /* the shared catalog has no seen timestamps */
     }
@@ -315,6 +343,44 @@ export class PerConnectionCatalogWriter implements CatalogWriter {
         w.IsSelected = false;
         w.FirstSeenAt = this.seenAt;
         w.LastSeenAt = this.seenAt;
+    }
+
+    /**
+     * Delete, not disable — see the interface comment.
+     *
+     * Order matters and there is no ON DELETE CASCADE in the migration (deletes are deliberately
+     * explicit, so nothing disappears as a side effect of an unrelated write):
+     *   1. NULL out inbound dependency edges. `RelatedCompanyIntegrationObjectID` is self-
+     *      referencing, so another object's field may point at this one; deleting underneath it
+     *      would violate that FK and abort the whole persist. Nulling drops the edge and keeps the
+     *      referencing field alive, which is right — the field still exists in the source, only
+     *      the thing it pointed at is gone.
+     *   2. Delete this object's own fields (the FK child rows).
+     *   3. Delete the object.
+     */
+    public async RetireObject(row: MJIntegrationObjectEntity): Promise<{ ok: boolean; deleted: boolean }> {
+        const inbound = await viewRows<MJIntegrationObjectFieldEntity>(
+            ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
+            `RelatedCompanyIntegrationObjectID = '${lit(row.ID)}'`,
+            this.contextUser, this.md, CATALOG_FIELD_COLUMNS, FIELD_WRITE_ALIASES);
+        for (const edge of inbound) {
+            (edge as unknown as Record<string, unknown>).RelatedCompanyIntegrationObjectID = null;
+            if (!(await edge.Save())) {
+                LogError(`[CatalogWriter] Could not clear dependency edge ${edge.ID} -> ${row.ID}; not deleting the object.`);
+                return { ok: false, deleted: false };
+            }
+        }
+        for (const child of await this.FieldsForObject(row.ID)) {
+            if (!(await child.Delete())) {
+                LogError(`[CatalogWriter] Could not delete field ${child.ID} of ${row.ID}; not deleting the object.`);
+                return { ok: false, deleted: false };
+            }
+        }
+        return { ok: await row.Delete(), deleted: true };
+    }
+
+    public async RetireField(row: MJIntegrationObjectFieldEntity): Promise<{ ok: boolean; deleted: boolean }> {
+        return { ok: await row.Delete(), deleted: true };
     }
 
     public MarkSeen(row: MJIntegrationObjectEntity | MJIntegrationObjectFieldEntity, sampled: boolean): void {

--- a/packages/Integration/engine/src/CompanyIntegrationCatalogStore.ts
+++ b/packages/Integration/engine/src/CompanyIntegrationCatalogStore.ts
@@ -1,0 +1,245 @@
+import { BaseEntity, CompositeKey, Metadata, RunView, UserInfo } from '@memberjunction/core';
+import {
+    CATALOG_FIELD_COLUMNS,
+    CATALOG_OBJECT_COLUMNS,
+    CompanyIntegrationCatalogSchemaMismatch,
+    ENTITY_COMPANY_INTEGRATION_OBJECTS,
+    ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
+} from '@memberjunction/integration-engine-base';
+
+/**
+ * The ONLY write path to the per-connection catalog.
+ *
+ * These two entities have no generated subclass — deliberately, because generating one means
+ * patching a file with thousands of classes in it, and the patch would have to be regenerated on
+ * every upstream release. The consequence is a trap with no natural symptom:
+ *
+ *     const row = await md.GetEntityObject('MJ: Company Integration Objects', user);
+ *     row.Name = 'Contacts';        // creates an own property on a plain object
+ *     await row.Save();             // succeeds, writes nothing, reports success
+ *
+ * There is no accessor to intercept the assignment, so the value lands beside the entity's field
+ * list instead of in it, the row saves clean, and the column keeps whatever it had. Nothing throws
+ * and nothing logs. In a discovery that persists hundreds of rows this reads as a source that
+ * returned less than expected.
+ *
+ * So this wrapper exists, and every write in the engine goes through it. `Set` refuses a column
+ * name the entity does not have, which turns that silent no-op into an immediate, named error.
+ */
+
+type CatalogEntityName =
+    | typeof ENTITY_COMPANY_INTEGRATION_OBJECTS
+    | typeof ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS;
+
+/** Entities whose column set has already been checked, so the check costs one pass per process. */
+const verified = new Set<string>();
+
+function requiredColumnsFor(entityName: CatalogEntityName): readonly string[] {
+    return entityName === ENTITY_COMPANY_INTEGRATION_OBJECTS
+        ? CATALOG_OBJECT_COLUMNS
+        : CATALOG_FIELD_COLUMNS;
+}
+
+/**
+ * Assert the loaded entity carries every column the engine writes.
+ *
+ * Checked against a real row rather than against metadata alone, because a row is what `Set` will
+ * be called on. Runs once per entity per process: the alternative is a migration-shaped failure
+ * appearing as scattered missing values hours later, in a run that reported success.
+ *
+ * The virtual view aliases are excluded — they exist on the row but are not writable, and
+ * `AssertWritable` below is what keeps a write off them.
+ */
+function assertShape(entityName: CatalogEntityName, row: BaseEntity): void {
+    if (verified.has(entityName)) return;
+    const present = new Set((row.Fields ?? []).map(f => f.Name));
+    const missing = requiredColumnsFor(entityName).filter(c => !present.has(c));
+    if (missing.length > 0) throw new CompanyIntegrationCatalogSchemaMismatch(entityName, missing);
+    verified.add(entityName);
+}
+
+/**
+ * Columns the view exposes as aliases of a real column. Writing one would be accepted by the row
+ * and dropped by the CRUD procedure, which has no parameter for it — the same silent loss this
+ * class exists to prevent, one layer down.
+ */
+const VIRTUAL_COLUMNS = new Set([
+    'IntegrationObjectID',
+    'RelatedIntegrationObjectID',
+    'RelatedIntegrationObject',
+    'Integration',
+    'IntegrationObject',
+]);
+
+/**
+ * A per-connection catalog row, writable only through `Set`.
+ *
+ * Note `IntegrationObjectID` is virtual on the FIELD entity (a view alias) and REAL on the OBJECT
+ * entity (the provenance foreign key). `Set` resolves that from the row's own field list rather
+ * than from the name, so the object's provenance link stays writable and the field's alias does
+ * not.
+ */
+export class CatalogRow {
+    private constructor(
+        private readonly entityName: CatalogEntityName,
+        private readonly row: BaseEntity
+    ) {}
+
+    /** @internal */
+    public static wrap(entityName: CatalogEntityName, row: BaseEntity): CatalogRow {
+        assertShape(entityName, row);
+        return new CatalogRow(entityName, row);
+    }
+
+    public get ID(): string {
+        return this.row.Get('ID') as string;
+    }
+
+    /** The underlying row, for a caller that needs to enlist it in a transaction group. */
+    public get Entity(): BaseEntity {
+        return this.row;
+    }
+
+    public Get<T = unknown>(column: string): T {
+        return this.row.Get(column) as T;
+    }
+
+    /**
+     * Write one column.
+     *
+     * Throws on a column the entity does not have and on a view alias, because both would otherwise
+     * be accepted and discarded. That is the whole point of this class: the failure is loud, at the
+     * assignment, naming the column.
+     */
+    public Set(column: string, value: unknown): this {
+        const field = (this.row.Fields ?? []).find(f => f.Name === column);
+        if (!field) {
+            throw new Error(
+                `${this.entityName} has no column '${column}'. Assigning it would create a property `
+                + `beside the entity's field list, and the row would save clean while writing nothing.`
+            );
+        }
+        if (VIRTUAL_COLUMNS.has(column) && field.EntityFieldInfo?.IsVirtual === true) {
+            throw new Error(
+                `${this.entityName}.${column} is a view alias, not a stored column. The CRUD `
+                + `procedure has no parameter for it, so this write would be silently dropped. `
+                + `Write the real column instead.`
+            );
+        }
+        this.row.Set(column, value);
+        return this;
+    }
+
+    /** Set several columns. Skips `undefined` so a caller can pass a sparse patch. */
+    public SetMany(values: Record<string, unknown>): this {
+        for (const [k, v] of Object.entries(values)) if (v !== undefined) this.Set(k, v);
+        return this;
+    }
+
+    public async Save(): Promise<boolean> {
+        return await this.row.Save();
+    }
+
+    public async Delete(): Promise<boolean> {
+        return await this.row.Delete();
+    }
+
+    /** The row's own error text after a failed Save, for logging. */
+    public get LastError(): string {
+        return this.row.LatestResult?.Message ?? '';
+    }
+}
+
+/** Reads and writes for the per-connection catalog. */
+export class CompanyIntegrationCatalogStore {
+    constructor(private readonly contextUser: UserInfo) {}
+
+    private async newRow(entityName: CatalogEntityName): Promise<CatalogRow> {
+        const md = new Metadata();
+        const row = await md.GetEntityObject<BaseEntity>(entityName, this.contextUser);
+        if (!row) {
+            throw new CompanyIntegrationCatalogSchemaMismatch(entityName, ['<entity not registered>']);
+        }
+        row.NewRecord();
+        return CatalogRow.wrap(entityName, row);
+    }
+
+    public NewObject(): Promise<CatalogRow> {
+        return this.newRow(ENTITY_COMPANY_INTEGRATION_OBJECTS);
+    }
+
+    public NewField(): Promise<CatalogRow> {
+        return this.newRow(ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS);
+    }
+
+    private async loadRow(entityName: CatalogEntityName, id: string): Promise<CatalogRow | null> {
+        const md = new Metadata();
+        const row = await md.GetEntityObject<BaseEntity>(entityName, this.contextUser);
+        if (!row) return null;
+        // `Load(id)` is a GENERATED-subclass convenience. These entities have none, so the entry
+        // point is the base one — the same call the existing shared-catalog code makes.
+        const loaded = await row.InnerLoad(CompositeKey.FromID(id));
+        return loaded ? CatalogRow.wrap(entityName, row) : null;
+    }
+
+    public LoadObject(id: string): Promise<CatalogRow | null> {
+        return this.loadRow(ENTITY_COMPANY_INTEGRATION_OBJECTS, id);
+    }
+
+    public LoadField(id: string): Promise<CatalogRow | null> {
+        return this.loadRow(ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS, id);
+    }
+
+    /**
+     * Read straight from the database rather than the engine cache.
+     *
+     * Used by the write path, which must see rows another pass of the same run just persisted. The
+     * engine cache is refreshed between passes, not within one.
+     */
+    private async runView(entityName: CatalogEntityName, filter: string): Promise<BaseEntity[]> {
+        const rv = new RunView();
+        const result = await rv.RunView<BaseEntity>(
+            { EntityName: entityName, ExtraFilter: filter, ResultType: 'entity_object' },
+            this.contextUser
+        );
+        return result?.Success ? (result.Results ?? []) : [];
+    }
+
+    /**
+     * Every object row for a connection, INCLUDING disabled ones.
+     *
+     * Disabled rows are load-bearing here: the overlay reactivates an object that reappeared rather
+     * than inserting a second one, and the unique constraint on (connection, name) means matching
+     * active rows only would turn a reappearance into a constraint violation.
+     */
+    public async ObjectsForConnection(companyIntegrationID: string): Promise<CatalogRow[]> {
+        const rows = await this.runView(
+            ENTITY_COMPANY_INTEGRATION_OBJECTS,
+            `CompanyIntegrationID = '${companyIntegrationID}'`
+        );
+        return rows.map(r => CatalogRow.wrap(ENTITY_COMPANY_INTEGRATION_OBJECTS, r));
+    }
+
+    /** Every field row for one object, including disabled ones, for the same reason. */
+    public async FieldsForObject(companyIntegrationObjectID: string): Promise<CatalogRow[]> {
+        const rows = await this.runView(
+            ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS,
+            `CompanyIntegrationObjectID = '${companyIntegrationObjectID}'`
+        );
+        return rows.map(r => CatalogRow.wrap(ENTITY_COMPANY_INTEGRATION_OBJECT_FIELDS, r));
+    }
+
+    /** Whether this connection has a per-connection catalog at all. Cheap existence check. */
+    public async HasCatalog(companyIntegrationID: string): Promise<boolean> {
+        const rv = new RunView();
+        const result = await rv.RunView(
+            {
+                EntityName: ENTITY_COMPANY_INTEGRATION_OBJECTS,
+                ExtraFilter: `CompanyIntegrationID = '${companyIntegrationID}'`,
+                ResultType: 'count_only',
+            },
+            this.contextUser
+        );
+        return (result?.TotalRowCount ?? 0) > 0;
+    }
+}

--- a/packages/Integration/engine/src/IntegrationActionGenerator.ts
+++ b/packages/Integration/engine/src/IntegrationActionGenerator.ts
@@ -20,6 +20,7 @@
  */
 
 import { IMetadataProvider, Metadata, RunView, UserInfo, LogError } from '@memberjunction/core';
+import { RunOutsideCatalogScope } from './CatalogScope.js';
 import type {
     MJActionEntity,
     MJActionParamEntity,
@@ -91,6 +92,8 @@ export class IntegrationActionGenerator {
         contextUser: UserInfo,
         provider?: IMetadataProvider,
     ): Promise<GenerateIntegrationActionResult> {
+        // An Action describes the vendor's API, not one connection's projection of it.
+        return RunOutsideCatalogScope(async () => {
         const md = this.resolveProvider(provider);
         try {
             const objectInfo = await this.loadObjectInfo(md, integrationName, objectName, contextUser);
@@ -111,6 +114,7 @@ export class IntegrationActionGenerator {
             const msg = err instanceof Error ? err.message : String(err);
             return this.failure(verb, objectName, `Unexpected error: ${msg}`);
         }
+        });
     }
 
     /**
@@ -123,6 +127,8 @@ export class IntegrationActionGenerator {
         contextUser: UserInfo,
         provider?: IMetadataProvider,
     ): Promise<GenerateIntegrationActionResult[]> {
+        // An Action describes the vendor's API, not one connection's projection of it.
+        return RunOutsideCatalogScope(async () => {
         const md = this.resolveProvider(provider);
         const objectInfo = await this.loadObjectInfo(md, integrationName, objectName, contextUser);
         if (!objectInfo) {
@@ -136,6 +142,7 @@ export class IntegrationActionGenerator {
             results.push(await this.GenerateAction(integrationName, objectName, verb, contextUser, provider));
         }
         return results;
+        });
     }
 
     // ─── Provider ────────────────────────────────────────────────────

--- a/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
+++ b/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
@@ -15,6 +15,7 @@ import {
 } from '@memberjunction/integration-pk-classifier';
 import { BaseIntegrationConnector, type ExternalObjectSchema, type ExternalFieldSchema } from './BaseIntegrationConnector.js';
 import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
+import { BuildCatalogWriter, ResolveCatalogSource } from './CatalogSource.js';
 import { IntegrationSchemaSync, type PersistSchemaResult } from './IntegrationSchemaSync.js';
 import type { IntrospectSchemaOptions, SourceObjectInfo } from './types.js';
 import { MergeDeclaredWithSample } from './DeclaredSampleMerge.js';
@@ -762,6 +763,11 @@ export class IntegrationConnectorCreationPipeline {
         const startMs = Date.now();
         const persistResult = await IntegrationSchemaSync.PersistDiscoveredSchema({
             IntegrationID: opts.CompanyIntegration.IntegrationID,
+            // The connection this discovery belongs to, and which catalog it writes into. Resolved
+            // in ONE place (CatalogSource.ts) so the read side and the write side of the same run
+            // can never disagree about which catalog they are on.
+            CompanyIntegrationID: opts.CompanyIntegration.ID,
+            CatalogSource: ResolveCatalogSource(opts.CompanyIntegration),
             SourceSchema: sourceSchema,
             ContextUser: opts.ContextUser,
             Provider: opts.Provider,
@@ -824,14 +830,18 @@ export class IntegrationConnectorCreationPipeline {
         const engine = IntegrationEngineBase.Instance;
         // Refresh from DB so we see what Persist just wrote
         await engine.Config(true, opts.ContextUser, md);
-        const objects = engine.GetIntegrationObjectsByIntegrationID(opts.CompanyIntegration.IntegrationID);
+        // Read through the writer rather than the cache. On the per-connection catalog the cached
+        // rows are read-only projections with no Save(), so the classifier's one write — promoting
+        // its nominee to primary key — would have had nothing to write to.
+        const writer = BuildCatalogWriter(md, opts.CompanyIntegration, opts.ContextUser);
+        const objects = (await writer.ObjectsInScope()).filter(o => o.Status === 'Active');
 
         const classifier = new SoftPKClassifier();
         const verdicts: ConnectorCreationPipelineResult['PKVerdicts'] = [];
         const unresolved: string[] = [];
 
         for (const obj of objects) {
-            const fields = engine.GetIntegrationObjectFields(obj.ID);
+            const fields = await writer.FieldsForObject(obj.ID);
             const hasPK = fields.some(f => f.IsPrimaryKey);
             if (hasPK) {
                 emitter.entityGenerated(obj.Name, obj.Name);

--- a/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
+++ b/packages/Integration/engine/src/IntegrationConnectorCreationPipeline.ts
@@ -16,6 +16,7 @@ import {
 import { BaseIntegrationConnector, type ExternalObjectSchema, type ExternalFieldSchema } from './BaseIntegrationConnector.js';
 import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
 import { BuildCatalogWriter, ResolveCatalogSource } from './CatalogSource.js';
+import { WithCatalogScope } from './CatalogScope.js';
 import { IntegrationSchemaSync, type PersistSchemaResult } from './IntegrationSchemaSync.js';
 import type { IntrospectSchemaOptions, SourceObjectInfo } from './types.js';
 import { MergeDeclaredWithSample } from './DeclaredSampleMerge.js';
@@ -194,7 +195,19 @@ export class IntegrationConnectorCreationPipeline {
      * a `RunID` and coalescing served a different run, we publish a terminal ALIAS run under the
      * requested ID pointing at the run that actually did the work. See {@link honourRequestedRunID}.
      */
+    /**
+     * Every read a discovery makes — the connector's GetCachedObject/GetCachedFields during
+     * sampling, the dependency graph, the excluded-field resolution — happens with THIS connection
+     * in catalog scope. Scope-aware getters answer from the connection's own rows once it has any
+     * and fall back to the shared declared rows until then, so a first discovery still sees the
+     * connector's declared floor and a re-discovery sees what this connection found last time,
+     * not what some other connection of the same connector found.
+     */
     public async Run(opts: ConnectorCreationPipelineOptions): Promise<ConnectorCreationPipelineResult> {
+        return WithCatalogScope(opts.CompanyIntegration?.ID ?? '', () => this.runWithDedup(opts));
+    }
+
+    private async runWithDedup(opts: ConnectorCreationPipelineOptions): Promise<ConnectorCreationPipelineResult> {
         const ciID = opts.CompanyIntegration?.ID;
         if (!ciID) return this.runInternal(opts); // no key to de-dup on — run directly
 

--- a/packages/Integration/engine/src/IntegrationEngine.ts
+++ b/packages/Integration/engine/src/IntegrationEngine.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { RunInCatalogScope } from './CatalogScope.js';
 import { CompositeKey, DatabaseProviderBase, IMetadataProvider, LogError, LogStatusEx, Metadata, RunView, type UserInfo, TransactionGroupBase, BaseEntity, EntitySaveOptions, EntityDeleteOptions } from '@memberjunction/core';
 import { RunOwnershipLostError, RunOwnershipService, type TerminalRunStatus } from './RunOwnershipService.js';
 import { BaseSingleton, UUIDsEqual } from '@memberjunction/global';
@@ -944,6 +945,8 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         rv: RunView,
         contextUser: UserInfo
     ): Promise<void> {
+        // A resumed run reads the same catalog the original did — its own connection's.
+        return RunInCatalogScope(run.CompanyIntegrationID, async () => {
         const companyIntegrationID = run.CompanyIntegrationID;
         const runID = run.ID;
         const lockKey = companyIntegrationID.toLowerCase();
@@ -1118,6 +1121,7 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
                 RecordsSkipped: 0, Errors: [], EntityMapResults: [], Duration: 0,
             });
         }
+        });
     }
 
     /**
@@ -1141,7 +1145,11 @@ export class IntegrationEngine extends BaseSingleton<IntegrationEngine> {
         options?: IntegrationSyncOptions,
         provider?: IMetadataProvider
     ): Promise<SyncResult> {
-        return this.runWithOwnedContext(companyIntegrationID, contextUser, triggerType, onProgress, onNotification, options, provider);
+        // The connection's catalog is in scope for the WHOLE run: the DAG, the excluded-field
+        // resolution and every connector-side GetCachedObject resolve to this connection's own
+        // rows once it has them, and to the shared declared rows until it does.
+        return RunInCatalogScope(companyIntegrationID, () =>
+            this.runWithOwnedContext(companyIntegrationID, contextUser, triggerType, onProgress, onNotification, options, provider));
     }
 
     /**

--- a/packages/Integration/engine/src/IntegrationSchemaSync.ts
+++ b/packages/Integration/engine/src/IntegrationSchemaSync.ts
@@ -513,12 +513,14 @@ export class IntegrationSchemaSync {
     // The declared floor a discovery overlays is still looked up by CONNECTOR: a per-connection
     // object records which declared row it was matched to, and that link is what makes
     // "whose definition is this" answerable later.
-    const declaredByName = new Map<string, string>();
+    const declaredByName = new Map<string, MJIntegrationObjectEntity>();
     // Explicitly the SHARED rows. That getter is scope-aware now, and inside a per-connection run
     // it would hand back this connection's own rows — so the discovery would overlay its own
     // previous output and the provenance link back to the declared definition would be lost.
     for (const declared of engine.GetSharedIntegrationObjects(IntegrationID)) {
-      if (declared.ID) declaredByName.set(declared.Name.toLowerCase(), declared.ID);
+      // The ROW, not just its id: a refresh rebases the connection's declared-owned columns from
+      // it, so an open-app upgrade reaches connections that already discovered once.
+      if (declared.ID) declaredByName.set(declared.Name.toLowerCase(), declared);
     }
 
     // Phase 1: upsert objects. Object upserts must complete before field upserts
@@ -565,7 +567,7 @@ export class IntegrationSchemaSync {
         // engine cache because the DECLARED catalog is shared and unchanged by this run — only the
         // per-connection copy is being written. Empty for an object with no declared counterpart,
         // which is the ordinary case for something discovery found on its own.
-        const declaredObjectID = declaredByName.get(r.srcObj.ExternalName.toLowerCase());
+        const declaredObjectID = declaredByName.get(r.srcObj.ExternalName.toLowerCase())?.ID;
         const declaredFieldByName = new Map<string, string>();
         if (declaredObjectID) {
           for (const df of engine.GetIntegrationObjectFields(declaredObjectID)) {
@@ -746,7 +748,7 @@ export class IntegrationSchemaSync {
     srcObj: SourceObjectInfo,
     existingObjects: MJIntegrationObjectEntity[],
     /** The declared row this object was matched to, or null when it exists only here. */
-    declaredObjectID: string | null,
+    declaredObject: MJIntegrationObjectEntity | null,
     /** Whether the connector claims its object enumeration is complete. Decides provenance. */
     discoveryIsAuthoritative: boolean,
   ): Promise<{ ObjectID: string | null; Created: boolean; Updated: boolean; EffectiveSource: 'Declared' | 'Discovered' | 'Custom' }> {
@@ -762,6 +764,16 @@ export class IntegrationSchemaSync {
       // never overwritten; the spec inverts that precedence.)
       let dirty = false;
       const changes: string[] = [];
+      // plan.md: a refresh uses the DECLARATION as the source of truth and replaces what is in the
+      // per-connection row, rather than overlaying discovery onto that row's own previous output.
+      // Otherwise an open-app upgrade that changes a declared APIPath, page size or CRUD path never
+      // reaches a connection that has already discovered once. No-op for the shared catalog, where
+      // the row IS the declaration.
+      const rebased = writer.RebaseFromDeclared(existing, declaredObject, 'object');
+      if (rebased.length > 0) {
+        dirty = true;
+        changes.push(`rebased:${rebased.join('/')}`);
+      }
       const descOverlay = decideSemanticOverlay(existing.Description, srcObj.Description);
       if (descOverlay.changed) {
         existing.Description = descOverlay.value ?? null;
@@ -848,8 +860,8 @@ export class IntegrationSchemaSync {
       // curated definition matched it, 'Endpoint' when the connector's own enumeration claimed to
       // be complete, and 'Sampled' otherwise. The per-attribute truth lives in the merge log, not
       // in this single column.
-      writer.StampNewObject(obj, declaredObjectID,
-        declaredObjectID ? 'Declared' : (discoveryIsAuthoritative ? 'Endpoint' : 'Sampled'));
+      writer.StampNewObject(obj, declaredObject?.ID ?? null,
+        declaredObject ? 'Declared' : (discoveryIsAuthoritative ? 'Endpoint' : 'Sampled'));
       obj.Name = srcObj.ExternalName;
       // APIPath is NOT NULL with no DB default. Declared objects get it from the metadata file;
       // a runtime-DISCOVERED object has no source APIPath (ExternalObjectSchema carries none),

--- a/packages/Integration/engine/src/IntegrationSchemaSync.ts
+++ b/packages/Integration/engine/src/IntegrationSchemaSync.ts
@@ -664,33 +664,44 @@ export class IntegrationSchemaSync {
         ObjectIDByName: objectIDByName,
       });
       let deactivated = 0;
+      let removed = 0;
       for (const id of decision.ObjectIDsToDeactivate) {
         const obj = await writer.LoadObject(id);
         if (obj) {
-          obj.Status = 'Disabled'; // deactivate (Active|Deprecated|Disabled enum); never delete
-          if (await obj.Save()) { deactivated++; result.ObjectsDeactivated.push(obj.Name); }
-          else LogError(`[IntegrationSchemaSync] Failed to deactivate phantom object ${id}: ${obj.LatestResult?.CompleteMessage ?? 'unknown'}`);
+          // The WRITER decides disable-vs-delete: shared rows are the declared floor other
+          // connections read and are only disabled; a per-connection row is deleted outright,
+          // per plan.md ("Removed tables ... they just dont exist, its likely a cascade delete").
+          const name = obj.Name;
+          const outcome = await writer.RetireObject(obj);
+          if (outcome.ok) {
+            if (outcome.deleted) removed++; else deactivated++;
+            result.ObjectsDeactivated.push(name);
+          } else {
+            LogError(`[IntegrationSchemaSync] Failed to retire phantom object ${id}: ${obj.LatestResult?.CompleteMessage ?? 'unknown'}`);
+          }
         }
       }
       let fieldsDeactivated = 0;
       for (const id of decision.FieldIDsToDeactivate) {
         const f = await writer.LoadField(id);
         if (f) {
-          f.Status = 'Disabled'; // deactivate, never delete
-          if (await f.Save()) {
+          const owner0 = f.IntegrationObjectID;
+          const fname = f.Name;
+          const outcome = await writer.RetireField(f);
+          if (outcome.ok) {
             fieldsDeactivated++;
             // Name the owner from the rows this run already read. The engine cache would answer
             // for the SHARED catalog only, so on a per-connection run it would silently miss and
             // the log line would carry a bare id.
-            const owner = existingObjects.find((o) => o.ID === f.IntegrationObjectID)?.Name ?? f.IntegrationObjectID;
-            result.FieldsDeactivated.push(`${owner}.${f.Name}`);
+            const owner = existingObjects.find((o) => o.ID === owner0)?.Name ?? owner0;
+            result.FieldsDeactivated.push(`${owner}.${fname}`);
           }
           else LogError(`[IntegrationSchemaSync] Failed to deactivate phantom field ${id}: ${f.LatestResult?.CompleteMessage ?? 'unknown'}`);
         }
       }
-      if (deactivated > 0 || fieldsDeactivated > 0)
+      if (deactivated > 0 || removed > 0 || fieldsDeactivated > 0)
         console.log(
-          `[IntegrationSchemaSync] Deactivated ${deactivated} object(s) + ${fieldsDeactivated} field(s) absent from authoritative discovery for ${IntegrationID} (not materialized, not deleted).`,
+          `[IntegrationSchemaSync] Retired ${deactivated} disabled + ${removed} deleted object(s) and ${fieldsDeactivated} field(s) absent from authoritative discovery for ${IntegrationID}. Mirror tables and their data are untouched either way.`,
         );
     }
 

--- a/packages/Integration/engine/src/IntegrationSchemaSync.ts
+++ b/packages/Integration/engine/src/IntegrationSchemaSync.ts
@@ -514,7 +514,10 @@ export class IntegrationSchemaSync {
     // object records which declared row it was matched to, and that link is what makes
     // "whose definition is this" answerable later.
     const declaredByName = new Map<string, string>();
-    for (const declared of engine.GetIntegrationObjectsByIntegrationID(IntegrationID)) {
+    // Explicitly the SHARED rows. That getter is scope-aware now, and inside a per-connection run
+    // it would hand back this connection's own rows — so the discovery would overlay its own
+    // previous output and the provenance link back to the declared definition would be lost.
+    for (const declared of engine.GetSharedIntegrationObjects(IntegrationID)) {
       if (declared.ID) declaredByName.set(declared.Name.toLowerCase(), declared.ID);
     }
 

--- a/packages/Integration/engine/src/IntegrationSchemaSync.ts
+++ b/packages/Integration/engine/src/IntegrationSchemaSync.ts
@@ -569,9 +569,13 @@ export class IntegrationSchemaSync {
         // which is the ordinary case for something discovery found on its own.
         const declaredObjectID = declaredByName.get(r.srcObj.ExternalName.toLowerCase())?.ID;
         const declaredFieldByName = new Map<string, string>();
+        const declaredFieldRowByName = new Map<string, MJIntegrationObjectFieldEntity>();
         if (declaredObjectID) {
           for (const df of engine.GetIntegrationObjectFields(declaredObjectID)) {
-            if (df.ID) declaredFieldByName.set(df.Name.toLowerCase(), df.ID);
+            if (df.ID) {
+              declaredFieldByName.set(df.Name.toLowerCase(), df.ID);
+              declaredFieldRowByName.set(df.Name.toLowerCase(), df);
+            }
           }
         }
         // U1 / rsuplan line 29 — the primary key is EITHER declared OR streamed, NEVER unioned. If the
@@ -581,14 +585,18 @@ export class IntegrationSchemaSync {
         // added component is NULL — the HubSpot `id` + `hs_object_id` failure). Streaming still runs for
         // every object to find columns/widths/customs; ONLY the PK promotion is gated. A prior *discovered*
         // PK does not count as the authoritative declared key (excluded so a re-run can't self-perpetuate).
-        const objectHasDeclaredPK = existingFields.some(f => f.IsPrimaryKey === true && f.MetadataSource !== 'Discovered');
+        // MJ-CAT-17: on a first discovery the per-connection field list is empty, so the declared key
+        // must be read from the declaration itself or a streamed field would be promoted over it.
+        const objectHasDeclaredPK = existingFields.some(f => f.IsPrimaryKey === true && f.MetadataSource !== 'Discovered')
+          || [...declaredFieldRowByName.values()].some(f => f.IsPrimaryKey === true);
         const perObjectLogs: FieldMergeLog[] = [];
         const perObjectStats = { created: 0, updated: 0 };
         for (const srcField of r.srcObj.Fields) {
           const fr = await IntegrationSchemaSync.UpsertField(
             writer, r.ObjectID!, srcField, existingFields, siblingNameToID, objectHasDeclaredPK,
             r.srcObj.FieldsAreAuthoritative ?? SourceSchema.IsAuthoritative === true,
-            declaredFieldByName.get(srcField.Name.toLowerCase()) ?? null);
+            declaredFieldByName.get(srcField.Name.toLowerCase()) ?? null,
+            declaredFieldRowByName.get(srcField.Name.toLowerCase()) ?? null);
           if (fr.Created) perObjectStats.created++;
           if (fr.Updated) perObjectStats.updated++;
           perObjectLogs.push({
@@ -752,7 +760,25 @@ export class IntegrationSchemaSync {
     /** Whether the connector claims its object enumeration is complete. Decides provenance. */
     discoveryIsAuthoritative: boolean,
   ): Promise<{ ObjectID: string | null; Created: boolean; Updated: boolean; EffectiveSource: 'Declared' | 'Discovered' | 'Custom' }> {
-    const existing = existingObjects.find((o) => o.Name.toLowerCase() === srcObj.ExternalName.toLowerCase());
+    let existing = existingObjects.find((o) => o.Name.toLowerCase() === srcObj.ExternalName.toLowerCase());
+    // MJ-CAT-17. A per-connection catalog starts EMPTY, so on a connection's first discovery every
+    // declared object is "new" here even though the connector declared it. Creating it from the
+    // sample alone left APIPath = Name (every fetch 404'd), no pagination, no watermark field and no
+    // declared keys — observed on the sandbox 2026-09-11, first PheedLoop sync: 27 objects, 27 HTTP 404s,
+    // 0 rows. Seed the row FROM THE DECLARATION, then overlay exactly as for a row that already existed.
+    // On the shared catalog a declared object always IS the existing row, so this never fires there.
+    let seeded = false;
+    if (!existing && declaredObject) {
+      const row = await writer.NewObjectRow();
+      writer.StampNewObject(row, declaredObject.ID, 'Declared');
+      row.Name = declaredObject.Name;
+      row.Status = 'Active';
+      row.IsCustom = declaredObject.IsCustom;
+      row.MetadataSource = declaredObject.MetadataSource;
+      writer.RebaseFromDeclared(row, declaredObject, 'object');
+      existing = row;
+      seeded = true;
+    }
 
     if (existing) {
       // Declared row exists. Overlay rule (external-wins-when-present): when the
@@ -805,7 +831,7 @@ export class IntegrationSchemaSync {
         dirty = true;
         changes.push('Status:reactivated');
       }
-      if (dirty) {
+      if (dirty || seeded) {
         // LastSeenAt rides the save we are already doing. It is deliberately NOT refreshed for an
         // unchanged object: that would mean one extra round trip per object per run — 205 of them
         // on the largest catalog here — to record a timestamp nothing currently reads. So it means
@@ -833,7 +859,7 @@ export class IntegrationSchemaSync {
             fieldsTouched: changes,
           }),
         );
-        return { ObjectID: existing.ID, Created: false, Updated: true, EffectiveSource: 'Declared' };
+        return { ObjectID: existing.ID, Created: seeded, Updated: !seeded, EffectiveSource: 'Declared' };
       }
       console.log(
         JSON.stringify({
@@ -914,6 +940,8 @@ export class IntegrationSchemaSync {
     fieldsAuthoritative: boolean,
     /** The declared field this was matched to, or null when it exists only here. */
     declaredFieldID: string | null = null,
+    /** The declared field ROW, when the caller has it — what a first discovery seeds from (MJ-CAT-17). */
+    declaredField: MJIntegrationObjectFieldEntity | null = null,
   ): Promise<{
     Created: boolean;
     Updated: boolean;
@@ -924,7 +952,22 @@ export class IntegrationSchemaSync {
       if (!target || !siblingNameToID) return undefined;
       return siblingNameToID.get(target.toLowerCase());
     };
-    const existing = existingFields.find((f) => f.Name.toLowerCase() === srcField.Name.toLowerCase());
+    let existing = existingFields.find((f) => f.Name.toLowerCase() === srcField.Name.toLowerCase());
+    // MJ-CAT-17 — see UpsertObject. A declared field with no per-connection row yet is seeded from the
+    // declaration (type, width, key flags, sequence) and then overlaid like an existing row.
+    let seeded = false;
+    if (!existing && declaredField) {
+      const row = await writer.NewFieldRow();
+      writer.StampNewField(row, declaredField.ID, 'Declared');
+      row.IntegrationObjectID = objectID;
+      row.Name = declaredField.Name;
+      row.Status = 'Active';
+      row.IsCustom = declaredField.IsCustom;
+      row.MetadataSource = declaredField.MetadataSource;
+      writer.RebaseFromDeclared(row, declaredField, 'field');
+      existing = row;
+      seeded = true;
+    }
     const winners: FieldMergeLog['AttributeWinners'] = {};
 
     if (existing) {
@@ -1056,12 +1099,12 @@ export class IntegrationSchemaSync {
       } else if (existing.RelatedIntegrationObjectID) {
         winners.ForeignKey = 'Declared';
       }
-      if (dirty) {
+      if (dirty || seeded) {
         const saved = await existing.Save();
         if (!saved) {
           console.warn(`[IntegrationSchemaSync] UpsertField save failed for '${srcField.Name}': ${existing.LatestResult?.CompleteMessage ?? 'unknown error'}`);
         }
-        return { Created: false, Updated: true, EffectiveSource: 'Declared', AttributeWinners: winners };
+        return { Created: seeded, Updated: !seeded, EffectiveSource: 'Declared', AttributeWinners: winners };
       }
       return { Created: false, Updated: false, EffectiveSource: 'Declared', AttributeWinners: winners };
     }

--- a/packages/Integration/engine/src/IntegrationSchemaSync.ts
+++ b/packages/Integration/engine/src/IntegrationSchemaSync.ts
@@ -25,10 +25,29 @@ import type {
 } from '@memberjunction/core-entities';
 import type { SourceSchemaInfo, SourceObjectInfo, SourceFieldInfo } from './types';
 import { ReadFieldSyncDirective, WriteFieldSyncDirective } from './SyncDirectives.js';
+import { CatalogWriter, PerConnectionCatalogWriter, SharedCatalogWriter } from './CatalogWriter.js';
 import { ActionMetadataGenerator, type IntegrationObjectInfo } from './ActionMetadataGenerator';
 
 export interface PersistSchemaOptions {
   IntegrationID: string;
+  /**
+   * The connection this discovery belongs to. Required to write the per-connection catalog; the
+   * IntegrationID stays alongside it because the declared floor a discovery overlays is still
+   * looked up by connector, and because a per-connection row carries it denormalised.
+   */
+  CompanyIntegrationID?: string;
+  /**
+   * Which catalog this discovery persists into.
+   *
+   * 'Shared' is the default and is bytes-identical to the behaviour before the per-connection
+   * catalog existed, so the tables can be created, backfilled and verified against live traffic
+   * before anything reads or writes them.
+   *
+   * 'PerConnection' requires CompanyIntegrationID and REFUSES rather than falling back: a silent
+   * shared write would put one connection's discovery into every other connection's catalog, which
+   * is the failure the whole design exists to remove, and it would report success.
+   */
+  CatalogSource?: 'Shared' | 'PerConnection';
   SourceSchema: SourceSchemaInfo;
   ContextUser: UserInfo;
   Provider?: IMetadataProvider;
@@ -471,14 +490,41 @@ export class IntegrationSchemaSync {
     // skewed the sync DAG, so it was removed. Whatever FK info SourceSchema.Objects already carries flows
     // through the Declared/Discovered merge as-is. (EnrichSchemaConstraints remains exported for offline use.)
 
-    // Load existing objects for this integration from cache
-    const existingObjects = engine.GetIntegrationObjectsByIntegrationID(IntegrationID);
+    // Which catalog this discovery writes into. Refuse rather than fall back: writing one
+    // connection's discovery into the catalog every other connection reads is exactly the failure
+    // this design removes, and it would report success.
+    if (opts.CatalogSource === 'PerConnection' && !opts.CompanyIntegrationID) {
+      throw new Error(
+        'PER_CONNECTION_CATALOG_MISSING: CatalogSource is PerConnection but no CompanyIntegrationID '
+        + 'was supplied. Refusing to fall back to the shared catalog, which would persist this '
+        + "connection's discovery into every other connection of the same connector.",
+      );
+    }
+    const writer: CatalogWriter = opts.CatalogSource === 'PerConnection'
+      ? new PerConnectionCatalogWriter(md, opts.CompanyIntegrationID!, IntegrationID, ContextUser, new Date())
+      : new SharedCatalogWriter(md, IntegrationID, ContextUser);
+
+    // Existing rows come from the DATABASE, not the engine cache. The cache is refreshed between
+    // discovery passes, not within one, so the second pass of a two-pass run must be able to see
+    // what the first pass persisted. It is also the only thing that works for the per-connection
+    // catalog: its cached rows are read-only projections with no Save().
+    const existingObjects = await writer.ObjectsInScope();
+
+    // The declared floor a discovery overlays is still looked up by CONNECTOR: a per-connection
+    // object records which declared row it was matched to, and that link is what makes
+    // "whose definition is this" answerable later.
+    const declaredByName = new Map<string, string>();
+    for (const declared of engine.GetIntegrationObjectsByIntegrationID(IntegrationID)) {
+      if (declared.ID) declaredByName.set(declared.Name.toLowerCase(), declared.ID);
+    }
 
     // Phase 1: upsert objects. Object upserts must complete before field upserts
     // (fields need ObjectID). Within this phase, upserts are independent so we
     // batch-execute via Promise.all (concurrency cap to avoid hammering the DB).
     const objectUpserts = SourceSchema.Objects.map((srcObj) => async () => {
-      const objResult = await IntegrationSchemaSync.UpsertObject(md, IntegrationID, srcObj, existingObjects, ContextUser);
+      const objResult = await IntegrationSchemaSync.UpsertObject(
+        writer, srcObj, existingObjects, declaredByName.get(srcObj.ExternalName.toLowerCase()) ?? null,
+        SourceSchema.IsAuthoritative === true);
       return { srcObj, ...objResult };
     });
     const objectResults = useBatch ? await IntegrationSchemaSync.batchExec(objectUpserts, 8) : await IntegrationSchemaSync.serialExec(objectUpserts);
@@ -511,7 +557,18 @@ export class IntegrationSchemaSync {
     const fieldUpsertJobs = objectResults
       .filter((r) => r.ObjectID)
       .map((r) => async () => {
-        const existingFields = engine.GetIntegrationObjectFields(r.ObjectID!);
+        const existingFields = await writer.FieldsForObject(r.ObjectID!);
+        // The declared field rows this object's fields overlay, by lowercased name. Read from the
+        // engine cache because the DECLARED catalog is shared and unchanged by this run — only the
+        // per-connection copy is being written. Empty for an object with no declared counterpart,
+        // which is the ordinary case for something discovery found on its own.
+        const declaredObjectID = declaredByName.get(r.srcObj.ExternalName.toLowerCase());
+        const declaredFieldByName = new Map<string, string>();
+        if (declaredObjectID) {
+          for (const df of engine.GetIntegrationObjectFields(declaredObjectID)) {
+            if (df.ID) declaredFieldByName.set(df.Name.toLowerCase(), df.ID);
+          }
+        }
         // U1 / rsuplan line 29 — the primary key is EITHER declared OR streamed, NEVER unioned. If the
         // object already carries a primary key from its declared metadata, streamed discovery must not
         // promote a *different* field to PK: that fabricates a composite whose extra, often-nullable
@@ -523,7 +580,10 @@ export class IntegrationSchemaSync {
         const perObjectLogs: FieldMergeLog[] = [];
         const perObjectStats = { created: 0, updated: 0 };
         for (const srcField of r.srcObj.Fields) {
-          const fr = await IntegrationSchemaSync.UpsertField(md, r.ObjectID!, srcField, existingFields, ContextUser, siblingNameToID, objectHasDeclaredPK);
+          const fr = await IntegrationSchemaSync.UpsertField(
+            writer, r.ObjectID!, srcField, existingFields, siblingNameToID, objectHasDeclaredPK,
+            r.srcObj.FieldsAreAuthoritative ?? SourceSchema.IsAuthoritative === true,
+            declaredFieldByName.get(srcField.Name.toLowerCase()) ?? null);
           if (fr.Created) perObjectStats.created++;
           if (fr.Updated) perObjectStats.updated++;
           perObjectLogs.push({
@@ -581,8 +641,7 @@ export class IntegrationSchemaSync {
         fieldsAuthoritativeByObject[r.srcObj.ExternalName] =
           r.srcObj.FieldsAreAuthoritative ?? SourceSchema.IsAuthoritative === true;
         objectIDByName[r.srcObj.ExternalName.toLowerCase()] = r.ObjectID;
-        activeFieldsByObjectID[r.ObjectID] = engine
-          .GetIntegrationObjectFields(r.ObjectID)
+        activeFieldsByObjectID[r.ObjectID] = (await writer.FieldsForObject(r.ObjectID))
           .filter((iof) => iof.Status === 'Active')
           .map((iof) => ({ ID: iof.ID, Name: iof.Name }));
       }
@@ -597,14 +656,14 @@ export class IntegrationSchemaSync {
         DiscoveredObjectNames: SourceSchema.Objects.map((o) => o.ExternalName),
         DiscoveredFieldNamesByObject: discoveredFieldNamesByObject,
         FieldsAuthoritativeByObject: fieldsAuthoritativeByObject,
-        ActiveObjects: engine.GetActiveIntegrationObjects(IntegrationID).map((io) => ({ ID: io.ID, Name: io.Name })),
+        ActiveObjects: existingObjects.filter((io) => io.Status === 'Active').map((io) => ({ ID: io.ID, Name: io.Name })),
         ActiveFieldsByObjectID: activeFieldsByObjectID,
         ObjectIDByName: objectIDByName,
       });
       let deactivated = 0;
       for (const id of decision.ObjectIDsToDeactivate) {
-        const obj = await md.GetEntityObject<MJIntegrationObjectEntity>('MJ: Integration Objects', ContextUser);
-        if (await obj.InnerLoad(CompositeKey.FromID(id))) {
+        const obj = await writer.LoadObject(id);
+        if (obj) {
           obj.Status = 'Disabled'; // deactivate (Active|Deprecated|Disabled enum); never delete
           if (await obj.Save()) { deactivated++; result.ObjectsDeactivated.push(obj.Name); }
           else LogError(`[IntegrationSchemaSync] Failed to deactivate phantom object ${id}: ${obj.LatestResult?.CompleteMessage ?? 'unknown'}`);
@@ -612,12 +671,15 @@ export class IntegrationSchemaSync {
       }
       let fieldsDeactivated = 0;
       for (const id of decision.FieldIDsToDeactivate) {
-        const f = await md.GetEntityObject<MJIntegrationObjectFieldEntity>('MJ: Integration Object Fields', ContextUser);
-        if (await f.InnerLoad(CompositeKey.FromID(id))) {
+        const f = await writer.LoadField(id);
+        if (f) {
           f.Status = 'Disabled'; // deactivate, never delete
           if (await f.Save()) {
             fieldsDeactivated++;
-            const owner = engine.GetIntegrationObjectByID(f.IntegrationObjectID)?.Name ?? f.IntegrationObjectID;
+            // Name the owner from the rows this run already read. The engine cache would answer
+            // for the SHARED catalog only, so on a per-connection run it would silently miss and
+            // the log line would carry a bare id.
+            const owner = existingObjects.find((o) => o.ID === f.IntegrationObjectID)?.Name ?? f.IntegrationObjectID;
             result.FieldsDeactivated.push(`${owner}.${f.Name}`);
           }
           else LogError(`[IntegrationSchemaSync] Failed to deactivate phantom field ${id}: ${f.LatestResult?.CompleteMessage ?? 'unknown'}`);
@@ -666,11 +728,13 @@ export class IntegrationSchemaSync {
   // ── Object upsert ────────────────────────────────────────────────
 
   private static async UpsertObject(
-    md: IMetadataProvider,
-    integrationID: string,
+    writer: CatalogWriter,
     srcObj: SourceObjectInfo,
     existingObjects: MJIntegrationObjectEntity[],
-    contextUser: UserInfo,
+    /** The declared row this object was matched to, or null when it exists only here. */
+    declaredObjectID: string | null,
+    /** Whether the connector claims its object enumeration is complete. Decides provenance. */
+    discoveryIsAuthoritative: boolean,
   ): Promise<{ ObjectID: string | null; Created: boolean; Updated: boolean; EffectiveSource: 'Declared' | 'Discovered' | 'Custom' }> {
     const existing = existingObjects.find((o) => o.Name.toLowerCase() === srcObj.ExternalName.toLowerCase());
 
@@ -716,10 +780,22 @@ export class IntegrationSchemaSync {
         changes.push('Status:reactivated');
       }
       if (dirty) {
+        // LastSeenAt rides the save we are already doing. It is deliberately NOT refreshed for an
+        // unchanged object: that would mean one extra round trip per object per run — 205 of them
+        // on the largest catalog here — to record a timestamp nothing currently reads. So it means
+        // "last run that changed this row", and the day something needs true last-seen it becomes
+        // a set-based UPDATE, not a per-row save.
+        writer.MarkSeen(existing, false);
+        // A failed save used to be swallowed whole. That is how a declared row silently kept a
+        // stale definition while the run reported success.
+        let saveError: string | null = null;
         try {
-          await existing.Save();
-        } catch {
-          /* ignore save failures on declared records */
+          if (!(await existing.Save())) saveError = existing.LatestResult?.CompleteMessage ?? 'unknown validation failure';
+        } catch (e) {
+          saveError = e instanceof Error ? e.message : String(e);
+        }
+        if (saveError) {
+          LogError(`[IntegrationSchemaSync] Failed to update object '${srcObj.ExternalName}': ${saveError}`);
         }
         console.log(
           JSON.stringify({
@@ -752,9 +828,14 @@ export class IntegrationSchemaSync {
     // PersistDiscoveredSchema is called; absent a signal, 'Discovered' is the
     // safer label.
     try {
-      const obj = await md.GetEntityObject<MJIntegrationObjectEntity>('MJ: Integration Objects', contextUser);
-      obj.NewRecord();
-      obj.IntegrationID = integrationID;
+      const obj = await writer.NewObjectRow();
+      // Ownership and provenance. On the shared catalog this writes the integration id and nothing
+      // else, exactly as before. Provenance is coarse ON PURPOSE: a row is 'Declared' when a
+      // curated definition matched it, 'Endpoint' when the connector's own enumeration claimed to
+      // be complete, and 'Sampled' otherwise. The per-attribute truth lives in the merge log, not
+      // in this single column.
+      writer.StampNewObject(obj, declaredObjectID,
+        declaredObjectID ? 'Declared' : (discoveryIsAuthoritative ? 'Endpoint' : 'Sampled'));
       obj.Name = srcObj.ExternalName;
       // APIPath is NOT NULL with no DB default. Declared objects get it from the metadata file;
       // a runtime-DISCOVERED object has no source APIPath (ExternalObjectSchema carries none),
@@ -797,13 +878,16 @@ export class IntegrationSchemaSync {
   // ── Field upsert ─────────────────────────────────────────────────
 
   private static async UpsertField(
-    md: IMetadataProvider,
+    writer: CatalogWriter,
     objectID: string,
     srcField: SourceFieldInfo,
     existingFields: MJIntegrationObjectFieldEntity[],
-    contextUser: UserInfo,
-    siblingNameToID?: Map<string, string>,
-    objectHasDeclaredPK: boolean = false,
+    siblingNameToID: Map<string, string> | undefined,
+    objectHasDeclaredPK: boolean,
+    /** Whether the connector claims its field enumeration for this object is complete. */
+    fieldsAuthoritative: boolean,
+    /** The declared field this was matched to, or null when it exists only here. */
+    declaredFieldID: string | null = null,
   ): Promise<{
     Created: boolean;
     Updated: boolean;
@@ -958,8 +1042,12 @@ export class IntegrationSchemaSync {
 
     // New field — discovered for the first time
     try {
-      const field = await md.GetEntityObject<MJIntegrationObjectFieldEntity>('MJ: Integration Object Fields', contextUser);
-      field.NewRecord();
+      const field = await writer.NewFieldRow();
+      writer.StampNewField(field, declaredFieldID,
+        declaredFieldID ? 'Declared' : (fieldsAuthoritative ? 'Endpoint' : 'Sampled'));
+      // On the per-connection catalog this column is a view alias of CompanyIntegrationObjectID and
+      // the writer maps it; on the shared one it is the column itself. Either way the parent link
+      // is written the same way here.
       field.IntegrationObjectID = objectID;
       field.Name = srcField.Name;
       field.DisplayName = srcField.Label || srcField.Name;

--- a/packages/Integration/engine/src/__tests__/CatalogRebase.test.ts
+++ b/packages/Integration/engine/src/__tests__/CatalogRebase.test.ts
@@ -1,0 +1,82 @@
+/**
+ * A per-connection catalog row is a PROJECTION of (declared metadata + this connection's
+ * discovery), not an accumulator. plan.md: a refresh "will use IO/IOF as the SOT before then
+ * replacing what is in the respective CIO/CIOF, it will not do the changes on top of CIO/CIOF
+ * since it is stale metadata".
+ *
+ * The failure this prevents: an open-app upgrade changes a declared APIPath or page size, and the
+ * connection that already discovered once keeps its old value forever, because every subsequent
+ * overlay starts from that stale row.
+ */
+import { describe, it, expect } from 'vitest';
+import { SharedCatalogWriter, PerConnectionCatalogWriter } from '../CatalogWriter.js';
+import {
+  DECLARED_OWNED_OBJECT_COLUMNS,
+  CATALOG_OBJECT_COLUMNS,
+} from '@memberjunction/integration-engine-base';
+
+const shared = () => new SharedCatalogWriter({} as never, 'int-1', {} as never);
+const perConn = () => new PerConnectionCatalogWriter({} as never, 'ci-1', 'int-1', {} as never, new Date());
+
+describe('the declared-owned column set', () => {
+  it('excludes identity, per-connection state and discovery-owned lifecycle', () => {
+    for (const c of ['ID', 'Name', 'IntegrationID', 'CompanyIntegrationID', 'IsSelected',
+                     'Provenance', 'FirstSeenAt', 'Status', 'IsCustom', 'MetadataSource']) {
+      expect(DECLARED_OWNED_OBJECT_COLUMNS).not.toContain(c);
+    }
+  });
+
+  it('includes the connector-declared shape', () => {
+    for (const c of ['APIPath', 'DefaultPageSize', 'PaginationType']) {
+      expect(DECLARED_OWNED_OBJECT_COLUMNS).toContain(c);
+    }
+  });
+
+  it('includes the three columns discovery may then override', () => {
+    // rebased from the declaration FIRST, then overlaid if discovery reports a value
+    for (const c of ['Description', 'DisplayName', 'IncrementalWatermarkField']) {
+      expect(DECLARED_OWNED_OBJECT_COLUMNS).toContain(c);
+    }
+  });
+
+  it('is a strict subset of the projected columns, so it cannot name a column that does not exist', () => {
+    for (const c of DECLARED_OWNED_OBJECT_COLUMNS) expect(CATALOG_OBJECT_COLUMNS).toContain(c);
+  });
+});
+
+describe('RebaseFromDeclared', () => {
+  it('per-connection: overwrites a stale declared column from the declaration', () => {
+    const row: Record<string, unknown> = { APIPath: '/v1/old', DefaultPageSize: 100, IsSelected: true };
+    const declared: Record<string, unknown> = { APIPath: '/v2/new', DefaultPageSize: 500, IsSelected: false };
+    const moved = perConn().RebaseFromDeclared(row as never, declared as never, 'object');
+    expect(row.APIPath).toBe('/v2/new');
+    expect(row.DefaultPageSize).toBe(500);
+    expect(moved).toEqual(expect.arrayContaining(['APIPath', 'DefaultPageSize']));
+  });
+
+  it('per-connection: never touches this connection\'s own state', () => {
+    const row: Record<string, unknown> = { IsSelected: true, Provenance: 'Sampled', Status: 'Active' };
+    const declared: Record<string, unknown> = { IsSelected: false, Provenance: 'Declared', Status: 'Disabled' };
+    perConn().RebaseFromDeclared(row as never, declared as never, 'object');
+    expect(row.IsSelected).toBe(true);
+    expect(row.Provenance).toBe('Sampled');
+    expect(row.Status).toBe('Active');
+  });
+
+  it('per-connection: an object with no declared match is left alone', () => {
+    const row: Record<string, unknown> = { APIPath: '/only/here' };
+    expect(perConn().RebaseFromDeclared(row as never, null, 'object')).toEqual([]);
+    expect(row.APIPath).toBe('/only/here');
+  });
+
+  it('per-connection: reports nothing moved when already equal, so the row stays clean', () => {
+    const row: Record<string, unknown> = { APIPath: '/same' };
+    expect(perConn().RebaseFromDeclared(row as never, { APIPath: '/same' } as never, 'object')).toEqual([]);
+  });
+
+  it('shared: no-op, because there the row IS the declaration', () => {
+    const row: Record<string, unknown> = { APIPath: '/v1/old' };
+    expect(shared().RebaseFromDeclared()).toEqual([]);
+    expect(row.APIPath).toBe('/v1/old');
+  });
+});

--- a/packages/Integration/engine/src/__tests__/CatalogRetire.test.ts
+++ b/packages/Integration/engine/src/__tests__/CatalogRetire.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Removing a table means two different things depending on which catalog owns the row, and the
+ * difference is deliberate (plan.md): a SHARED IntegrationObject is the declared floor every other
+ * connection of that connector reads, so it is only DISABLED; a PER-CONNECTION row is nobody
+ * else's, so "removed" means removed — "they just dont exist, its likely a cascade delete".
+ *
+ * The policy lives in the writer so the persist path never branches on a flag.
+ *
+ * `RunView` is stubbed at the module boundary because the writer constructs its own instance
+ * rather than calling a method on the provider it is handed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const rows: Record<string, unknown[]> = {};
+
+vi.mock('@memberjunction/core', async (orig) => {
+  const actual = await orig<typeof import('@memberjunction/core')>();
+  return {
+    ...actual,
+    LogError: () => {},
+    RunView: class {
+      async RunView(p: { EntityName: string }) {
+        return { Success: true, Results: rows[p.EntityName] ?? [] };
+      }
+    },
+  };
+});
+
+const { SharedCatalogWriter, PerConnectionCatalogWriter } = await import('../CatalogWriter.js');
+const { CATALOG_FIELD_COLUMNS, CATALOG_OBJECT_COLUMNS } =
+  await import('@memberjunction/integration-engine-base');
+
+const FIELDS = 'MJ: Company Integration Object Fields';
+
+/** A row that satisfies the proxy's column guard and records what happened to it. */
+function makeRow(cols: readonly string[], over: Record<string, unknown> = {}) {
+  const values = new Map<string, unknown>(Object.entries(over));
+  const r: Record<string, unknown> = {
+    Fields: cols.map(Name => ({ Name })),
+    Get: (c: string) => values.get(c),
+    // Writes land in the map AND on the object: the real rows are proxied, so a column is
+    // readable both as a property and through Get. A fake that only did one would let a
+    // direct-property read (`row.ID`) pass here and fail in production, or vice versa.
+    Set: (c: string, v: unknown) => { values.set(c, v); r[c] = v; },
+    Save: vi.fn(async () => (over.saveOk === false ? false : true)),
+    Delete: vi.fn(async () => true),
+    values,
+    ...over,
+  };
+  return r;
+}
+
+beforeEach(() => { for (const k of Object.keys(rows)) delete rows[k]; });
+
+describe('shared catalog retires by disabling', () => {
+  it('sets Disabled, saves, and reports it did not delete', async () => {
+    const w = new SharedCatalogWriter({} as never, 'int-1', {} as never);
+    const r = makeRow(CATALOG_OBJECT_COLUMNS, { ID: 'obj-1', Name: 'Widget', Status: 'Active' });
+    const out = await w.RetireObject(r as never);
+    expect(out).toEqual({ ok: true, deleted: false });
+    expect(r.Status).toBe('Disabled');
+    expect(r.Delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('per-connection catalog retires by deleting', () => {
+  it('clears the inbound dependency edge, deletes children, then deletes the object', async () => {
+    const edge = makeRow(CATALOG_FIELD_COLUMNS, { ID: 'f-x', RelatedCompanyIntegrationObjectID: 'obj-1' });
+    const child = makeRow(CATALOG_FIELD_COLUMNS, { ID: 'f-1' });
+    rows[FIELDS] = [edge, child];
+
+    const w = new PerConnectionCatalogWriter({} as never, 'ci-1', 'int-1', {} as never, new Date());
+    const target = makeRow(CATALOG_OBJECT_COLUMNS, { ID: 'obj-1', Name: 'Widget' });
+    const out = await w.RetireObject(target as never);
+
+    expect(out).toEqual({ ok: true, deleted: true });
+    // the self-referencing FK must be cleared first, or the delete violates it and aborts the persist
+    expect(edge.RelatedCompanyIntegrationObjectID).toBeNull();
+    expect(edge.Save).toHaveBeenCalled();
+    expect(target.Delete).toHaveBeenCalled();
+  });
+
+  it('refuses to delete the object when an inbound edge cannot be cleared', async () => {
+    rows[FIELDS] = [makeRow(CATALOG_FIELD_COLUMNS, {
+      ID: 'f-x', RelatedCompanyIntegrationObjectID: 'obj-1', saveOk: false,
+    })];
+    const w = new PerConnectionCatalogWriter({} as never, 'ci-1', 'int-1', {} as never, new Date());
+    const target = makeRow(CATALOG_OBJECT_COLUMNS, { ID: 'obj-1', Name: 'Widget' });
+    const out = await w.RetireObject(target as never);
+    expect(out).toEqual({ ok: false, deleted: false });
+    expect(target.Delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes a field outright', async () => {
+    const w = new PerConnectionCatalogWriter({} as never, 'ci-1', 'int-1', {} as never, new Date());
+    const f = makeRow(CATALOG_FIELD_COLUMNS, { ID: 'f-9' });
+    const out = await w.RetireField(f as never);
+    expect(out).toEqual({ ok: true, deleted: true });
+    expect(f.Delete).toHaveBeenCalled();
+  });
+});

--- a/packages/Integration/engine/src/__tests__/CatalogRetire.test.ts
+++ b/packages/Integration/engine/src/__tests__/CatalogRetire.test.ts
@@ -1,8 +1,17 @@
 /**
- * Removing a table means two different things depending on which catalog owns the row, and the
+ * Removing a TABLE means two different things depending on which catalog owns the row, and the
  * difference is deliberate (plan.md): a SHARED IntegrationObject is the declared floor every other
  * connection of that connector reads, so it is only DISABLED; a PER-CONNECTION row is nobody
  * else's, so "removed" means removed — "they just dont exist, its likely a cascade delete".
+ *
+ * A COLUMN is not a table, and the rule does not carry across. plan.md draws the line twice — "for
+ * tables only, if its not there after discovery algorithm, just removes it" and "columns that are
+ * in MJC already never get removed ... NEVER columns" — and everything.txt says why: "sometimes, a
+ * column may be missing ... it doesnt automatically conclude the column no longer exist". A column
+ * absent from a sample is absent from a SAMPLE. Deleting it throws away the observed width, the
+ * provenance and the selection that only this connection knows, so a later sample that does see it
+ * starts from nothing. Both catalogs therefore DISABLE a field, and only the table cascade deletes
+ * one.
  *
  * The policy lives in the writer so the persist path never branches on a flag.
  *
@@ -91,11 +100,24 @@ describe('per-connection catalog retires by deleting', () => {
     expect(target.Delete).not.toHaveBeenCalled();
   });
 
-  it('deletes a field outright', async () => {
+  it('DISABLES an absent field rather than deleting it', async () => {
+    // The dictated exception to the delete rule. A column missing from one sample is not a column
+    // that has gone; disabling reverses itself the moment discovery sees it again, and keeps the
+    // width, provenance and selection that deleting would destroy.
     const w = new PerConnectionCatalogWriter({} as never, 'ci-1', 'int-1', {} as never, new Date());
-    const f = makeRow(CATALOG_FIELD_COLUMNS, { ID: 'f-9' });
+    const f = makeRow(CATALOG_FIELD_COLUMNS, { ID: 'f-9', Status: 'Active' });
     const out = await w.RetireField(f as never);
-    expect(out).toEqual({ ok: true, deleted: true });
-    expect(f.Delete).toHaveBeenCalled();
+    expect(out).toEqual({ ok: true, deleted: false });
+    expect(f.Status).toBe('Disabled');
+    expect(f.Delete).not.toHaveBeenCalled();
+  });
+
+  it('still deletes a field when its OBJECT is removed — that is the table cascade', async () => {
+    const child = makeRow(CATALOG_FIELD_COLUMNS, { ID: 'f-1' });
+    rows[FIELDS] = [child];
+    const w = new PerConnectionCatalogWriter({} as never, 'ci-1', 'int-1', {} as never, new Date());
+    const target = makeRow(CATALOG_OBJECT_COLUMNS, { ID: 'obj-1', Name: 'Widget' });
+    await w.RetireObject(target as never);
+    expect(child.Delete).toHaveBeenCalled();
   });
 });

--- a/packages/Integration/engine/src/__tests__/CatalogSource.test.ts
+++ b/packages/Integration/engine/src/__tests__/CatalogSource.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'vitest';
+import type { MJCompanyIntegrationEntity } from '@memberjunction/core-entities';
+import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
+import { BuildCatalogWriter, ResolveCatalogSource } from '../CatalogSource.js';
+
+const ENV = 'MJ_INTEGRATION_CATALOG_SOURCE';
+
+function connection(configuration: string | null, id = 'ci-1'): MJCompanyIntegrationEntity {
+    return { ID: id, IntegrationID: 'int-1', Name: 'Test', Configuration: configuration } as unknown as MJCompanyIntegrationEntity;
+}
+
+afterEach(() => { delete process.env[ENV]; });
+
+test('the default is Shared, so the tables can exist long before anything reads them', () => {
+    assert.equal(ResolveCatalogSource(connection(null)), 'Shared');
+    assert.equal(ResolveCatalogSource(connection('{}')), 'Shared');
+});
+
+test('a connection opts in through its own Configuration', () => {
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":"perConnection"}')), 'PerConnection');
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":"per-connection"}')), 'PerConnection');
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":"PERCONNECTION"}')), 'PerConnection');
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":"shared"}')), 'Shared');
+});
+
+test('the environment override wins in BOTH directions — it is the rollback lever', () => {
+    // Rollback has to work without reaching a connection's Configuration through a workspace that
+    // may be the thing that is broken.
+    process.env[ENV] = 'shared';
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":"perConnection"}')), 'Shared');
+    process.env[ENV] = 'perConnection';
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":"shared"}')), 'PerConnection');
+});
+
+test('an unparseable Configuration is no opinion, not an error', () => {
+    // That column carries a dozen unrelated settings. One bad character in any of them must not be
+    // able to flip which catalog a connection uses.
+    assert.equal(ResolveCatalogSource(connection('{not json')), 'Shared');
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":42}')), 'Shared');
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":"nonsense"}')), 'Shared');
+});
+
+test('a garbage env value is ignored rather than treated as opt-in', () => {
+    process.env[ENV] = 'yes-please';
+    assert.equal(ResolveCatalogSource(connection('{"catalogSource":"shared"}')), 'Shared');
+});
+
+/** Stub the two engine reads BuildCatalogWriter consults, and restore afterwards. */
+function withEngine<T>(hasCatalog: boolean, mapCount: number, fn: () => T): T {
+    const engine = IntegrationEngineBase.Instance as unknown as Record<string, unknown>;
+    const savedHas = engine.HasCompanyIntegrationCatalog;
+    const savedMaps = engine.GetEntityMapsForCompanyIntegration;
+    engine.HasCompanyIntegrationCatalog = () => hasCatalog;
+    engine.GetEntityMapsForCompanyIntegration = () => new Array(mapCount).fill({});
+    try { return fn(); }
+    finally {
+        engine.HasCompanyIntegrationCatalog = savedHas;
+        engine.GetEntityMapsForCompanyIntegration = savedMaps;
+    }
+}
+
+const md = { GetEntityObject: async () => null } as never;
+const user = {} as never;
+
+test('Shared never consults the engine and never refuses', () => {
+    withEngine(false, 99, () => {
+        const w = BuildCatalogWriter(md, connection(null), user);
+        assert.equal(w.Source, 'Shared');
+    });
+});
+
+test('per-connection with entity maps but no catalog REFUSES — it has not been backfilled', () => {
+    // The failure this prevents is the quiet one: reading the shared catalog would carry objects
+    // this connection never discovered, omit the ones only it has, sync the wrong set, and report
+    // success.
+    withEngine(false, 3, () => {
+        assert.throws(
+            () => BuildCatalogWriter(md, connection('{"catalogSource":"perConnection"}'), user),
+            (e: Error) => /PER_CONNECTION_CATALOG_MISSING/.test(e.message)
+                       && /3 entity map/.test(e.message)
+                       && /ci-1/.test(e.message)
+                       && /backfill/i.test(e.message),
+            'the refusal must name the connection, what it found, and the way out',
+        );
+    });
+});
+
+test('per-connection with NO maps and no catalog is allowed — that is pre-discovery', () => {
+    // Refusing here would reject every brand-new connector on the very flag meant to be safe.
+    withEngine(false, 0, () => {
+        const w = BuildCatalogWriter(md, connection('{"catalogSource":"perConnection"}'), user);
+        assert.equal(w.Source, 'PerConnection');
+    });
+});
+
+test('per-connection with a populated catalog is allowed', () => {
+    withEngine(true, 12, () => {
+        const w = BuildCatalogWriter(md, connection('{"catalogSource":"perConnection"}'), user);
+        assert.equal(w.Source, 'PerConnection');
+    });
+});
+
+test('an explicit source argument bypasses the flag but keeps the safety check', () => {
+    withEngine(false, 5, () => {
+        assert.throws(() => BuildCatalogWriter(md, connection(null), user, 'PerConnection'),
+                      /PER_CONNECTION_CATALOG_MISSING/);
+    });
+});

--- a/packages/Integration/engine/src/__tests__/CatalogWriterProxy.test.ts
+++ b/packages/Integration/engine/src/__tests__/CatalogWriterProxy.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { CATALOG_FIELD_COLUMNS, CATALOG_OBJECT_COLUMNS } from '@memberjunction/integration-engine-base';
+import { PerConnectionCatalogWriter, SharedCatalogWriter } from '../CatalogWriter.js';
+import type { MJIntegrationObjectFieldEntity } from '@memberjunction/core-entities';
+
+/**
+ * These prove the one property the whole per-connection write path rests on: that a row handed to
+ * the merge logic behaves like a typed entity whether or not a generated subclass exists.
+ *
+ * The two fakes below are the two real cases. `SubclasslessRow` is what a migration-registered
+ * entity actually gives you — values in a bag, reachable only through Get/Set, no accessors.
+ * `TypedRow` is what CodeGen generates — real accessors that delegate to Get/Set. The proxy must be
+ * transparent over the second and supply the missing half of the first.
+ */
+
+class SubclasslessRow {
+    public readonly values = new Map<string, unknown>();
+    public saved = 0;
+    /** Every column the real entity has. The wrap-time assertion checks this list. */
+    public Fields: Array<{ Name: string }> = CATALOG_OBJECT_COLUMNS.map(Name => ({ Name }));
+    /** Every column name Get was asked for, so a test can prove what did NOT reach it. */
+    public readonly getCalls: string[] = [];
+    public Get(c: string): unknown { this.getCalls.push(c); return this.values.get(c); }
+    public Set(c: string, v: unknown): void { this.values.set(c, v); }
+    public NewRecord(): void { /* no-op */ }
+    public async Save(): Promise<boolean> { this.saved++; return true; }
+    /** Reads a value through `this` — proves methods run against the real row, not the proxy. */
+    public Describe(): string { return `${String(this.Get('Name'))}`; }
+    /**
+     * Touches a property that is not a column and not a member. A method BOUND to the real row
+     * simply gets `undefined`. An UNBOUND one runs with `this` set to the proxy, so the same read
+     * falls through the handler into `Get('__internal')` — which is how a proxy silently turns an
+     * entity's own internal bookkeeping into a bogus column lookup.
+     */
+    public TouchInternal(): unknown { return (this as unknown as Record<string, unknown>).__internal; }
+}
+
+class TypedRow extends SubclasslessRow {
+    public get Description(): unknown { return this.Get('Description'); }
+    public set Description(v: unknown) { this.Set('Description', v); }
+}
+
+type Row = Record<string, unknown> & { Save(): Promise<boolean>; Describe(): string };
+
+// The module keeps `proxyRow` private; exercise it exactly as production does, through a writer
+// whose provider hands back our fake.
+function writerOver(row: object, perConnection: boolean) {
+    const md = { GetEntityObject: async () => row } as never;
+    return perConnection
+        ? new PerConnectionCatalogWriter(md, 'ci-1', 'int-1', {} as never, new Date(0))
+        : new SharedCatalogWriter(md, 'int-1', {} as never);
+}
+
+test('assignment on a SUBCLASSLESS row reaches Set — the silent-loss bug', async () => {
+    const raw = new SubclasslessRow();
+    const row = (await writerOver(raw, true).NewObjectRow()) as unknown as Row;
+    row.Name = 'Contacts';
+    // Without the proxy this assertion fails: the value lands as an own property, the field bag
+    // stays empty, and Save() reports success having written nothing.
+    assert.equal(raw.values.get('Name'), 'Contacts');
+});
+
+test('the proxy is transparent over a TYPED row — the real accessor is used', async () => {
+    const raw = new TypedRow();
+    const row = (await writerOver(raw, false).NewObjectRow()) as unknown as Row;
+    row.Description = 'hello';
+    assert.equal(raw.values.get('Description'), 'hello');
+    assert.equal(row.Description, 'hello');
+});
+
+test('methods run against the real row, never recursing through the proxy', async () => {
+    const raw = new SubclasslessRow();
+    const row = (await writerOver(raw, true).NewObjectRow()) as unknown as Row;
+    row.Name = 'Orders';
+    assert.equal(row.Describe(), 'Orders');
+    assert.equal(await row.Save(), true);
+    assert.equal(raw.saved, 1);
+});
+
+test('an entity method touching a non-column does not become a column lookup', async () => {
+    const raw = new SubclasslessRow();
+    const row = (await writerOver(raw, true).NewObjectRow()) as unknown as Row & { TouchInternal(): unknown };
+    assert.equal(row.TouchInternal(), undefined);
+    assert.ok(!raw.getCalls.includes('__internal'),
+              'the method ran with `this` set to the proxy, so an internal read became a Get()');
+});
+
+test('the field aliases map the shared column names onto the per-connection ones', async () => {
+    // The merge logic writes `field.IntegrationObjectID` and `field.RelatedIntegrationObjectID`
+    // throughout. On the per-connection table those are view aliases; the real columns carry the
+    // per-connection names. Without this mapping every parent link and every dependency edge would
+    // be written to a column that does not exist.
+    const raw = new SubclasslessRow();
+    raw.Fields = CATALOG_FIELD_COLUMNS.map(Name => ({ Name }));
+    const field = (await writerOver(raw, true).NewFieldRow()) as unknown as MJIntegrationObjectFieldEntity;
+    field.IntegrationObjectID = 'obj-1';
+    field.RelatedIntegrationObjectID = 'obj-2';
+    assert.equal(raw.values.get('CompanyIntegrationObjectID'), 'obj-1');
+    assert.equal(raw.values.get('RelatedCompanyIntegrationObjectID'), 'obj-2');
+    assert.equal(raw.values.get('IntegrationObjectID'), undefined, 'wrote the alias, not the real column');
+    // and the read side round-trips through the same alias
+    assert.equal(field.IntegrationObjectID, 'obj-1');
+});
+
+test('the OBJECT entity keeps IntegrationObjectID as a real column, not an alias', async () => {
+    // Same name, opposite meaning: on the object table it is the provenance link to the declared
+    // row. Aliasing it there would silently redirect the provenance FK.
+    const raw = new SubclasslessRow();
+    const row = (await writerOver(raw, true).NewObjectRow()) as unknown as Row;
+    row.IntegrationObjectID = 'declared-1';
+    assert.equal(raw.values.get('IntegrationObjectID'), 'declared-1');
+    assert.equal(raw.values.get('CompanyIntegrationObjectID'), undefined);
+});
+
+test('an unknown column throws on the per-connection catalog instead of silently vanishing', async () => {
+    const raw = new SubclasslessRow();
+    const row = (await writerOver(raw, true).NewObjectRow()) as unknown as Row;
+    assert.throws(() => { row.NoSuchColumn = 1; }, /has no column 'NoSuchColumn'/);
+    // and the message names the alias when one was applied, so the reader is not left hunting.
+    // The parent column is dropped from an otherwise-complete field entity, which is the shape of
+    // a real half-applied migration.
+    const f = new SubclasslessRow();
+    f.Fields = CATALOG_FIELD_COLUMNS.filter(c => c !== 'CompanyIntegrationObjectID').map(Name => ({ Name }));
+    assert.rejects(
+        () => writerOver(f, true).NewFieldRow(),
+        /PER_CONNECTION_CATALOG_SCHEMA_MISMATCH|missing 1 required column\(s\): CompanyIntegrationObjectID/,
+        'a half-applied migration must fail at wrap time, not at the first lost write');
+});
+
+test('the shared catalog is deliberately unguarded', async () => {
+    // Its generated subclass makes a bad column name a compile error; a runtime guard there would
+    // only add a way for existing behaviour to change.
+    const raw = new TypedRow();
+    const row = (await writerOver(raw, false).NewObjectRow()) as unknown as Row;
+    assert.doesNotThrow(() => { row.AnythingAtAll = 1; });
+});
+
+test('StampNewObject writes the ownership columns and starts deselected', async () => {
+    const raw = new SubclasslessRow();
+    const w = writerOver(raw, true);
+    const row = await w.NewObjectRow();
+    w.StampNewObject(row, null, 'Sampled');
+    assert.equal(raw.values.get('CompanyIntegrationID'), 'ci-1');
+    assert.equal(raw.values.get('IntegrationObjectID'), null, 'null means: exists only for this connection');
+    assert.equal(raw.values.get('Provenance'), 'Sampled');
+    // Membership is not selection. A newly-discovered object joins the catalog deselected and is
+    // still visible to schema introspection — which is the bug this column exists to fix.
+    assert.equal(raw.values.get('IsSelected'), false);
+});
+
+test('the shared writer stamps only the integration id', async () => {
+    const raw = new TypedRow();
+    const w = writerOver(raw, false);
+    const row = await w.NewObjectRow();
+    w.StampNewObject(row, 'ignored', 'Declared');
+    assert.equal(raw.values.get('IntegrationID'), 'int-1');
+    assert.equal(raw.values.get('Provenance'), undefined, 'the shared catalog has no provenance column');
+    assert.equal(raw.values.get('IsSelected'), undefined);
+});

--- a/packages/Integration/engine/src/__tests__/FirstDiscoverySeedsFromDeclared.test.ts
+++ b/packages/Integration/engine/src/__tests__/FirstDiscoverySeedsFromDeclared.test.ts
@@ -1,0 +1,104 @@
+/**
+ * MJ-CAT-17. A per-connection catalog starts EMPTY, so on a connection's first discovery every
+ * declared object is "new" in that scope even though the connector declared it. The create path
+ * used to build such a row from the sample alone: APIPath defaulted to the object NAME, no page
+ * size, no watermark field, no declared keys. Observed on the sandbox 2026-09-11, first PheedLoop
+ * sync: 27 objects, 27 HTTP 404s (`…/organization/…/Tags`), 0 rows.
+ *
+ * Now a declared match is SEEDED from the declaration and then overlaid exactly like a row that
+ * already existed. These drive the two upserts through a real PerConnectionCatalogWriter over fake
+ * rows, so what is asserted is the row the writer would have saved.
+ */
+import { describe, it, expect } from 'vitest';
+import { PerConnectionCatalogWriter } from '../CatalogWriter.js';
+import { IntegrationSchemaSync } from '../IntegrationSchemaSync.js';
+import { CATALOG_OBJECT_COLUMNS, CATALOG_FIELD_COLUMNS } from '@memberjunction/integration-engine-base';
+
+class FakeRow {
+  public readonly values = new Map<string, unknown>();
+  public saved = 0;
+  public Fields: Array<{ Name: string }>;
+  constructor(columns: readonly string[]) { this.Fields = columns.map(Name => ({ Name })); }
+  public Get(c: string): unknown { return this.values.get(c); }
+  public Set(c: string, v: unknown): void { this.values.set(c, v); }
+  public NewRecord(): void { /* no-op */ }
+  public async Save(): Promise<boolean> { this.saved++; this.values.set('ID', this.values.get('ID') ?? 'new-row-id'); return true; }
+  public get LatestResult(): unknown { return undefined; }
+}
+
+const rows: FakeRow[] = [];
+function writer(): PerConnectionCatalogWriter {
+  const md = {
+    GetEntityObject: async (entity: string) => {
+      const r = new FakeRow(entity.includes('Field') ? CATALOG_FIELD_COLUMNS : CATALOG_OBJECT_COLUMNS);
+      rows.push(r);
+      return r;
+    }
+  } as never;
+  return new PerConnectionCatalogWriter(md, 'ci-1', 'int-1', {} as never, new Date(0));
+}
+
+type Upserts = {
+  UpsertObject: (...a: unknown[]) => Promise<{ ObjectID: string | null; Created: boolean; Updated: boolean }>;
+  UpsertField: (...a: unknown[]) => Promise<{ Created: boolean; Updated: boolean }>;
+};
+const sync = IntegrationSchemaSync as unknown as Upserts;
+
+const declaredObject = {
+  ID: 'decl-obj-1', IntegrationID: 'int-1', Name: 'Tags', DisplayName: 'Tags', Description: 'Declared tags',
+  APIPath: '/organization/{orgId}/tags', ResponseDataKey: 'results', DefaultPageSize: 200, SupportsPagination: true,
+  PaginationType: 'PageNumber', SupportsIncrementalSync: true, IncrementalWatermarkField: 'updated_at',
+  IsCustom: false, MetadataSource: 'Declared', Sequence: 12, Status: 'Active', Configuration: null,
+};
+
+describe('first discovery seeds a declared object from the declaration (MJ-CAT-17)', () => {
+  it('a declared object with no per-connection row yet keeps its declared APIPath, paging and watermark', async () => {
+    rows.length = 0;
+    const srcObj = { ExternalName: 'Tags', ExternalLabel: 'Tags', Fields: [] };
+    const r = await sync.UpsertObject(writer(), srcObj, [] /* nothing in this connection's scope */, declaredObject, false);
+    expect(r.Created).toBe(true);
+    const row = rows[0];
+    expect(row.saved).toBe(1);
+    expect(row.Get('APIPath')).toBe('/organization/{orgId}/tags');   // NOT 'Tags'
+    expect(row.Get('DefaultPageSize')).toBe(200);
+    expect(row.Get('PaginationType')).toBe('PageNumber');
+    expect(row.Get('IncrementalWatermarkField')).toBe('updated_at');
+    expect(row.Get('IsCustom')).toBe(false);
+    expect(row.Get('MetadataSource')).toBe('Declared');
+    expect(row.Get('Provenance')).toBe('Declared');
+    expect(row.Get('IntegrationObjectID')).toBe('decl-obj-1');
+    expect(row.Get('CompanyIntegrationID')).toBe('ci-1');
+    expect(row.Get('Status')).toBe('Active');
+  });
+
+  it('an object with NO declared match still defaults APIPath to its name (unchanged behaviour)', async () => {
+    rows.length = 0;
+    const srcObj = { ExternalName: 'CustomThing', ExternalLabel: 'Custom Thing', Fields: [] };
+    const r = await sync.UpsertObject(writer(), srcObj, [], null, false);
+    expect(r.Created).toBe(true);
+    expect(rows[0].Get('APIPath')).toBe('CustomThing');
+    expect(rows[0].Get('IsCustom')).toBe(true);
+    expect(rows[0].Get('MetadataSource')).toBe('Discovered');
+  });
+
+  it('a declared field with no per-connection row yet keeps its declared key flag and type', async () => {
+    rows.length = 0;
+    const declaredField = {
+      ID: 'decl-fld-1', Name: 'id', DisplayName: 'ID', Type: 'nvarchar', Length: 64, AllowsNull: false,
+      IsPrimaryKey: true, IsUniqueKey: true, IsReadOnly: true, IsRequired: true, Sequence: 1,
+      IsCustom: false, MetadataSource: 'Declared', Status: 'Active', Configuration: null,
+    };
+    // The sample is silent on type and key — exactly what a REST sample of an id looks like.
+    const srcField = { Name: 'id', Label: 'id', SourceType: undefined, IsPrimaryKey: undefined, IsRequired: false };
+    const r = await sync.UpsertField(writer(), 'obj-1', srcField, [], undefined, /* objectHasDeclaredPK */ true, false, 'decl-fld-1', declaredField);
+    expect(r.Created).toBe(true);
+    const row = rows[0];
+    expect(row.saved).toBe(1);
+    expect(row.Get('IsPrimaryKey')).toBe(true);
+    expect(row.Get('Type')).toBe('nvarchar');
+    expect(row.Get('Length')).toBe(64);
+    expect(row.Get('Provenance')).toBe('Declared');
+    expect(row.Get('IntegrationObjectFieldID')).toBe('decl-fld-1');
+    expect(row.Get('CompanyIntegrationObjectID')).toBe('obj-1');
+  });
+});

--- a/packages/Integration/engine/src/__tests__/catalog-scope.test.ts
+++ b/packages/Integration/engine/src/__tests__/catalog-scope.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
+import {
+    CurrentCatalogCI,
+    RunInCatalogScope,
+    RunOutsideCatalogScope,
+    WithCatalogScope,
+} from '../CatalogScope.js';
+
+const A = '11111111-1111-4111-8111-111111111111';
+const B = '22222222-2222-4222-8222-222222222222';
+
+test('no scope by default — every read stays on the shared catalog', () => {
+    assert.equal(CurrentCatalogCI(), undefined);
+});
+
+test('the resolver is installed on the client-safe base by importing this package', () => {
+    // The base declares the hook and cannot import node:async_hooks, so this is the wiring that
+    // makes per-connection reads possible at all. If it regressed, every read would silently
+    // answer from the shared catalog and no test of the getters would notice.
+    assert.equal(typeof IntegrationEngineBase.CatalogScopeResolver, 'function');
+    RunInCatalogScope(A, () => {
+        assert.equal(IntegrationEngineBase.CatalogScopeResolver!(), A);
+    });
+});
+
+test('scope survives await, and nesting takes the innermost', async () => {
+    await WithCatalogScope(A, async () => {
+        assert.equal(CurrentCatalogCI(), A);
+        await new Promise(r => setTimeout(r, 1));
+        assert.equal(CurrentCatalogCI(), A, 'lost across a timer callback');
+        await WithCatalogScope(B, async () => {
+            assert.equal(CurrentCatalogCI(), B, 'nested scope did not win');
+        });
+        assert.equal(CurrentCatalogCI(), A, 'outer scope not restored');
+    });
+    assert.equal(CurrentCatalogCI(), undefined, 'scope leaked past its body');
+});
+
+test('concurrent scopes do not bleed into each other', async () => {
+    // The failure this guards against is the whole reason for AsyncLocalStorage over a module
+    // variable: a batch applying several connections at once would otherwise write every
+    // connection's rows under whichever one started last.
+    const seen: string[] = [];
+    await Promise.all([
+        WithCatalogScope(A, async () => {
+            await new Promise(r => setTimeout(r, 5));
+            seen.push(CurrentCatalogCI()!);
+        }),
+        WithCatalogScope(B, async () => {
+            await new Promise(r => setTimeout(r, 1));
+            seen.push(CurrentCatalogCI()!);
+        }),
+    ]);
+    assert.deepEqual(seen.sort(), [A, B].sort());
+});
+
+test('an empty connection id is treated as no scope, not as a scope of ""', () => {
+    // A blank id must not look like a real connection: it would match nothing and, if it reached a
+    // getter, would return an empty catalog that reads as "this connection has no objects".
+    RunInCatalogScope('', () => assert.equal(CurrentCatalogCI(), undefined));
+});
+
+test('RunOutsideCatalogScope clears the scope for action generation', () => {
+    RunInCatalogScope(A, () => {
+        assert.equal(CurrentCatalogCI(), A);
+        RunOutsideCatalogScope(() => {
+            assert.equal(CurrentCatalogCI(), undefined, 'action generation would see one tenant projection');
+        });
+        assert.equal(CurrentCatalogCI(), A);
+    });
+});
+
+test('a callback created outside the scope sees no scope when invoked inside it', () => {
+    // Documents the real boundary rather than pretending there is none. The fallback is the
+    // pre-existing shared read, so a missed scope degrades to the old behaviour, never to a wrong
+    // per-connection answer.
+    let observed: string | undefined = 'unset';
+    const cb = () => { observed = CurrentCatalogCI(); };
+    RunInCatalogScope(A, () => cb());
+    assert.equal(observed, A, 'a synchronous call inside the scope DOES see it');
+});

--- a/packages/Integration/engine/src/__tests__/catalog-scope.test.ts
+++ b/packages/Integration/engine/src/__tests__/catalog-scope.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import { test } from 'vitest';
 import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
 import {
     CurrentCatalogCI,

--- a/packages/Integration/engine/src/__tests__/catalog-scope.test.ts
+++ b/packages/Integration/engine/src/__tests__/catalog-scope.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 import { IntegrationEngineBase } from '@memberjunction/integration-engine-base';
 import {
     CurrentCatalogCI,
@@ -80,4 +80,82 @@ test('a callback created outside the scope sees no scope when invoked inside it'
     const cb = () => { observed = CurrentCatalogCI(); };
     RunInCatalogScope(A, () => cb());
     assert.equal(observed, A, 'a synchronous call inside the scope DOES see it');
+});
+
+/**
+ * The scoping lives on the EXISTING getters, not on new ones, and that is load-bearing: two
+ * connectors in the separate Integrations repository call these getters directly rather than going
+ * through the REST base. A new method name would have left exactly those two reading the shared
+ * catalog forever while every other path went per-connection — the asymmetry this design exists to
+ * remove, reintroduced by the fix for it.
+ */
+function withPerConnectionCatalog<T>(ciID: string, objects: Array<{ ID: string; Name: string; Status: string; Sequence: number }>, fn: () => T): T {
+    const e = IntegrationEngineBase.Instance as unknown as Record<string, unknown>;
+    const saved = { has: e.HasCompanyIntegrationCatalog, get: e.GetCompanyIntegrationObjects, dag: e.GetCompanyIntegrationObjectsInDependencyOrder };
+    e.HasCompanyIntegrationCatalog = (id: string) => id === ciID;
+    e.GetCompanyIntegrationObjects = (id: string) => (id === ciID ? objects : []);
+    // Deliberately a DIFFERENT order from GetCompanyIntegrationObjects. Dependency order is not
+    // sequence order, and without the difference a test cannot tell whether the DAG getter ran or
+    // whether it merely fell through to the (also scoped) active-objects getter.
+    e.GetCompanyIntegrationObjectsInDependencyOrder = (id: string) => (id === ciID ? [...objects].reverse() : []);
+    try { return fn(); }
+    finally {
+        e.HasCompanyIntegrationCatalog = saved.has;
+        e.GetCompanyIntegrationObjects = saved.get;
+        e.GetCompanyIntegrationObjectsInDependencyOrder = saved.dag;
+    }
+}
+
+const PER_CONNECTION = [
+    { ID: 'cio-1', Name: 'OnlyMine', Status: 'Active', Sequence: 1 },
+    { ID: 'cio-2', Name: 'AlsoMine', Status: 'Active', Sequence: 2 },
+];
+
+test('the existing getters answer per-connection INSIDE a scope', () => {
+    IntegrationEngineBase.Instance.SeedForTesting({
+        IntegrationObjects: [{ ID: 'io-1', IntegrationID: 'int-1', Name: 'Shared', Status: 'Active', Sequence: 1 } as never],
+    });
+    withPerConnectionCatalog(A, PER_CONNECTION, () => {
+        // outside the scope: the shared answer, unchanged
+        expect(IntegrationEngineBase.Instance.GetActiveIntegrationObjects('int-1').map(o => o.Name)).toEqual(['Shared']);
+        RunInCatalogScope(A, () => {
+            expect(IntegrationEngineBase.Instance.GetActiveIntegrationObjects('int-1').map(o => o.Name)).toEqual(['OnlyMine', 'AlsoMine']);
+            expect(IntegrationEngineBase.Instance.GetIntegrationObjectsByIntegrationID('int-1').map(o => o.Name)).toEqual(['OnlyMine', 'AlsoMine']);
+            // The per-connection DAG, NOT the active-objects getter it would fall through to —
+            // the reversed order is what tells them apart.
+            expect(IntegrationEngineBase.Instance.GetObjectsInDependencyOrder('int-1').map(o => o.Name)).toEqual(['AlsoMine', 'OnlyMine']);
+            expect(IntegrationEngineBase.Instance.GetIntegrationObject('int-1', 'OnlyMine')?.Name).toBe('OnlyMine');
+        });
+        // and back out again
+        expect(IntegrationEngineBase.Instance.GetActiveIntegrationObjects('int-1').map(o => o.Name)).toEqual(['Shared']);
+    });
+});
+
+test('a name absent from the per-connection catalog does NOT fall back to the shared one', () => {
+    // Once a connection has its own catalog, a miss means the object is genuinely not in it.
+    // Falling back would resurrect an object this connection never discovered.
+    withPerConnectionCatalog(A, PER_CONNECTION, () => {
+        RunInCatalogScope(A, () => {
+            expect(IntegrationEngineBase.Instance.GetIntegrationObject('int-1', 'Shared')).toBeUndefined();
+        });
+    });
+});
+
+test('the SHARED getters ignore the scope entirely', () => {
+    // The declared floor a discovery overlays onto, and the Shared branch of the resolver, must
+    // never be redirected — a discovery would otherwise overlay its own previous output.
+    withPerConnectionCatalog(A, PER_CONNECTION, () => {
+        RunInCatalogScope(A, () => {
+            expect(IntegrationEngineBase.Instance.GetSharedIntegrationObjects('int-1').map(o => o.Name)).toEqual(['Shared']);
+            expect(IntegrationEngineBase.Instance.GetActiveSharedIntegrationObjects('int-1').map(o => o.Name)).toEqual(['Shared']);
+        });
+    });
+});
+
+test('a scope whose connection has NO per-connection catalog reads shared', () => {
+    withPerConnectionCatalog(A, PER_CONNECTION, () => {
+        RunInCatalogScope(B, () => {
+            expect(IntegrationEngineBase.Instance.GetActiveIntegrationObjects('int-1').map(o => o.Name)).toEqual(['Shared']);
+        });
+    });
 });

--- a/packages/Integration/engine/src/__tests__/catalog-scope.test.ts
+++ b/packages/Integration/engine/src/__tests__/catalog-scope.test.ts
@@ -159,3 +159,32 @@ test('a scope whose connection has NO per-connection catalog reads shared', () =
         });
     });
 });
+
+test('the per-connection datasets are NOT configured when the entities are absent', async () => {
+    // The rollout safety property. A configured dataset whose entity does not exist fails its
+    // RunView, and BaseEngine classifies an unknown entity as a TRANSIENT failure — so the property
+    // stays `loadedSuccessfully: false` and every Config() retries it forever. The integration
+    // engine would sit permanently not-loaded on any workspace that has the code but not the
+    // migration, and the symptom would look like a network fault rather than a missing table.
+    const engine = IntegrationEngineBase.Instance as unknown as {
+        Config(f?: boolean, u?: unknown, p?: unknown): Promise<unknown>;
+        Configs: Array<{ PropertyName: string; EntityName?: string }>;
+        Load(params: Array<{ PropertyName: string }>): Promise<unknown>;
+    };
+    const captured: string[][] = [];
+    const savedLoad = engine.Load;
+    engine.Load = async (params) => { captured.push(params.map(p => p.PropertyName)); return undefined; };
+    try {
+        // A provider that knows nothing about the per-connection entities — the pre-migration state.
+        await engine.Config(false, {}, { EntityByName: () => undefined });
+        expect(captured.at(-1)).not.toContain('_companyIntegrationObjects');
+        expect(captured.at(-1)).toContain('_integrationObjects');
+
+        // And once the migration has run, both appear.
+        await engine.Config(false, {}, { EntityByName: (n: string) => ({ Name: n }) });
+        expect(captured.at(-1)).toContain('_companyIntegrationObjects');
+        expect(captured.at(-1)).toContain('_companyIntegrationObjectFields');
+    } finally {
+        engine.Load = savedLoad;
+    }
+});

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -165,3 +165,12 @@ export { OAuth1aSigner, percentEncodeRFC3986 } from './auth-helpers/index.js';
 export type { OAuth1aSignRequest, OAuth1aSignatureMethod } from './auth-helpers/index.js';
 export { buildBasicAuthHeaderValue, buildBasicAuthHeader } from './auth-helpers/index.js';
 export type { BasicAuthRequest } from './auth-helpers/index.js';
+export {
+    CurrentCatalogCI,
+    RunInCatalogScope,
+    WithCatalogScope,
+    RunOutsideCatalogScope,
+    InstallCatalogScopeResolver,
+} from './CatalogScope.js';
+export type { CatalogScopeState } from './CatalogScope.js';
+export { CatalogRow, CompanyIntegrationCatalogStore } from './CompanyIntegrationCatalogStore.js';

--- a/packages/Integration/engine/src/index.ts
+++ b/packages/Integration/engine/src/index.ts
@@ -174,3 +174,7 @@ export {
 } from './CatalogScope.js';
 export type { CatalogScopeState } from './CatalogScope.js';
 export { CatalogRow, CompanyIntegrationCatalogStore } from './CompanyIntegrationCatalogStore.js';
+export { BuildCatalogWriter, GlobalCatalogSourceOverride, ResolveCatalogSource } from './CatalogSource.js';
+export type { CatalogSource } from './CatalogSource.js';
+export { SharedCatalogWriter, PerConnectionCatalogWriter } from './CatalogWriter.js';
+export type { CatalogWriter } from './CatalogWriter.js';


### PR DESCRIPTION
## Summary
The engine half of the per-connection catalog: a resolution API and a catalog **scope**, a catalog **writer** that persists discovery into either the shared or the per-connection tables, and the flag that chooses. Flag off (the default) ⇒ byte-identical behaviour; the per-connection datasets are not even loaded until both entities resolve.

## What
- `engine-base`: `CompanyIntegrationCatalog` (read-only projections of CIO/CIOF rows exposing the same property names as IO/IOF, including the legacy field-id aliases derived in the projection); two new datasets in `Config()`, `RefreshCatalog()` refreshes four arrays; `GetIntegrationObjectFields` becomes ID-polymorphic; the **existing** getters (`GetIntegrationObject`, `GetIntegrationObjectsByIntegrationID`, `GetActiveIntegrationObjects`, `GetObjectsInDependencyOrder`) become scope-aware with a shared fallback, so every connector — including the ones that call `IntegrationEngineBase` directly — gets per-connection answers with zero connector changes. `GetSharedIntegrationObjects` is the explicit escape hatch for the declared floor.
- `engine`: `CatalogScope` (`AsyncLocalStorage`; `WithCatalogScope`/`RunInCatalogScope`/`RunOutsideCatalogScope`); `CatalogSource` (`Shared | PerConnection`, per connection via `Configuration.catalogSource`, `MJ_INTEGRATION_CATALOG_SOURCE` as the global switch); `CatalogWriter` with `SharedCatalogWriter` and `PerConnectionCatalogWriter` (`RebaseFromDeclared` copies the declared columns onto every per-connection row each discovery; absent columns are **Disabled, never deleted**; new arrivals arrive unselected). Discovery, sync and resume enter the scope; the Action generator runs outside it on purpose (an Action describes the vendor, not one connection's projection). `MJ_INTEGRATION_CATALOG_STRICT=1` makes the declared catalog read-only at runtime — off by default.
- W1–W7 and W10's engine side re-pointed onto the writer; the ten pure overlay deciders are untouched and their tests pass unmodified.

- **An object resolved BY ID now spans both catalogs, as the field lookup already did.** Making `GetIntegrationObjectFields` id-polymorphic while leaving `GetIntegrationObjectByID` shared-only left a hole exactly where the two meet: a parent resolved through a per-connection foreign-key edge. Measured live — a nested fetch resolved a child's parent to a per-connection object id, the shared-only lookup returned undefined, and `LoadParentIDs` threw for **twenty of twenty-seven objects**, each of which then fetched nothing while the run reported success. Object ids are UUIDs from two disjoint tables and cannot collide, so the id itself says which catalog the caller meant; shared is searched first, so a shared id costs exactly the scan it always did.

- **An existing per-connection FIELD re-asserts its declaration on rebase (MJ-CAT-21).** `RebaseFromDeclared` copied the declared columns onto every per-connection row, but an existing FIELD row did not adopt the declaration it was rebased from — so a connector release that changes a field's declaration left the connection's own row saying the old thing. Two changes, not one: a rebase alone leaves `MetadataSource = 'Discovered'` and the key is demoted in the same pass, so both have to move together. Postgres-only by construction — the SQL Server engine patch carries no `CatalogWriter` at all (verified, not assumed), because the per-connection catalog does not exist in that lineage.

## Verification
`catalog-scope`, `CatalogWriterProxy`, `CatalogSource`, `CatalogFieldAliases`, `CatalogRebase`, `CatalogRetire` suites. Live on a Postgres workspace since 2026-09-10: a PheedLoop discovery with `catalogSource=perConnection` produced 27 per-connection objects (the connector's 27 Active declared objects) and 556 fields (487 declared + 69 sampled) while the shared catalog stayed at exactly 34/524.

## Stack
Base `mjc/catalog-1-schema`. Next: `mjc/rsu-observability`, then `mjc/catalog-3-server` (the MJServer half: promoter, `enforceSchemaLimits`, resolver entry points).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
