### PR TITLE
fix(codegen): guard the AI entity name, propagate a failed INSERT, and keep advanced generation off in-process

### DIFF
--- a/.changeset/codegen-in-process-guards.md
+++ b/.changeset/codegen-in-process-guards.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/codegen-lib": patch
+---
+
+An AI-generated entity name is validated before it is used, a failed entity INSERT propagates instead of being swallowed (so the surrounding transaction can roll back rather than commit a partial set of new entities), a rolled-back batch no longer leaves its names in the process-static new-entity list, and in-process CodeGen runs with advanced generation off unless `RSU_CODEGEN_ADVANCED_GENERATION=1`.

--- a/packages/CodeGenLib/src/Config/config.ts
+++ b/packages/CodeGenLib/src/Config/config.ts
@@ -1485,3 +1485,43 @@ export function mj_core_schema(): string {
 export function dbPlatform(): DatabasePlatform {
   return configInfo.dbPlatform;
 }
+
+/**
+ * Environment switch that keeps advanced (AI) generation ON for in-process CodeGen runs. Absent, or any
+ * value other than '1', means an in-process run turns it off for its duration.
+ */
+export const IN_PROCESS_ADVANCED_GENERATION_ENV = 'RSU_CODEGEN_ADVANCED_GENERATION';
+
+/**
+ * Applies the in-process CodeGen policy for advanced generation to `config` and returns a function that
+ * puts the previous value back.
+ *
+ * In-process CodeGen is the runtime schema-update path: a connector's tables are created while a
+ * customer watches a progress screen. The CLI's full AI profile is the wrong thing to run there. Every
+ * new entity and field goes through several LLM round trips, so the step's duration becomes the LLM
+ * provider's failover behaviour rather than the schema's size (one 27-table connector spent hours in
+ * it), and a model that answers the name prompt with `-1` puts the whole table at risk. So an in-process
+ * run disables advanced generation unless the operator opts back in with
+ * RSU_CODEGEN_ADVANCED_GENERATION=1. Table-derived names and descriptions are what the runtime path
+ * produces; the AI profile stays available to the CLI, which reads the same config untouched.
+ */
+export function applyInProcessAdvancedGenerationPolicy(
+  config: ConfigInfo,
+  env: NodeJS.ProcessEnv = process.env
+): { disabled: boolean; restore: () => void } {
+  const noop = { disabled: false, restore: (): void => undefined };
+  if (env[IN_PROCESS_ADVANCED_GENERATION_ENV] === '1') {
+    return noop;
+  }
+  const section = config.advancedGeneration;
+  if (!section || section.enableAdvancedGeneration !== true) {
+    return noop;
+  }
+  section.enableAdvancedGeneration = false;
+  return {
+    disabled: true,
+    restore: (): void => {
+      section.enableAdvancedGeneration = true;
+    },
+  };
+}

--- a/packages/CodeGenLib/src/Database/manage-metadata.ts
+++ b/packages/CodeGenLib/src/Database/manage-metadata.ts
@@ -17,7 +17,7 @@ import { logError, logMessage, logStatus, logWarning, startSpinner, updateSpinne
 import { SQLUtilityBase } from "./sql";
 import { applyIncludeSchemaScope } from "./schema-scope";
 import { buildHealSchemaRoutineParams, getAuthoredExcludeSchemas, snapshotAuthoredExcludeSchemas } from "./heal-schema-params";
-import { AdvancedGeneration, EntityDescriptionResult, EntityNameResult, SmartFieldIdentificationResult, FormLayoutResult, VirtualEntityDecorationResult } from "../Misc/advanced_generation";
+import { AdvancedGeneration, EntityDescriptionResult, EntityNameResult, SmartFieldIdentificationResult, FormLayoutResult, VirtualEntityDecorationResult, isPlausibleEntityName } from "../Misc/advanced_generation";
 import { CodeGenReporter } from "../Misc/codegen-reporter";
 import {
    applySearchableFieldsCap,
@@ -5870,6 +5870,10 @@ export class ManageMetadataBase {
          if (newEntities && newEntities.length > 0 ) {
             const md = new Metadata() // global-provider-ok: codegen runs offline against a single provider
             const transaction = await pool.beginTransaction();
+            // The in-run list of new entity names is process-static. Names pushed by a batch that is then
+            // rolled back must not survive into the next run of the same process (in-process CodeGen runs
+            // many times per process), or every one of them reads as "taken" and gets a schema suffix.
+            const newEntityNamesBefore = ManageMetadataBase.newEntityList.length;
             try {
                // wrap in a transaction so we get all of it or none of it
                for ( let i = 0; i < newEntities.length; ++i) {
@@ -5879,6 +5883,7 @@ export class ManageMetadataBase {
                await transaction.commit();
             } catch (e) {
                await transaction.rollback();
+               ManageMetadataBase.newEntityList.length = newEntityNamesBefore;
                throw e;
             }
 
@@ -6001,11 +6006,13 @@ export class ManageMetadataBase {
 
    protected async newEntityNameWithAdvancedGeneration(ag: AdvancedGeneration, newEntity: any, currentUser: UserInfo): Promise<string> {
       const result = await ag.generateEntityName(newEntity.TableName, currentUser);
-      if (result?.entityName) {
+      // Checked here as well as inside generateEntityName: a subclass or a stub can return anything, and
+      // a non-name that reaches the INSERT fails it (see createNewEntity's catch for why that used to be silent).
+      if (result && isPlausibleEntityName(result.entityName)) {
          return this.markupEntityName(newEntity.SchemaName, result.entityName);
       }
       else {
-         console.warn('   >>> Advanced Generation Error: LLM returned invalid result, falling back to simple generated entity name');
+         console.warn(`   >>> Advanced Generation Error: LLM returned an unusable entity name for ${newEntity.SchemaName}.${newEntity.TableName}, falling back to simple generated entity name`);
          return this.simpleNewEntityName(newEntity.SchemaName, newEntity.TableName);
       }
    }
@@ -6230,6 +6237,15 @@ export class ManageMetadataBase {
          if (errStack) {
             LogError(`   Stack trace: ${errStack}`);
          }
+         // Rethrow so createNewEntities stops, rolls back, and the run fails. Swallowing here let CodeGen
+         // commit a PARTIAL set of new entities and report success: the table whose INSERT failed was simply
+         // absent afterwards, with a log line as the only witness. It has bitten twice — a UQ_Entity_Name
+         // collision (see resolveUniqueEntityName) and an AI-generated name of `-1` that dropped eleven of a
+         // connector's twenty-seven tables while the schema update reported "complete". The transaction in
+         // createNewEntities exists to give "all of it or none of it"; it can only do that if a failure
+         // reaches it. A table that does not QUALIFY (no primary key) is still a skip, not a failure — that
+         // path returns above and never gets here.
+         throw e instanceof Error ? e : new Error(errMsg);
       }
    }
 

--- a/packages/CodeGenLib/src/Misc/advanced_generation.ts
+++ b/packages/CodeGenLib/src/Misc/advanced_generation.ts
@@ -12,6 +12,40 @@ export type EntityNameResult = { entityName: string, tableName: string }
 export type EntityDescriptionResult = { entityDescription: string, tableName: string }
 export type CheckConstraintParserResult = { Description: string, Code: string, MethodName: string, ModelID: string }
 
+/** Width of `Entity.Name`; a candidate longer than this cannot be inserted. */
+const MAX_ENTITY_NAME_LENGTH = 255;
+
+/**
+ * Tokens a model returns in place of a name when it has no answer. Compared case-insensitively
+ * against the trimmed candidate.
+ */
+const NON_NAME_SENTINELS: ReadonlySet<string> = new Set([
+    'null', 'undefined', 'none', 'n/a', 'na', 'error', 'unknown', 'entityname', 'entity name'
+]);
+
+/**
+ * True when `candidate` could plausibly be an entity name: a non-empty string that fits the column,
+ * contains at least one run of two letters, and is not a bare non-answer token.
+ *
+ * Exists because a model can — and did — answer the entity-name prompt with `-1`. Nothing between the
+ * prompt and the INSERT questioned it: the name became `-1`, the INSERT failed on the metadata
+ * constraints, the failure was logged and swallowed, and CodeGen carried on reporting success with the
+ * table silently absent. Eleven of twenty-seven tables vanished from one connector that way.
+ */
+export function isPlausibleEntityName(candidate: unknown): candidate is string {
+    if (typeof candidate !== 'string') {
+        return false;
+    }
+    const name = candidate.trim();
+    if (name.length === 0 || name.length > MAX_ENTITY_NAME_LENGTH) {
+        return false;
+    }
+    if (NON_NAME_SENTINELS.has(name.toLowerCase())) {
+        return false;
+    }
+    return /[A-Za-z]{2,}/.test(name);
+}
+
 export type SmartFieldIdentificationResult = {
     /**
      * RANKED candidate list for the entity's human-readable record name, best first.
@@ -636,6 +670,10 @@ export class AdvancedGeneration {
             const result = await this.executePrompt<EntityNameResult>(params);
 
             if (result.success && result.result) {
+                if (!isPlausibleEntityName(result.result.entityName)) {
+                    LogError(`AdvancedGeneration:Entity name generation for ${tableName} returned ${JSON.stringify(result.result.entityName)}, which is not a name; the table-derived name will be used instead`);
+                    return null;
+                }
                 LogStatus(`Entity name generated for ${tableName}: ${result.result.entityName}`);
                 return result.result;
             } else {

--- a/packages/CodeGenLib/src/__tests__/entity-name-guard.test.ts
+++ b/packages/CodeGenLib/src/__tests__/entity-name-guard.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AdvancedGeneration, isPlausibleEntityName } from '../Misc/advanced_generation';
+
+/**
+ * The AI entity-name path must never hand a non-name to the INSERT.
+ *
+ * Observed on a live runtime schema update: the model answered the entity-name prompt with `-1`.
+ * The name became `-1`, the INSERT failed, the failure was swallowed, and eleven of twenty-seven
+ * tables were simply absent while the step reported success. These tests pin the two guards that
+ * now stand between the prompt and the INSERT.
+ */
+
+type Runner = (params: unknown) => Promise<unknown>;
+
+function stub(ag: AdvancedGeneration, runner: Runner): void {
+    const open = ag as unknown as {
+        _promptRunner: { ExecutePrompt: Runner };
+        featureEnabled: (name: string) => boolean;
+        getPromptEntity: (name: string) => Promise<unknown>;
+    };
+    open._promptRunner = { ExecutePrompt: runner };
+    open.featureEnabled = () => true;
+    open.getPromptEntity = async () => ({ Name: 'CodeGen: Entity Name Generation' });
+}
+
+const USER = { ID: 'u' } as never;
+
+describe('isPlausibleEntityName', () => {
+    it.each([
+        ['Attendees', true],
+        ['Event Sessions', true],
+        ['MJ: Company Integration Objects', true],
+        ['Sessions__pheedloop', true],
+        ['-1', false],
+        ['0', false],
+        ['', false],
+        ['   ', false],
+        ['A', false],
+        ['X1', false],
+        ['null', false],
+        ['NULL', false],
+        ['undefined', false],
+        ['N/A', false],
+        ['entityName', false],
+        ['!!!', false]
+    ])('%j → %s', (candidate, plausible) => {
+        expect(isPlausibleEntityName(candidate)).toBe(plausible);
+    });
+
+    it('rejects non-strings and names wider than the column', () => {
+        expect(isPlausibleEntityName(-1)).toBe(false);
+        expect(isPlausibleEntityName(null)).toBe(false);
+        expect(isPlausibleEntityName(undefined)).toBe(false);
+        expect(isPlausibleEntityName({ entityName: 'Attendees' })).toBe(false);
+        expect(isPlausibleEntityName('A'.repeat(256))).toBe(false);
+        expect(isPlausibleEntityName('A'.repeat(255))).toBe(true);
+    });
+});
+
+describe('AdvancedGeneration.generateEntityName', () => {
+    it('returns the model answer when it is a name', async () => {
+        const ag = new AdvancedGeneration();
+        stub(ag, async () => ({ success: true, result: { entityName: 'Attendees', tableName: 'attendee' } }));
+        await expect(ag.generateEntityName('attendee', USER)).resolves.toEqual({
+            entityName: 'Attendees',
+            tableName: 'attendee'
+        });
+    });
+
+    it('returns null — the fallback signal — when the model answers with "-1"', async () => {
+        const ag = new AdvancedGeneration();
+        stub(ag, async () => ({ success: true, result: { entityName: '-1', tableName: 'attendee' } }));
+        await expect(ag.generateEntityName('attendee', USER)).resolves.toBeNull();
+    });
+
+    it('returns null when the answer has no name at all', async () => {
+        const ag = new AdvancedGeneration();
+        stub(ag, async () => ({ success: true, result: { tableName: 'attendee' } }));
+        await expect(ag.generateEntityName('attendee', USER)).resolves.toBeNull();
+    });
+
+    it('still returns null on a failed prompt', async () => {
+        const ag = new AdvancedGeneration();
+        const runner = vi.fn(async () => ({ success: false, errorMessage: 'provider down' }));
+        stub(ag, runner);
+        await expect(ag.generateEntityName('attendee', USER)).resolves.toBeNull();
+        expect(runner).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/CodeGenLib/src/__tests__/in-process-advanced-generation-policy.test.ts
+++ b/packages/CodeGenLib/src/__tests__/in-process-advanced-generation-policy.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+    applyInProcessAdvancedGenerationPolicy,
+    IN_PROCESS_ADVANCED_GENERATION_ENV,
+    type ConfigInfo
+} from '../Config/config';
+
+/**
+ * In-process CodeGen (the runtime schema-update path) runs without advanced (AI) generation unless the
+ * operator opts in. Every new entity and field otherwise costs several LLM round trips, so the step's
+ * duration becomes the provider's failover behaviour rather than the schema's size, and a bad answer
+ * can drop a table.
+ */
+
+function config(enabled: boolean | undefined): ConfigInfo {
+    return {
+        advancedGeneration: enabled === undefined ? undefined : { enableAdvancedGeneration: enabled, features: [] }
+    } as unknown as ConfigInfo;
+}
+
+describe('applyInProcessAdvancedGenerationPolicy', () => {
+    it('turns advanced generation off for the run and back on afterwards', () => {
+        const c = config(true);
+        const policy = applyInProcessAdvancedGenerationPolicy(c, {});
+        expect(policy.disabled).toBe(true);
+        expect(c.advancedGeneration?.enableAdvancedGeneration).toBe(false);
+        policy.restore();
+        expect(c.advancedGeneration?.enableAdvancedGeneration).toBe(true);
+    });
+
+    it('leaves it on when the operator opts in with the environment switch', () => {
+        const c = config(true);
+        const policy = applyInProcessAdvancedGenerationPolicy(c, { [IN_PROCESS_ADVANCED_GENERATION_ENV]: '1' });
+        expect(policy.disabled).toBe(false);
+        expect(c.advancedGeneration?.enableAdvancedGeneration).toBe(true);
+    });
+
+    it('treats any value other than "1" as not opted in', () => {
+        const c = config(true);
+        expect(applyInProcessAdvancedGenerationPolicy(c, { [IN_PROCESS_ADVANCED_GENERATION_ENV]: 'true' }).disabled).toBe(true);
+        expect(c.advancedGeneration?.enableAdvancedGeneration).toBe(false);
+    });
+
+    it('does nothing when the config already has it off, or has no section', () => {
+        const off = config(false);
+        expect(applyInProcessAdvancedGenerationPolicy(off, {}).disabled).toBe(false);
+        expect(off.advancedGeneration?.enableAdvancedGeneration).toBe(false);
+        expect(applyInProcessAdvancedGenerationPolicy(config(undefined), {}).disabled).toBe(false);
+    });
+
+    it('is wired into RunInProcess, before the pipeline runs and restored after it', () => {
+        // runCodeGen.ts pulls in the class-registration manifest at import, so it is pinned as text.
+        const src = readFileSync(join(__dirname, '..', 'runCodeGen.ts'), 'utf8');
+        const start = src.indexOf('public async RunInProcess(');
+        const end = src.indexOf('public async Run(', start);
+        expect(start).toBeGreaterThan(-1);
+        const body = src.slice(start, end);
+        const apply = body.indexOf('applyInProcessAdvancedGenerationPolicy(configInfo)');
+        const pipeline = body.indexOf('this.executeCodeGenPipeline(');
+        expect(apply).toBeGreaterThan(-1);
+        expect(pipeline).toBeGreaterThan(apply);
+        expect(body.slice(pipeline)).toMatch(/finally\s*\{\s*advancedGeneration\.restore\(\);/);
+        // The CLI entry point keeps the config untouched.
+        const cli = src.slice(end);
+        expect(cli).not.toContain('applyInProcessAdvancedGenerationPolicy');
+    });
+});

--- a/packages/CodeGenLib/src/__tests__/new-entity-failure-propagates.test.ts
+++ b/packages/CodeGenLib/src/__tests__/new-entity-failure-propagates.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ManageMetadataBase } from '../Database/manage-metadata';
+import type { AdvancedGeneration } from '../Misc/advanced_generation';
+import type { CodeGenConnection, CodeGenQueryResult } from '../Database/codeGenDatabaseProvider';
+import { Metadata, type UserInfo } from '@memberjunction/core';
+
+/**
+ * A new entity that fails to be created must fail the run, not vanish.
+ *
+ * createNewEntity used to catch every error, log it, and return — so createNewEntities committed
+ * whatever subset had succeeded and reported true. The table whose INSERT failed was absent
+ * afterwards with a log line as the only witness. On a runtime schema update that read as a
+ * "complete" build of a connector missing eleven of its twenty-seven tables.
+ */
+
+const USER = { ID: 'u' } as unknown as UserInfo;
+const MD = { Entities: [] } as unknown as Metadata;
+
+class Testable extends ManageMetadataBase {
+    public failOn = new Set<string>();
+    public created: string[] = [];
+    public tables: Array<{ SchemaName: string; TableName: string }> = [];
+
+    protected override async materializedResultTableExists(): Promise<boolean> {
+        return false;
+    }
+    protected override async runQuery(): Promise<CodeGenQueryResult> {
+        return { recordset: this.tables } as unknown as CodeGenQueryResult;
+    }
+    protected override async createNewEntity(_pool: CodeGenConnection, newEntity: { TableName: string }): Promise<void> {
+        if (this.failOn.has(newEntity.TableName)) {
+            ManageMetadataBase.newEntityList.push(`Half-created ${newEntity.TableName}`);
+            throw new Error(`INSERT failed for ${newEntity.TableName}`);
+        }
+        this.created.push(newEntity.TableName);
+        ManageMetadataBase.newEntityList.push(newEntity.TableName);
+    }
+    public nameWith(ag: AdvancedGeneration, table: string): Promise<string> {
+        return this.newEntityNameWithAdvancedGeneration(ag, { SchemaName: 'pheedloop', TableName: table }, USER);
+    }
+}
+
+class RealCreate extends ManageMetadataBase {
+    protected override async shouldCreateNewEntity(): Promise<{ shouldCreate: boolean; validationMessage: string }> {
+        return { shouldCreate: true, validationMessage: '' };
+    }
+    protected override async createNewEntityName(): Promise<string> {
+        throw new Error('name generation exploded');
+    }
+    public run(): Promise<void> {
+        return this.createNewEntity({} as CodeGenConnection, { SchemaName: 'pheedloop', TableName: 'attendee' }, MD, USER);
+    }
+}
+
+function pool(): { conn: CodeGenConnection; commit: ReturnType<typeof vi.fn>; rollback: ReturnType<typeof vi.fn> } {
+    const commit = vi.fn(async () => undefined);
+    const rollback = vi.fn(async () => undefined);
+    const conn = { beginTransaction: async () => ({ commit, rollback }) } as unknown as CodeGenConnection;
+    return { conn, commit, rollback };
+}
+
+describe('createNewEntity', () => {
+    it('rethrows after logging instead of swallowing the failure', async () => {
+        await expect(new RealCreate().run()).rejects.toThrow('name generation exploded');
+    });
+});
+
+describe('createNewEntities', () => {
+    beforeEach(() => {
+        ManageMetadataBase.newEntityList.length = 0;
+    });
+
+    it('commits and returns true when every qualifying table is created', async () => {
+        const mm = new Testable();
+        mm.tables = [{ SchemaName: 'pheedloop', TableName: 'attendee' }, { SchemaName: 'pheedloop', TableName: 'session' }];
+        const p = pool();
+        // The success path refreshes metadata; there is no provider in this test.
+        const refresh = vi.spyOn(Metadata.prototype, 'Refresh').mockResolvedValue(undefined as never);
+
+        await expect(mm.createNewEntities(p.conn, USER)).resolves.toBe(true);
+
+        expect(mm.created).toEqual(['attendee', 'session']);
+        expect(p.commit).toHaveBeenCalledTimes(1);
+        expect(p.rollback).not.toHaveBeenCalled();
+        expect(refresh).toHaveBeenCalledTimes(1);
+        refresh.mockRestore();
+    });
+
+    it('rolls back, returns false and forgets the batch\'s names when one table fails', async () => {
+        const mm = new Testable();
+        mm.tables = [
+            { SchemaName: 'pheedloop', TableName: 'attendee' },
+            { SchemaName: 'pheedloop', TableName: 'badge' },
+            { SchemaName: 'pheedloop', TableName: 'session' }
+        ];
+        mm.failOn.add('badge');
+        ManageMetadataBase.newEntityList.push('From An Earlier Run');
+        const p = pool();
+
+        await expect(mm.createNewEntities(p.conn, USER)).resolves.toBe(false);
+
+        expect(mm.created).toEqual(['attendee']);
+        expect(p.commit).not.toHaveBeenCalled();
+        expect(p.rollback).toHaveBeenCalledTimes(1);
+        expect(ManageMetadataBase.newEntityList).toEqual(['From An Earlier Run']);
+    });
+});
+
+describe('newEntityNameWithAdvancedGeneration', () => {
+    const stubAg = (answer: unknown): AdvancedGeneration =>
+        ({ generateEntityName: async () => answer }) as unknown as AdvancedGeneration;
+
+    it('uses a plausible AI name', async () => {
+        await expect(new Testable().nameWith(stubAg({ entityName: 'Attendees', tableName: 'attendee' }), 'attendee')).resolves.toBe('Attendees');
+    });
+
+    it('falls back to the table-derived name when the AI answers "-1"', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const name = await new Testable().nameWith(stubAg({ entityName: '-1', tableName: 'attendee' }), 'attendee');
+        expect(name).toBe('Attendees');
+        expect(warn).toHaveBeenCalledTimes(1);
+        warn.mockRestore();
+    });
+
+    it('falls back when the AI path returns null', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        await expect(new Testable().nameWith(stubAg(null), 'attendee')).resolves.toBe('Attendees');
+        vi.restoreAllMocks();
+    });
+});

--- a/packages/CodeGenLib/src/runCodeGen.ts
+++ b/packages/CodeGenLib/src/runCodeGen.ts
@@ -13,7 +13,7 @@ import { EntitySubClassGeneratorBase } from './Misc/entity_subclasses_codegen';
 import { ManageMetadataBase } from './Database/manage-metadata';
 import { applyIncludeSchemaScope } from './Database/schema-scope';
 import { partitionEntitiesByOutputDirectory } from './Config/schema-output';
-import { outputDir, commands, configInfo, getSettingValue, dbPlatform, getExternalEntitySchemas, initializeConfig, CommandInfo } from './Config/config';
+import { outputDir, commands, configInfo, getSettingValue, dbPlatform, getExternalEntitySchemas, initializeConfig, CommandInfo, applyInProcessAdvancedGenerationPolicy, IN_PROCESS_ADVANCED_GENERATION_ENV } from './Config/config';
 import { resolveDirtySchemasForEmit, schemaKey, SchemaEmitOptions } from './Misc/schema-emit';
 import { EmitStats } from './Misc/emit-stats';
 import { logError, logStatus, logWarning, startSpinner, updateSpinner, succeedSpinner, failSpinner, warnSpinner } from './Misc/status_logging';
@@ -128,7 +128,18 @@ export class RunCodeGenBase {
       // are seen as PK-less → entities are skipped ("No primary key found") → 0 rows sync until an MJAPI
       // restart. In-process path only; the CLI Run() keeps load-once. Deterministic — no mtime/TOCTOU.
       ManageMetadataBase.invalidateSoftPKFKConfigCache();
-      return await this.executeCodeGenPipeline(dataSource, skipDatabaseGeneration, skipFileGeneration);
+      // In-process runs are the runtime schema-update path, where the CLI's full AI profile turns a
+      // minutes-class step into an hours-class one and a bad AI answer can drop a table. Off unless the
+      // operator opts in; see applyInProcessAdvancedGenerationPolicy for the reasoning.
+      const advancedGeneration = applyInProcessAdvancedGenerationPolicy(configInfo);
+      if (advancedGeneration.disabled) {
+        logStatus(`In-process CodeGen: advanced (AI) generation is off for this run; set ${IN_PROCESS_ADVANCED_GENERATION_ENV}=1 to keep it on`);
+      }
+      try {
+        return await this.executeCodeGenPipeline(dataSource, skipDatabaseGeneration, skipFileGeneration);
+      } finally {
+        advancedGeneration.restore();
+      }
     } catch (e) {
       logError('In-process CodeGen failed: ' + e);
       return false;


### PR DESCRIPTION
## Summary
Three guards on CodeGen's new-entity path, and a policy for in-process runs. Together they are why a 27-table connector came out with sixteen tables while every surface reported the schema update complete.

## What

**An AI-generated entity name is checked before it is used.** A model answered the entity-name prompt with `-1`. Nothing between the prompt and the INSERT questioned it: the name became `-1`, the INSERT failed on the metadata constraints, and the failure was logged and swallowed. `isPlausibleEntityName` rejects a non-string, an empty or over-long candidate, a bare non-answer token (`null`, `n/a`, `unknown`, `entityName`), and anything without a run of two letters. It is applied inside `generateEntityName` and again at the call site, because a subclass or a stub can return anything.

**A failed `createNewEntity` rethrows.** Swallowing it let CodeGen commit a *partial* set of new entities and report success — the table whose INSERT failed was simply absent afterwards, with a log line as the only witness. The transaction in `createNewEntities` exists to give all of it or none of it, and it can only do that if the failure reaches it. A table that does not *qualify* (no primary key) is still a skip, not a failure; that path returns earlier.

**A rolled-back batch no longer poisons the next run.** The in-run list of new entity names is process-static and in-process CodeGen runs many times per process, so names pushed by a batch that then rolled back survived and every one of them read as "taken" on the next attempt, earning a schema suffix.

**In-process CodeGen runs with advanced generation off unless `RSU_CODEGEN_ADVANCED_GENERATION=1`.** In-process is the runtime schema-update path, with a user watching a progress screen. The CLI's full AI profile puts several LLM round trips behind every new entity and field, so the step's duration becomes the provider's failover behaviour rather than the schema's size — one 27-table connector spent hours in it at ~1% CPU with ten sockets open to a model provider. The CLI's own `Run()` reads the same config untouched, and the previous value is restored in a `finally`.

## Verification
`entity-name-guard`, `in-process-advanced-generation-policy` and `new-entity-failure-propagates` suites; package suite 1287 pass, 0 fail.

## Stack
Independent of the per-connection catalog stack — based directly on `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
